### PR TITLE
panel-content overflow-x from scroll to auto

### DIFF
--- a/resources/assets/less/_components.panels.less
+++ b/resources/assets/less/_components.panels.less
@@ -21,5 +21,5 @@
 
 .panel-content {
   background: #FAFAFA;
-  overflow-x: scroll;
+  overflow-x: auto;
 }


### PR DESCRIPTION
Do not show scrollbar when content does not exceed the panel maximum width.