### PR TITLE
Reports: limit excessive payloads (commands) via configuration option

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -45,6 +45,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Payload Threshold
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to configure when the Job Payload will be truncated
+    | for reports. Size of payload is limited in bytes.
+    |
+    */
+
+    'payload' => 1000,
+
+    /*
+    |--------------------------------------------------------------------------
     | Queue Worker Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -49,11 +49,11 @@ return [
     |--------------------------------------------------------------------------
     |
     | This option allows you to configure when the Job Payload will be truncated
-    | for reports. Size of payload is limited in bytes.
+    | for reports. Size of payload is limited in bytes, default ~0.5 Mb.
     |
     */
 
-    'payload' => 1000,
+    'payload' => 500000,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -24,10 +24,9 @@ class Controller extends BaseController
      */
     public function checkPayload(&$job) {
         $payload_size = ini_get('mbstring.func_overload') ? mb_strlen($job->payload , '8bit') : strlen($job->payload);
+        $job->payload = json_decode($job->payload);
         if($payload_size > config('horizon.payload')) {
-            $job->payload = 'Payload Size Exceeded';
-        } else {
-            $job->payload = json_decode($job->payload);
+            $job->payload->data = 'Payload Size Exceeded';
         }
     }
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -16,4 +16,18 @@ class Controller extends BaseController
     {
         $this->middleware(Authenticate::class);
     }
+
+    /**
+     * Check payload limits for job reports
+     *
+     * @param $job
+     */
+    public function checkPayload(&$job) {
+        $payload_size = ini_get('mbstring.func_overload') ? mb_strlen($job->payload , '8bit') : strlen($job->payload);
+        if($payload_size > config('horizon.payload')) {
+            $job->payload = 'Payload Size Exceeded';
+        } else {
+            $job->payload = json_decode($job->payload);
+        }
+    }
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -26,7 +26,10 @@ class Controller extends BaseController
         $payload_size = ini_get('mbstring.func_overload') ? mb_strlen($job->payload , '8bit') : strlen($job->payload);
         $job->payload = json_decode($job->payload);
         if($payload_size > config('horizon.payload')) {
-            $job->payload->data = 'Payload Size Exceeded';
+            $job->payload->data->command = serialize([
+                'command'=>$job->payload->data->commandName,
+                'payload'=>'Payload Size Exceeded'
+            ]);
         }
     }
 }

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -113,7 +113,7 @@ class FailedJobsController extends Controller
      */
     protected function decode($job)
     {
-        $job->payload = json_decode($job->payload);
+        $this->checkPayload($job);
 
         $job->retried_by = collect(json_decode($job->retried_by))
                     ->sortByDesc('retried_at')->values();

--- a/src/Http/Controllers/MonitoringController.php
+++ b/src/Http/Controllers/MonitoringController.php
@@ -84,7 +84,7 @@ class MonitoringController extends Controller
     protected function getJobs($jobIds, $startingAt = 0)
     {
         return $this->jobs->getJobs($jobIds, $startingAt)->map(function ($job) {
-            $job->payload = json_decode($job->payload);
+            $this->checkPayload($job);
 
             return $job;
         })->values();

--- a/src/Http/Controllers/RecentJobsController.php
+++ b/src/Http/Controllers/RecentJobsController.php
@@ -36,7 +36,7 @@ class RecentJobsController extends Controller
     public function index(Request $request)
     {
         $jobs = $this->jobs->getRecent($request->query('starting_at', -1))->map(function ($job) {
-            $job->payload = json_decode($job->payload);
+            $this->checkPayload($job);
 
             return $job;
         })->values();


### PR DESCRIPTION
When you have a series of job that have a large payload (say 2mb each) then the recent jobs listing fails in horizon due to memory exhausted when dealing with the json.