### PR TITLE
Add provider step to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Horizon requires Laravel 5.5, which is currently in beta, and PHP 7.1+. You may 
 After installing Horizon, publish its assets using the `vendor:publish` Artisan command:
 
     php artisan vendor:publish
+    
+After publishing vendor assets, add the ServiceProvider to the providers array in config/app.php
+
+    Laravel\Horizon\HorizonServiceProvider::class
 
 ## Configuration
 


### PR DESCRIPTION
Added instructions on how to add the `Laravel\Horizon\HorizonServiceProvider::class` to app.php providers array.