### PR TITLE
Avoid using redis keys() method

### DIFF
--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -29,7 +29,7 @@ class SnapshotCommand extends Command
      */
     public function handle()
     {
-        if (resolve(Lock::class)->get('metrics:snapshot', 10)) {
+        if (resolve(Lock::class)->get('metrics:snapshot', 300)) {
             resolve(MetricsRepository::class)->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');

--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -29,7 +29,7 @@ class SnapshotCommand extends Command
      */
     public function handle()
     {
-        if (resolve(Lock::class)->get('metrics:snapshot', 300)) {
+        if (resolve(Lock::class)->get('metrics:snapshot', 10)) {
             resolve(MetricsRepository::class)->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');

--- a/src/Contracts/MasterSupervisorRepository.php
+++ b/src/Contracts/MasterSupervisorRepository.php
@@ -51,4 +51,11 @@ interface MasterSupervisorRepository
      * @return void
      */
     public function forget($name);
+
+    /**
+     * Remove expired master supervisors from storage.
+     *
+     * @return void
+     */
+    public function flushExpired();
 }

--- a/src/Contracts/SupervisorRepository.php
+++ b/src/Contracts/SupervisorRepository.php
@@ -58,4 +58,11 @@ interface SupervisorRepository
      * @return void
      */
     public function forget($names);
+
+    /**
+     * Remove expired supervisors from storage.
+     *
+     * @return void
+     */
+    public function flushExpired();
 }

--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -45,6 +45,7 @@ trait EventMap
         'Laravel\Horizon\Events\MasterSupervisorLooped' => [
             'Laravel\Horizon\Listeners\TrimRecentJobs',
             'Laravel\Horizon\Listeners\TrimFailedJobs',
+            'Laravel\Horizon\Listeners\ExpireSupervisors',
             'Laravel\Horizon\Listeners\MonitorMasterSupervisorMemory',
         ],
 

--- a/src/Listeners/ExpireSupervisors.php
+++ b/src/Listeners/ExpireSupervisors.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Horizon\Listeners;
+
+use Cake\Chronos\Chronos;
+use Laravel\Horizon\Events\MasterSupervisorLooped;
+use Laravel\Horizon\Contracts\SupervisorRepository;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+
+class ExpireSupervisors
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Laravel\Horizon\Events\MasterSupervisorLooped  $event
+     * @return void
+     */
+    public function handle(MasterSupervisorLooped $event)
+    {
+        resolve(MasterSupervisorRepository::class)->flushExpired();
+
+        resolve(SupervisorRepository::class)->flushExpired();
+    }
+}

--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -8,14 +8,17 @@ class LuaScripts
      * Update the metrics for a job.
      *
      * KEYS[1] - The name of the key being updated
+     * KEYS[2] - The name of the key of the metrics group
      * ARGV[1] - The runtime in milliseconds of the current job
      *
      * @return string
      */
-    public static function updateJobMetrics()
+    public static function updateMetrics()
     {
         return <<<'LUA'
             redis.call('hsetnx', KEYS[1], 'throughput', 0)
+            
+            redis.call('sadd', KEYS[2], KEYS[1])
             
             local hash = redis.call('hmget', KEYS[1], 'throughput', 'runtime')
 

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -37,7 +37,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     public function names()
     {
         return $this->connection()->zrevrangebyscore('masters', '+inf',
-            Chronos::now()->subSeconds(15)->getTimestamp()
+            Chronos::now()->subSeconds(14)->getTimestamp()
         );
     }
 

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -138,6 +138,18 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     }
 
     /**
+     * Remove expired master supervisors from storage.
+     *
+     * @return void
+     */
+    public function flushExpired()
+    {
+        $this->connection()->zremrangebyscore('masters', '-inf',
+            Chronos::now()->subSeconds(14)->getTimestamp()
+        );
+    }
+
+    /**
      * Get the Redis connection instance.
      *
      * @return \Illuminate\Redis\Connections\Connection

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -155,6 +155,18 @@ class RedisSupervisorRepository implements SupervisorRepository
     }
 
     /**
+     * Remove expired supervisors from storage.
+     *
+     * @return void
+     */
+    public function flushExpired()
+    {
+        $this->connection()->zremrangebyscore('supervisors', '-inf',
+            Chronos::now()->subSeconds(14)->getTimestamp()
+        );
+    }
+
+    /**
      * Get the Redis connection instance.
      *
      * @return \Illuminate\Redis\Connections\Connection

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -36,7 +36,7 @@ class RedisSupervisorRepository implements SupervisorRepository
     public function names()
     {
         return $this->connection()->zrevrangebyscore('supervisors', '+inf',
-            Chronos::now()->subSeconds(15)->getTimestamp()
+            Chronos::now()->subSeconds(29)->getTimestamp()
         );
     }
 


### PR DESCRIPTION
We use a sorted set for `masters` and `supervisors` where we add the supervisor name with a score of the current timestamp, every time we persist we update the score, and on termination we remove the member for the set.

While collecting the master/supervisors we get the members where the score isn't too old, which means it's still running since the score is getting updates.

Added a `ExpireSupervisors` listener to the `MasterSupervisorLooped` event which removes old records from these sorted sets for it to be too large.

---

For measured jobs I used a set to collect all `jobs` and `queues`, we later use this sets to find `measuredJobs` and `measuredQueues`.