### PR TITLE
no sleep

### DIFF
--- a/tests/Feature/WorkerProcessTest.php
+++ b/tests/Feature/WorkerProcessTest.php
@@ -20,7 +20,7 @@ class WorkerProcessTest extends IntegrationTest
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });
-        usleep(250 * 1000);
+        sleep(1);
         $workerProcess->monitor();
 
         Event::assertDispatched(WorkerProcessRestarting::class);
@@ -35,7 +35,7 @@ class WorkerProcessTest extends IntegrationTest
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });
-        usleep(250 * 1000);
+        sleep(1);
         $workerProcess->monitor();
         $workerProcess->monitor();
 
@@ -53,13 +53,14 @@ class WorkerProcessTest extends IntegrationTest
         });
 
         // Give process time to start...
-        usleep(250 * 1000);
+        sleep(1);
 
         // Should fail and set cooldown timestamp...
         $workerProcess->monitor();
         $this->assertTrue($workerProcess->coolingDown());
 
         // Travel to the future...
+        sleep(1);
         Chronos::setTestNow(Chronos::now()->addMinutes(3));
         $this->assertFalse($workerProcess->coolingDown());
 


### PR DESCRIPTION
Fix for #176
### Changes
after every start(), the process goes to a cool-down period. During the cool-down we should not attempt to restart.
The first cool-down is 1 second long. If the process is running after a cool-down we set `restartAgainAt` to null.
If the process is not running after any cool-down, another 1 minute cool-down begins and `UnableToLaunchProcess` event is fired.

### Suggestion
For the future releases, I think we can implement [Supervisord state machine](http://supervisord.org/subprocess.html#process-states). This pull request also simulates moving the process from 'STARTING' to 'RUNNING' state in Supervisord implementation. Please see `startsecs` config [here](http://supervisord.org/configuration.html#program-x-section-values) as well.

![Supervisor Transitions](http://supervisord.org/_images/subprocess-transitions.png)