### PR TITLE
[1.0] Updated mockery/mockery dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/debug": "~3.3"
     },
     "require-dev": {
-        "mockery/mockery": "~0.9",
+        "mockery/mockery": "~1.0",
         "orchestra/database": "~3.5",
         "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "~6.0"


### PR DESCRIPTION
Updated [`mockery/mockery`](https://github.com/mockery/mockery) to [`~1.0`](https://github.com/mockery/mockery/releases/tag/1.0).