### PR TITLE
Make the snapshot command available outside console

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -168,7 +168,6 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\PurgeCommand::class,
                 Console\PauseCommand::class,
                 Console\ContinueCommand::class,
-                Console\SnapshotCommand::class,
                 Console\SupervisorCommand::class,
                 Console\SupervisorsCommand::class,
                 Console\TerminateCommand::class,
@@ -176,5 +175,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\WorkCommand::class,
             ]);
         }
+
+        $this->commands([Console\SnapshotCommand::class]);
     }
 }


### PR DESCRIPTION
This helps if you are scheduling commands using http requests, for example using: https://crondog.io/