### PR TITLE
Support for non-standard PHP binary

### DIFF
--- a/src/PhpBinary.php
+++ b/src/PhpBinary.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Laravel\Horizon;
+
+class PhpBinary
+{
+    /**
+     * Determine the proper PHP executable.
+     *
+     * @return string
+     */
+    public static function getPath()
+    {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
+        return $escape.PHP_BINARY.$escape;
+    }
+}

--- a/src/SupervisorCommandString.php
+++ b/src/SupervisorCommandString.php
@@ -9,7 +9,7 @@ class SupervisorCommandString
      *
      * @var string
      */
-    public static $command = 'exec php artisan horizon:supervisor';
+    public static $command = 'exec @php artisan horizon:supervisor';
 
     /**
      * Get the command-line representation of the options for a supervisor.
@@ -19,9 +19,11 @@ class SupervisorCommandString
      */
     public static function fromOptions(SupervisorOptions $options)
     {
+        $command = str_replace('@php', PhpBinary::getPath(), static::$command);
+
         return sprintf(
             "%s {$options->name} {$options->connection} %s",
-            static::$command,
+            $command,
             static::toOptionsString($options)
         );
     }
@@ -47,6 +49,6 @@ class SupervisorCommandString
      */
     public static function reset()
     {
-        static::$command = 'exec php artisan horizon:supervisor';
+        static::$command = 'exec @php artisan horizon:supervisor';
     }
 }

--- a/src/WorkerCommandString.php
+++ b/src/WorkerCommandString.php
@@ -9,7 +9,7 @@ class WorkerCommandString
      *
      * @var string
      */
-    public static $command = 'exec php artisan horizon:work';
+    public static $command = 'exec @php artisan horizon:work';
 
     /**
      * Get the command-line representation of the options for a worker.
@@ -19,9 +19,11 @@ class WorkerCommandString
      */
     public static function fromOptions(SupervisorOptions $options)
     {
+        $command = str_replace('@php', PhpBinary::getPath(), static::$command);
+
         return sprintf(
             "%s {$options->connection} %s",
-            static::$command,
+            $command,
             static::toOptionsString($options)
         );
     }
@@ -46,6 +48,6 @@ class WorkerCommandString
      */
     public static function reset()
     {
-        static::$command = 'exec php artisan horizon:work';
+        static::$command = 'exec @php artisan horizon:work';
     }
 }

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
+use Laravel\Horizon\PhpBinary;
 use Laravel\Horizon\MasterSupervisor;
 use Laravel\Horizon\SupervisorOptions;
 use Laravel\Horizon\Tests\IntegrationTest;
@@ -13,6 +14,7 @@ class AddSupervisorTest extends IntegrationTest
     public function test_add_supervisor_command_creates_new_supervisor_on_master_process()
     {
         $master = new MasterSupervisor;
+        $phpBinary = PhpBinary::getPath();
 
         $master->loop();
 
@@ -24,8 +26,9 @@ class AddSupervisorTest extends IntegrationTest
         $master->loop();
 
         $this->assertCount(1, $master->supervisors);
+
         $this->assertEquals(
-            'exec php artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue=default --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue=default --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/MasterSupervisorTest.php
+++ b/tests/Feature/MasterSupervisorTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon\Tests\Feature;
 
 use Mockery;
+use Laravel\Horizon\PhpBinary;
 use Illuminate\Support\Facades\Redis;
 use Laravel\Horizon\MasterSupervisor;
 use Laravel\Horizon\SupervisorOptions;
@@ -222,8 +223,10 @@ class MasterSupervisorTest extends IntegrationTest
     protected function options()
     {
         return tap(new SupervisorOptions(MasterSupervisor::name().':name', 'redis'), function ($options) {
+            $phpBinary = PhpBinary::getPath();
             $options->directory = realpath(__DIR__.'/../');
-            WorkerCommandString::$command = 'exec php worker.php';
+
+            WorkerCommandString::$command = 'exec '.$phpBinary.' worker.php';
         });
     }
 }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -4,6 +4,7 @@ namespace Laravel\Horizon\Tests\Feature;
 
 use Mockery;
 use Cake\Chronos\Chronos;
+use Laravel\Horizon\PhpBinary;
 use Laravel\Horizon\AutoScaler;
 use Laravel\Horizon\Supervisor;
 use Illuminate\Support\Facades\Event;
@@ -23,7 +24,15 @@ use Laravel\Horizon\Events\WorkerProcessRestarting;
 
 class SupervisorTest extends IntegrationTest
 {
+    public $phpBinary;
     public $supervisor;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->phpBinary = PhpBinary::getPath();
+    }
 
     public function tearDown()
     {
@@ -57,7 +66,7 @@ class SupervisorTest extends IntegrationTest
 
         $host = MasterSupervisor::name();
         $this->assertEquals(
-            'exec php worker.php redis --delay=0 --memory=128 --queue=default --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue=default --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
     }
@@ -75,12 +84,12 @@ class SupervisorTest extends IntegrationTest
         $host = MasterSupervisor::name();
 
         $this->assertEquals(
-            'exec php worker.php redis --delay=0 --memory=128 --queue=first --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue=first --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
 
         $this->assertEquals(
-            'exec php worker.php redis --delay=0 --memory=128 --queue=second --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue=second --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[1]->getCommandLine()
         );
     }
@@ -465,7 +474,7 @@ class SupervisorTest extends IntegrationTest
     {
         return tap(new SupervisorOptions(MasterSupervisor::name().':name', 'redis'), function ($options) {
             $options->directory = realpath(__DIR__.'/../');
-            WorkerCommandString::$command = 'exec php worker.php';
+            WorkerCommandString::$command = 'exec '.$this->phpBinary.' worker.php';
         });
     }
 }


### PR DESCRIPTION
This PR allows to use Horizon in environments with multiple PHP cli versions.

In some cases you can have:
- `php` -> PHP 5.6 (default)
- `/usr/bin/php70` -> PHP 7.0
- `/usr/bin/php71` -> PHP 7.1

In this case Supervisor doesn't work because some classes call `'exec php artisan ...'`
but the default PHP command is PHP 5.6 and not PHP 7.0 or 7.1

With this changes, Horizon uses the PHP binary called in the Supervisor, e.g. :
```
[program:horizon]
process_name=%(program_name)s
command=/usr/bin/php70 /home/forge/app.com/artisan horizon
        --------------
              |------> Horizon should use this binary
...
```