### PR TITLE
Require POSIX extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require": {
         "php": ">=7.1.0",
         "ext-pcntl": "*",
+        "ext-posix": "*",
         "cakephp/chronos": "^1.0",
         "illuminate/contracts": "~5.5",
         "illuminate/queue": "~5.5",


### PR DESCRIPTION
The ext-posix extension is required. Without horizon:terminate fails.

```sh
# php artisan horizon:terminate
Sending TERM Signal To Process: 21942

  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Call to undefined function Laravel\Horizon\Console\posix_kill()
```
