### PR TITLE
[WIP] Allow users to specify a custom middleware

### DIFF
--- a/src/Contracts/InvalidAuthenticationMethod.php
+++ b/src/Contracts/InvalidAuthenticationMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Laravel\Horizon\Contracts;
+
+use Exception;
+
+class InvalidAuthenticationMethod extends Exception
+{
+    public function __construct()
+    {
+        $this->message = 'You may not use Horizon::check() when using middleware authentication.';
+    }
+}

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Http\Controllers;
 
-use Laravel\Horizon\Http\Middleware\Authenticate;
+use Laravel\Horizon\Horizon;
 use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
@@ -14,6 +14,6 @@ class Controller extends BaseController
      */
     public function __construct()
     {
-        $this->middleware(Authenticate::class);
+        $this->middleware(Horizon::middleware());
     }
 }

--- a/tests/Feature/Fixtures/CustomAuthMiddleware.php
+++ b/tests/Feature/Fixtures/CustomAuthMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Fixtures;
+
+class CustomAuthMiddleware
+{
+    public function handle($request, $next)
+    {
+        if (! $request->input('passes')) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This PR allows for users to pass a custom middleware, instead of just a closure, to `Horizon::auth()`. This allows for greater flexibility as users can use existing admin middleware instead of having to specify a new closure just for Horizon.

This is a WIP, and before making this ready for merge, I will fix any code style that is wrong, and add support for middleware parameters to be passed. Support for parameters would allow users to easily make use of Laravel's permissions system for Horizon access.