### PR TITLE
Fix minor typo in ContinueCommand

### DIFF
--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -21,7 +21,7 @@ class ContinueCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Instruct the master supevisor to continue processing jobs';
+    protected $description = 'Instruct the master supervisor to continue processing jobs';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
Not much to say, simply a missing letter.