### PR TITLE
Null check while adding a new Monitoring Tag

### DIFF
--- a/resources/assets/js/components/Modals/AddTagModal.vue
+++ b/resources/assets/js/components/Modals/AddTagModal.vue
@@ -57,6 +57,10 @@
 
                             this.saving = false;
                         })
+                        .catch(function (error) {
+                            this.saving = false;
+                            this.$refs.tag.focus();
+                        });
 
             }
         }

--- a/src/Http/Controllers/MonitoringController.php
+++ b/src/Http/Controllers/MonitoringController.php
@@ -94,11 +94,17 @@ class MonitoringController extends Controller
      * Start monitoring the given tag.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return void
+     * @return \Illuminate\Http\JsonResponse
      */
     public function store(Request $request)
     {
+        if (null === $request->tag) {
+            return response()->json(['success' => false], 422);
+        }
+
         dispatch(new MonitorTag($request->tag));
+
+        return response()->json([], 201);
     }
 
     /**


### PR DESCRIPTION
`                if (!this.name) {
                    this.$refs.tag.focus();
                    return;
                }`

I saw that code above at AddTagModal's saveTag() method for validate user provides a **tag** but I've successfully created an empty tag in the morning. (I forgot to investigate why and deleted all keys starts with **horizon** manually on redis-cli). Empty tag cause an issue while deleting on Horizon.

Not sure am I doing right with don't using validate() method, but it is quick solution for directly check $request->tag.