### PR TITLE
allow horizon route to be configurable

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -92,4 +92,17 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Route Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This is the name of the route prefix, and will define the base URL
+    | where your installation of Horizon will live. If you would like
+    | Horizon to live at the webroot, you can use a forward slash.
+    |
+    */
+
+    'route' => 'horizon',
+
 ];

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -49,7 +49,7 @@ class HorizonServiceProvider extends ServiceProvider
     protected function registerRoutes()
     {
         Route::group([
-            'prefix' => 'horizon',
+            'prefix' => config('horizon.route', 'horizon'),
             'namespace' => 'Laravel\Horizon\Http\Controllers',
             'middleware' => 'web',
         ], function () {


### PR DESCRIPTION
in reference to this issue: https://github.com/laravel/horizon/issues/98

I was going to run a `trim()` on the config value, but it looks like that is taken care of in the router, which makes sense to do it higher up the chain.

I'm not really sure how to add a test for this?  anyone able to help?