### PR TITLE
Fix issue with Workload widget when balancing is OFF

### DIFF
--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -69,9 +69,15 @@ class RedisWorkloadRepository implements WorkloadRepository
             ->map(function ($waitTime, $queue) use ($processes) {
                 [$connection, $queueName] = explode(':', $queue, 2);
 
+                $length = ! str_contains($queue, ',')
+                    ? $this->queue->connection($connection)->readyNow($queueName)
+                    : collect(explode(',', $queueName))->sum(function ($queueName) use ($connection) {
+                        return $this->queue->connection($connection)->readyNow($queueName);
+                    });
+                
                 return [
                     'name' => $queueName,
-                    'length' => $this->queue->connection($connection)->readyNow($queueName),
+                    'length' => $length,
                     'wait' => $waitTime,
                     'processes' => $processes[$queue] ?? 0,
                 ];


### PR DESCRIPTION
In reference to https://github.com/laravel/horizon/issues/82

While balancing is off the wait time calculator uses queue names collected from the supervisor process pools, the name of pools in this case shall contain multiple queues `first,second` so the calculations get messed up, this PR fixed that issue by detecting this situation and calculate wait time & queue length per queue.