### PR TITLE
Add missing step to README for installing Horizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ Horizon requires Laravel 5.5, which is currently in beta, and PHP 7.1+. You may 
 
     composer require laravel/horizon
 
-After installing Horizon, publish its assets using the `vendor:publish` Artisan command:
+After installing Horizon, add `HorizonServiceProvider` to `config/app.php`
+```php
+Laravel\Tinker\TinkerServiceProvider::class,
+Laravel\Horizon\HorizonServiceProvider::class
+```
+Then finally publish its assets using the `vendor:publish` Artisan command:
 
     php artisan vendor:publish
 


### PR DESCRIPTION
Adding HorizonServiceProvider to config/app.php was missing in the installation steps.