### PR TITLE
Overflow tables.

### DIFF
--- a/resources/assets/less/_components.panels.less
+++ b/resources/assets/less/_components.panels.less
@@ -20,5 +20,6 @@
 }
 
 .panel-content {
-  background: #FAFAFA
+  background: #FAFAFA;
+  overflow-x: scroll;
 }


### PR DESCRIPTION
`.panel-content` needs `overflow-x: scroll` so tables that extend too wide (recent jobs for example) can scroll and view the content.