### PR TITLE
Remove trailing slashes on Ajax calls in Vuejs

### DIFF
--- a/resources/assets/js/pages/Failed/Job.vue
+++ b/resources/assets/js/pages/Failed/Job.vue
@@ -51,7 +51,7 @@
             loadFailedJob(id) {
                 this.loadingJob = true;
 
-                this.$http.get('/horizon/api/jobs/failed/' + id)
+                this.$http.get('/horizon/api/jobs/failed' + id)
                         .then(response => {
                             this.job = response.data;
 
@@ -64,7 +64,7 @@
              * Reload the job retries.
              */
             reloadRetries() {
-                this.$http.get('/horizon/api/jobs/failed/' + this.jobId)
+                this.$http.get('/horizon/api/jobs/failed' + this.jobId)
                         .then(response => {
                             this.job.retried_by = response.data.retried_by;
 

--- a/resources/assets/js/pages/Failed/Job.vue
+++ b/resources/assets/js/pages/Failed/Job.vue
@@ -51,7 +51,7 @@
             loadFailedJob(id) {
                 this.loadingJob = true;
 
-                this.$http.get('/horizon/api/jobs/failed' + id)
+                this.$http.get('/horizon/api/jobs/failed/' + id)
                         .then(response => {
                             this.job = response.data;
 
@@ -64,7 +64,7 @@
              * Reload the job retries.
              */
             reloadRetries() {
-                this.$http.get('/horizon/api/jobs/failed' + this.jobId)
+                this.$http.get('/horizon/api/jobs/failed/' + this.jobId)
                         .then(response => {
                             this.job.retried_by = response.data.retried_by;
 

--- a/resources/assets/js/pages/RecentJobs/Jobs.vue
+++ b/resources/assets/js/pages/RecentJobs/Jobs.vue
@@ -59,7 +59,7 @@
                     this.loadState = true;
                 }
 
-                return this.$http.get('/horizon/api/jobs/recent/' + '?starting_at=' + starting + '&limit=' + this.perPage)
+                return this.$http.get('/horizon/api/jobs/recent' + '?starting_at=' + starting + '&limit=' + this.perPage)
                         .then(response => {
                             this.jobs = response.data.jobs;
 


### PR DESCRIPTION
If you run Laravel on Apache, it has the following .htaccess rule that gets used.

```
<IfModule mod_rewrite.c>
    [ ... snip ... ]

    # Redirect Trailing Slashes If Not A Folder...
    RewriteCond %{REQUEST_FILENAME} !-d
    RewriteRule ^(.*)/$ /$1 [L,R=301]

    [ ... snip ... ]
</IfModule>
```

This looks at all requests that have a trailing slash, and redirects them to the page _without_ the trailing slash. If you're behind an HTTPS proxy (like Nginx/Cloudflare/...) this redirects you to an HTTP page, instead of an HTTPS page.

This PR tries to avoid that redirect altogether, by modifying the Vuejs calls to be _without_ the trailing slash, which are also valid.

This will solve issue #145.