### PR TITLE
Use Lua script for baseSnapshotData instead of transaction (for #193)

### DIFF
--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -34,4 +34,20 @@ class LuaScripts
             redis.call('hmset', KEYS[1], 'throughput', throughput, 'runtime', runtime)
 LUA;
     }
+
+    /**
+     * Get the base snapshot data for a given key and remove it.
+     *
+     * KEYS[1] - The name of the key to snapshot
+     *
+     * @return string
+     */
+    public static function baseSnapshotData()
+    {
+        return <<<'LUA'
+            local hash = redis.call('hmget', KEYS[1], 'throughput', 'runtime')
+            redis.call('del', KEYS[1])
+            return hash
+LUA;
+    }
 }

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -310,13 +310,9 @@ class RedisMetricsRepository implements MetricsRepository
      */
     protected function baseSnapshotData($key)
     {
-        $responses = $this->connection()->transaction(function ($trans) use ($key) {
-            $trans->hmget($key, ['throughput', 'runtime']);
+        $response = $this->connection()->eval(LuaScripts::baseSnapshotData(), 1, $key);
 
-            $trans->del($key);
-        });
-
-        $snapshot = array_values($responses[0]);
+        $snapshot = array_values($response);
 
         return [
             'throughput' => $snapshot[0],


### PR DESCRIPTION
Another try at removing transaction dependency blocking use of sentinel (#193).  I'm not a redis expert, but my quick study indicates Lua scripts are atomic (https://redis.io/commands/eval), so this should be an equivalent substitution, while allowing high availability configurations w/sentinel.