### PR TITLE
fix zrange returns score as float in PHPRedis

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -231,13 +231,10 @@ class RedisMetricsRepository implements MetricsRepository
      */
     protected function snapshotsFor($key)
     {
-        $snapshots = collect($this->connection()->zrange('snapshot:'.$key, 0, - 1, 'withscores'))->map(function ($val) {
-            return (integer) $val;
-        })->flip();
-
-        return collect($snapshots)->map(function ($snapshot, $time) {
-            return (object) json_decode($snapshot, true);
-        })->values()->all();
+        return collect($this->connection()->zrange('snapshot:'.$key, 0, - 1, 'withscores'))
+            ->map(function ($time, $snapshot) {
+                return (object) json_decode($snapshot, true);
+            })->values()->all();
     }
 
     /**

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -231,7 +231,9 @@ class RedisMetricsRepository implements MetricsRepository
      */
     protected function snapshotsFor($key)
     {
-        $snapshots = array_flip($this->connection()->zrange('snapshot:'.$key, 0, -1, 'withscores'));
+        $snapshots = collect($this->connection()->zrange('snapshot:'.$key, 0, - 1, 'withscores'))->map(function ($val) {
+            return (integer) $val;
+        })->flip();
 
         return collect($snapshots)->map(function ($snapshot, $time) {
             return (object) json_decode($snapshot, true);

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -231,8 +231,8 @@ class RedisMetricsRepository implements MetricsRepository
      */
     protected function snapshotsFor($key)
     {
-        return collect($this->connection()->zrange('snapshot:'.$key, 0, - 1, 'withscores'))
-            ->map(function ($time, $snapshot) {
+        return collect($this->connection()->zrange('snapshot:'.$key, 0, - 1))
+            ->map(function ($snapshot) {
                 return (object) json_decode($snapshot, true);
             })->values()->all();
     }


### PR DESCRIPTION
As reported in https://github.com/phpredis/phpredis/issues/1189

zrange returns the score as float causing `array_flip` to error.

Here we'll just use  the payload without scores since we don't use it anyway.