### PR TITLE
Service Provider added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Horizon requires Laravel 5.5, which is currently in beta, and PHP 7.1+. You may 
 
     composer require laravel/horizon
 
+Then add HorizonServiceProvider to `providers` array in `config/app.php`:
+
+    Laravel\Horizon\HorizonServiceProvider::class,
+
 After installing Horizon, publish its assets using the `vendor:publish` Artisan command:
 
     php artisan vendor:publish


### PR DESCRIPTION
When I try to install the package with following the README this command not working successfully:

> php artisan vendor:publish

Because service provider not added to app/config.php file so I change the README file for non-laravel users :) 