### PR TITLE
Register resolving method in register instead of boot

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -23,7 +23,6 @@ class HorizonServiceProvider extends ServiceProvider
         $this->registerRoutes();
         $this->registerResources();
         $this->defineAssetPublishing();
-        $this->registerQueueConnectors();
     }
 
     /**
@@ -108,6 +107,7 @@ class HorizonServiceProvider extends ServiceProvider
         $this->offerPublishing();
         $this->registerServices();
         $this->registerCommands();
+        $this->registerQueueConnectors();
     }
 
     /**


### PR DESCRIPTION
Otherwise this can lead to timing issues, where another ServiceProvider resolves the binding, before the resolving callback is registered. See https://github.com/barryvdh/laravel-debugbar/issues/682 for example.
//cc @fredlahde