### PR TITLE
add error message

### DIFF
--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -34,5 +34,9 @@ class SnapshotCommand extends Command
 
             $this->info('Metrics snapshot stored successfully.');
         }
+        
+        else {
+            $this->error('Unable to take snapshot.');
+        }
     }
 }


### PR DESCRIPTION
kind of driven by [this issue](https://github.com/laravel/horizon/issues/186).

it's not immediately obvious that the snapshot command has failed, since there is currently no output.  not until you dig into the code do you realize you need a response for a success.