### PR TITLE
Single database setup

### DIFF
--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -29,7 +29,7 @@ class SnapshotCommand extends Command
      */
     public function handle()
     {
-        if (resolve(Lock::class)->get('metrics:snapshot', 1)) {
+        if (resolve(Lock::class)->get('metrics:snapshot', 300)) {
             resolve(MetricsRepository::class)->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');

--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -29,7 +29,7 @@ class SnapshotCommand extends Command
      */
     public function handle()
     {
-        if (resolve(Lock::class)->get('metrics:snapshot', 300)) {
+        if (resolve(Lock::class)->get('metrics:snapshot', 1)) {
             resolve(MetricsRepository::class)->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -73,9 +73,9 @@ class Horizon
     {
         $config = config("database.redis.{$connection}");
 
-        foreach (static::$databases as $database) {
-            static::{"configure{$database}Database"}($config);
-        }
+        config(['database.redis.horizon' => array_merge($config, [
+            'options' => ['prefix' => 'horizon:']
+        ])]);
     }
 
     /**
@@ -102,96 +102,5 @@ class Horizon
         static::$smsNumber = $number;
 
         return new static;
-    }
-
-    /**
-     * Configure the database that holds a copy of the queue jobs.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureJobsDatabase(array $config)
-    {
-        config(['database.redis.horizon-jobs' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
-    }
-
-    /**
-     * Configure the database that stores meta information on supervisors.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureSupervisorsDatabase(array $config)
-    {
-        config(['database.redis.horizon-supervisors' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
-    }
-
-    /**
-     * Configure the database for the supervisor command queues.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureCommandQueueDatabase(array $config)
-    {
-        config(['database.redis.horizon-command-queue' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
-    }
-
-    /**
-     * Configure the database that stores tag to job mappings.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureTagsDatabase(array $config)
-    {
-        config(['database.redis.horizon-tags' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
-    }
-
-    /**
-     * Configure the database that stores tag to job mappings.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureMetricsDatabase(array $config)
-    {
-        config(['database.redis.horizon-metrics' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
-    }
-
-    /**
-     * Configure the database that stores locks.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureLocksDatabase(array $config)
-    {
-        config(['database.redis.horizon-locks' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
-    }
-
-    /**
-     * Configure the database that stores locks.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    protected static function configureProcessesDatabase(array $config)
-    {
-        config(['database.redis.horizon-processes' => array_merge($config, [
-            'options' => ['prefix' => 'horizon:']
-        ])]);
     }
 }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -113,7 +113,7 @@ class Horizon
     protected static function configureJobsDatabase(array $config)
     {
         config(['database.redis.horizon-jobs' => array_merge($config, [
-            'database' => 9,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 
@@ -126,7 +126,7 @@ class Horizon
     protected static function configureSupervisorsDatabase(array $config)
     {
         config(['database.redis.horizon-supervisors' => array_merge($config, [
-            'database' => 10,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 
@@ -139,7 +139,7 @@ class Horizon
     protected static function configureCommandQueueDatabase(array $config)
     {
         config(['database.redis.horizon-command-queue' => array_merge($config, [
-            'database' => 11,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 
@@ -152,7 +152,7 @@ class Horizon
     protected static function configureTagsDatabase(array $config)
     {
         config(['database.redis.horizon-tags' => array_merge($config, [
-            'database' => 12,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 
@@ -165,7 +165,7 @@ class Horizon
     protected static function configureMetricsDatabase(array $config)
     {
         config(['database.redis.horizon-metrics' => array_merge($config, [
-            'database' => 13,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 
@@ -178,7 +178,7 @@ class Horizon
     protected static function configureLocksDatabase(array $config)
     {
         config(['database.redis.horizon-locks' => array_merge($config, [
-            'database' => 14,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 
@@ -191,7 +191,7 @@ class Horizon
     protected static function configureProcessesDatabase(array $config)
     {
         config(['database.redis.horizon-processes' => array_merge($config, [
-            'database' => 15,
+            'options' => ['prefix' => 'horizon:']
         ])]);
     }
 }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -90,6 +90,6 @@ class Lock
      */
     public function connection()
     {
-        return $this->redis->connection('horizon-locks');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -15,6 +15,8 @@ class LuaScripts
     public static function updateJobMetrics()
     {
         return <<<'LUA'
+            redis.call('hsetnx', KEYS[1], 'throughput', 0)
+            
             local hash = redis.call('hmget', KEYS[1], 'throughput', 'runtime')
 
             local throughput = hash[1] + 1

--- a/src/RedisHorizonCommandQueue.php
+++ b/src/RedisHorizonCommandQueue.php
@@ -34,7 +34,7 @@ class RedisHorizonCommandQueue implements HorizonCommandQueue
      */
     public function push($name, $command, array $options = [])
     {
-        $this->connection()->rpush($name, json_encode([
+        $this->connection()->rpush('commands:'.$name, json_encode([
             'command' => $command,
             'options' => $options,
         ]));
@@ -48,16 +48,16 @@ class RedisHorizonCommandQueue implements HorizonCommandQueue
      */
     public function pending($name)
     {
-        $length = $this->connection()->llen($name);
+        $length = $this->connection()->llen('commands:'.$name);
 
         if ($length < 1) {
             return [];
         }
 
         $results = $this->connection()->pipeline(function ($pipe) use ($name, $length) {
-            $pipe->lrange($name, 0, $length - 1);
+            $pipe->lrange('commands:'.$name, 0, $length - 1);
 
-            $pipe->ltrim($name, $length, -1);
+            $pipe->ltrim('commands:'.$name, $length, -1);
         });
 
         return collect($results[0])->map(function ($result) {
@@ -73,7 +73,7 @@ class RedisHorizonCommandQueue implements HorizonCommandQueue
      */
     public function flush($name)
     {
-        $this->connection()->del($name);
+        $this->connection()->del('commands:'.$name);
     }
 
     /**

--- a/src/RedisHorizonCommandQueue.php
+++ b/src/RedisHorizonCommandQueue.php
@@ -83,6 +83,6 @@ class RedisHorizonCommandQueue implements HorizonCommandQueue
      */
     protected function connection()
     {
-        return $this->redis->connection('horizon-command-queue');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -541,6 +541,6 @@ class RedisJobRepository implements JobRepository
      */
     protected function connection()
     {
-        return $this->redis->connection('horizon-jobs');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -36,7 +36,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     public function names()
     {
         return collect($this->connection()->keys('master:*'))->map(function ($name) {
-            return substr($name, 7);
+            return substr($name, 15);
         })->all();
     }
 

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -137,6 +137,6 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
      */
     protected function connection()
     {
-        return $this->redis->connection('horizon-supervisors');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -394,6 +394,6 @@ class RedisMetricsRepository implements MetricsRepository
      */
     public function connection()
     {
-        return $this->redis->connection('horizon-metrics');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -39,7 +39,7 @@ class RedisMetricsRepository implements MetricsRepository
         $classes = (array) $this->connection()->keys('job:*');
 
         return collect($classes)->map(function ($class) {
-            return substr($class, 4);
+            return substr($class, 12);
         })->all();
     }
 
@@ -53,7 +53,7 @@ class RedisMetricsRepository implements MetricsRepository
         $queues = (array) $this->connection()->keys('queue:*');
 
         return collect($queues)->map(function ($class) {
-            return substr($class, 6);
+            return substr($class, 14);
         })->all();
     }
 
@@ -207,8 +207,6 @@ class RedisMetricsRepository implements MetricsRepository
     protected function increment($key, $runtime)
     {
         $this->connection()->pipeline(function ($pipe) use ($key, $runtime) {
-            $pipe->hsetnx($key, 'throughput', 0);
-
             if (config('database.redis.client') == 'phpredis') {
                 $pipe->eval(LuaScripts::updateJobMetrics(), [$key, $runtime], 1);
             } else {

--- a/src/Repositories/RedisProcessRepository.php
+++ b/src/Repositories/RedisProcessRepository.php
@@ -102,6 +102,6 @@ class RedisProcessRepository implements ProcessRepository
      */
     protected function connection()
     {
-        return $this->redis->connection('horizon-processes');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -154,6 +154,6 @@ class RedisSupervisorRepository implements SupervisorRepository
      */
     protected function connection()
     {
-        return $this->redis->connection('horizon-supervisors');
+        return $this->redis->connection('horizon');
     }
 }

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -35,7 +35,7 @@ class RedisSupervisorRepository implements SupervisorRepository
     public function names()
     {
         return collect($this->connection()->keys('supervisor:*'))->map(function ($name) {
-            return substr($name, 11);
+            return substr($name, 19);
         })->all();
     }
 

--- a/src/Repositories/RedisTagRepository.php
+++ b/src/Repositories/RedisTagRepository.php
@@ -180,6 +180,6 @@ class RedisTagRepository implements TagRepository
      */
     protected function connection()
     {
-        return $this->redis->connection('horizon-tags');
+        return $this->redis->connection('horizon');
     }
 }

--- a/tests/Feature/FailedJobTest.php
+++ b/tests/Feature/FailedJobTest.php
@@ -15,7 +15,7 @@ class FailedJobTest extends IntegrationTest
         $id = Queue::push(new Jobs\FailingJob);
         $this->work();
         $this->assertEquals(1, $this->failedJobs());
-        $this->assertGreaterThan(0, Redis::connection('horizon-jobs')->ttl($id));
+        $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($id));
 
         $job = resolve(JobRepository::class)->getJobs([$id])[0];
 
@@ -38,7 +38,7 @@ class FailedJobTest extends IntegrationTest
     {
         $id = Queue::push(new Jobs\FailingJob);
         $this->work();
-        $ttl = Redis::connection('horizon-tags')->pttl('failed:first');
+        $ttl = Redis::connection('horizon')->pttl('failed:first');
         $this->assertNotNull($ttl);
         $this->assertGreaterThan(0, $ttl);
     }

--- a/tests/Feature/JobRetrievalTest.php
+++ b/tests/Feature/JobRetrievalTest.php
@@ -59,14 +59,14 @@ class JobRetrievalTest extends IntegrationTest
         $repository = resolve(JobRepository::class);
         Chronos::setTestNow(Chronos::now()->addHours(3));
 
-        $this->assertEquals(5, Redis::connection('horizon-jobs')->zcard('recent_jobs'));
+        $this->assertEquals(5, Redis::connection('horizon')->zcard('recent_jobs'));
 
         $repository->trimRecentJobs();
-        $this->assertEquals(0, Redis::connection('horizon-jobs')->zcard('recent_jobs'));
+        $this->assertEquals(0, Redis::connection('horizon')->zcard('recent_jobs'));
 
         // Assert job record has a TTL...
         $repository->completed(new JobPayload(json_encode(['id' => $ids[0]])));
-        $this->assertGreaterThan(0, Redis::connection('horizon-jobs')->ttl($ids[0]));
+        $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($ids[0]));
 
         Chronos::setTestNow();
     }

--- a/tests/Feature/MasterSupervisorTest.php
+++ b/tests/Feature/MasterSupervisorTest.php
@@ -77,7 +77,7 @@ class MasterSupervisorTest extends IntegrationTest
         $master->loop();
 
         $this->assertTrue($supervisorProcess->dead);
-        $commands = Redis::connection('horizon-command-queue')->lrange(
+        $commands = Redis::connection('horizon')->lrange(
             'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
         );
 

--- a/tests/Feature/MasterSupervisorTest.php
+++ b/tests/Feature/MasterSupervisorTest.php
@@ -78,7 +78,7 @@ class MasterSupervisorTest extends IntegrationTest
 
         $this->assertTrue($supervisorProcess->dead);
         $commands = Redis::connection('horizon-command-queue')->lrange(
-            MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
+            'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
         );
 
         $this->assertCount(1, $commands);

--- a/tests/Feature/MonitoringTest.php
+++ b/tests/Feature/MonitoringTest.php
@@ -44,7 +44,7 @@ class MonitoringTest extends IntegrationTest
     {
         dispatch(new MonitorTag('first'));
         dispatch(new StopMonitoringTag('first'));
-        $this->assertNull(Redis::connection('horizon-tags')->get('first'));
+        $this->assertNull(Redis::connection('horizon')->get('first'));
     }
 
     public function test_completed_jobs_are_stored_in_database_when_one_of_their_tags_is_being_monitored()
@@ -53,7 +53,7 @@ class MonitoringTest extends IntegrationTest
         $id = Queue::push(new Jobs\BasicJob);
         $this->work();
         $this->assertEquals(1, $this->monitoredJobs('first'));
-        $this->assertEquals(-1, Redis::connection('horizon-jobs')->ttl($id));
+        $this->assertEquals(-1, Redis::connection('horizon')->ttl($id));
     }
 
     public function test_completed_jobs_are_removed_from_database_when_their_tag_is_no_longer_monitored()

--- a/tests/Feature/ProvisioningPlanTest.php
+++ b/tests/Feature/ProvisioningPlanTest.php
@@ -26,7 +26,7 @@ class ProvisioningPlanTest extends IntegrationTest
         $plan->deploy('production');
 
         $commands = Redis::connection('horizon-command-queue')->lrange(
-            MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
+            'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
         );
 
         $this->assertCount(1, $commands);
@@ -52,7 +52,7 @@ class ProvisioningPlanTest extends IntegrationTest
         $plan->deploy('production');
 
         $commands = Redis::connection('horizon-command-queue')->lrange(
-            MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
+            'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
         );
 
         $this->assertCount(1, $commands);

--- a/tests/Feature/ProvisioningPlanTest.php
+++ b/tests/Feature/ProvisioningPlanTest.php
@@ -25,7 +25,7 @@ class ProvisioningPlanTest extends IntegrationTest
         $plan = new ProvisioningPlan(MasterSupervisor::name(), $plan);
         $plan->deploy('production');
 
-        $commands = Redis::connection('horizon-command-queue')->lrange(
+        $commands = Redis::connection('horizon')->lrange(
             'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
         );
 
@@ -51,7 +51,7 @@ class ProvisioningPlanTest extends IntegrationTest
         $plan = new ProvisioningPlan(MasterSupervisor::name(), $plan);
         $plan->deploy('production');
 
-        $commands = Redis::connection('horizon-command-queue')->lrange(
+        $commands = Redis::connection('horizon')->lrange(
             'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
         );
 

--- a/tests/Feature/QueueProcessingTest.php
+++ b/tests/Feature/QueueProcessingTest.php
@@ -31,20 +31,20 @@ class QueueProcessingTest extends IntegrationTest
     {
         $id = Queue::push(new Jobs\BasicJob);
         $this->assertEquals(1, $this->recentJobs());
-        $this->assertSame('pending', Redis::connection('horizon-jobs')->hget($id, 'status'));
+        $this->assertSame('pending', Redis::connection('horizon')->hget($id, 'status'));
     }
 
     public function test_pending_jobs_are_stored_with_their_tags()
     {
         $id = Queue::push(new Jobs\BasicJob);
-        $payload = json_decode(Redis::connection('horizon-jobs')->hget($id, 'payload'), true);
+        $payload = json_decode(Redis::connection('horizon')->hget($id, 'payload'), true);
         $this->assertEquals(['first', 'second'], $payload['tags']);
     }
 
     public function test_pending_jobs_are_stored_with_their_type()
     {
         $id = Queue::push(new Jobs\BasicJob);
-        $payload = json_decode(Redis::connection('horizon-jobs')->hget($id, 'payload'), true);
+        $payload = json_decode(Redis::connection('horizon')->hget($id, 'payload'), true);
         $this->assertSame('job', $payload['type']);
     }
 
@@ -63,7 +63,7 @@ class QueueProcessingTest extends IntegrationTest
 
         $status = null;
         Event::listen(JobReserved::class, function ($event) use ($id, &$status) {
-            $status = Redis::connection('horizon-jobs')->hget($id, 'status');
+            $status = Redis::connection('horizon')->hget($id, 'status');
         });
 
         $this->work();
@@ -75,11 +75,11 @@ class QueueProcessingTest extends IntegrationTest
     {
         $id = Queue::later(Chronos::now()->addSeconds(0), new Jobs\BasicJob);
 
-        Redis::connection('horizon-jobs')->hset($id, 'status', 'reserved');
+        Redis::connection('horizon')->hset($id, 'status', 'reserved');
 
         $status = null;
         Event::listen(JobsMigrated::class, function ($event) use ($id, &$status) {
-            $status = Redis::connection('horizon-jobs')->hget($id, 'status');
+            $status = Redis::connection('horizon')->hget($id, 'status');
         });
 
         $this->work();

--- a/tests/Feature/RetryJobTest.php
+++ b/tests/Feature/RetryJobTest.php
@@ -43,7 +43,7 @@ class RetryJobTest extends IntegrationTest
         dispatch(new RetryFailedJob($id));
 
         // Test status is set to pending...
-        $retried = Redis::connection('horizon-jobs')->hget($id, 'retried_by');
+        $retried = Redis::connection('horizon')->hget($id, 'retried_by');
         $retried = json_decode($retried, true);
         $this->assertSame('pending', $retried[0]['status']);
 
@@ -54,7 +54,7 @@ class RetryJobTest extends IntegrationTest
         $this->assertEquals(1, $this->monitoredJobs('first'));
 
         // Test that retry job ID reference is stored on original failed job...
-        $retried = Redis::connection('horizon-jobs')->hget($id, 'retried_by');
+        $retried = Redis::connection('horizon')->hget($id, 'retried_by');
         $retried = json_decode($retried, true);
         $this->assertCount(1, $retried);
         $this->assertNotNull($retried[0]['id']);
@@ -73,7 +73,7 @@ class RetryJobTest extends IntegrationTest
         $this->work();
 
         // Test that retry job ID reference is stored on original failed job...
-        $retried = Redis::connection('horizon-jobs')->hget($id, 'retried_by');
+        $retried = Redis::connection('horizon')->hget($id, 'retried_by');
         $retried = json_decode($retried, true);
 
         // Test status is now failed on the retry...

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -100,7 +100,7 @@ class SupervisorTest extends IntegrationTest
         });
 
         $this->wait(function () use ($id) {
-            $this->assertGreaterThan(0, Redis::connection('horizon-jobs')->ttl($id));
+            $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($id));
         });
     }
 


### PR DESCRIPTION
I've opened this PR to address the concern in: https://github.com/laravel/horizon/issues/11

Here we use a single database setup for all Horizon connections, and use a prefix `horizon:` before all keys.

