### PR TITLE
Feature/allow custom middleware

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -92,4 +92,14 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Middleware Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define which middleware to apply to horizon routes. By
+    | default the standard web middleware is applied.
+    |
+    */
+    'middleware' => env('HORIZON_MIDDLEWARE', 'web'),
 ];

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -92,14 +92,4 @@ return [
         ],
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Middleware Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Here you may define which middleware to apply to horizon routes. By
-    | default the standard web middleware is applied.
-    |
-    */
-    'middleware' => env('HORIZON_MIDDLEWARE', 'web'),
 ];

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -51,7 +51,7 @@ class HorizonServiceProvider extends ServiceProvider
         Route::group([
             'prefix' => config('horizon.uri', 'horizon'),
             'namespace' => 'Laravel\Horizon\Http\Controllers',
-            'middleware' => config('horizon.middleware', 'web'),
+            'middleware' => 'web',
         ], function () {
             $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         });

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -51,7 +51,7 @@ class HorizonServiceProvider extends ServiceProvider
         Route::group([
             'prefix' => config('horizon.uri', 'horizon'),
             'namespace' => 'Laravel\Horizon\Http\Controllers',
-            'middleware' => 'web',
+            'middleware' => config('horizon.middleware', 'web'),
         ], function () {
             $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         });


### PR DESCRIPTION
Added ability to override default `web` middleware for horizon routes. Similar feature to [PR 200](https://github.com/laravel/horizon/pull/200).