### PR TITLE
Fix default current working directory when creating a Symfony Process object

### DIFF
--- a/src/MasterSupervisorCommands/AddSupervisor.php
+++ b/src/MasterSupervisorCommands/AddSupervisor.php
@@ -38,7 +38,7 @@ class AddSupervisor
     {
         $command = $options->toSupervisorCommand();
 
-        return (new Process($command, $options->directory ?? null))
+        return (new Process($command, $options->directory ?? base_path()))
                     ->setTimeout(null)
                     ->disableOutput();
     }


### PR DESCRIPTION
Regarding issue #83, I found the line that is causing this issue:

- [MasterSupervisorCommands/AddSupervisor.php#L41](https://github.com/laravel/horizon/blob/master/src/MasterSupervisorCommands/AddSupervisor.php#L41)

We'll need to change the current working directory (`$cwd`) parameter for the Symfony Process object, `$options->directory ?? null`, to one of the following:

- `$options->directory ?? base_path()`
- `$options->directory ?? realpath(__DIR__.'/../../../../../')`

Given horizon is intended for a laravel app, I'm most in favor of defaulting to the `base_path()` helper. This will consistently tell the Symfony Process object the directory to launch the `artisan horizon:supervisor` sub-processes no matter what directory a CLI user is in (or process like Supervisor) when running the `artisan horizon` daemon.