### PR TITLE
Remove unnecessary padding from bottom of page

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -9,7 +9,7 @@
     <body>
         <div id="root"></div>
 
-        <div style="height: 0; width: 0; position: absolute; visibility: hidden;">
+        <div style="height: 0; width: 0; position: absolute; display: none;">
             {!! file_get_contents(public_path('/vendor/horizon/img/sprite.svg')) !!}
         </div>
 


### PR DESCRIPTION
The sprite was affecting layout because `visibility` was used instead of `display`

![img](http://i.imgur.com/C26obwr.png)

https://github.com/laravel/horizon/blob/43a70bf75a6f40ba5d59bbe206d657a9dc87f4be/resources/views/app.blade.php#L12-L14

Changing the `visibility: hidden` to `display: none`

![img](http://i.imgur.com/YgjVJRT.png)

You can see that the padding is no longer there and that the icons still work just fine!