### PR TITLE
Fix issue with maximum processes

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -113,12 +113,10 @@ class AutoScaler
     {
         $supervisor->pruneTerminatingProcesses();
 
-        $totalProcesses = $supervisor->totalSystemProcessCount();
-
         $poolProcesses = $pool->totalProcessCount();
 
         if (round($workers) > $poolProcesses &&
-            $this->wouldNotExceedMaxProcesses($supervisor, $totalProcesses)) {
+            $this->wouldNotExceedMaxProcesses($supervisor)) {
             $pool->scale($poolProcesses + 1);
         } elseif (round($workers) < $poolProcesses &&
                   $poolProcesses > $supervisor->options->minProcesses) {
@@ -130,11 +128,10 @@ class AutoScaler
      * Determine if adding another process would exceed max process limit.
      *
      * @param  \Laravel\Horizon\Supervisor  $supervisor
-     * @param  int  $totalProcesses
      * @return bool
      */
-    protected function wouldNotExceedMaxProcesses(Supervisor $supervisor, $totalProcesses)
+    protected function wouldNotExceedMaxProcesses(Supervisor $supervisor)
     {
-        return ($totalProcesses + 1) <= $supervisor->options->maxProcesses;
+        return ($supervisor->totalProcessCount() + 1) <= $supervisor->options->maxProcesses;
     }
 }


### PR DESCRIPTION
To replicate the issue you need to have a supervisor that runs two queues on simple balancing and having an odd maximum number of processes. (e.g 5)

On the first loop of the supervisor process, when we run the autoscaler, we use `$supervisor->totalSystemProcessCount()` to get the current worker processes using `exec ps aux`, however the processes won't be running on the system until we call `monitor` later:

```php
if ($this->working) {
    $this->autoScale();

    $this->processPools->each->monitor();
}
```

So at the point the number of total processes will be equal to ZERO, so we add extra processes to the pool even though it has enough processes already.

If the number of maximum processes is 5 for example, the initial scaling that happened inside `SupervisorCommand` would create 2 processes per queue, leaving the maximum processes as 4.

Now after the first loop an extra process will be added for each queue, after adding the first processes the process count should be 5, so while adding the next process the supervisor should stop it since we already have 5. But this doesn't happen because we use `exec ps aux` to count the total processes, and by the time we call it that extra processes we created wouldn't be running yet.

In this PR I use the count stored in the supervisor processes pools instead of relying on the system processes count.