### PR TITLE
use a fluid container

### DIFF
--- a/resources/assets/js/pages/Dashboard.vue
+++ b/resources/assets/js/pages/Dashboard.vue
@@ -153,7 +153,7 @@
                 <div class="card-header">Overview</div>
 
                 <div class="card-body p-0">
-                    <div class="container">
+                    <div class="container-fluid">
                         <div class="stats row">
                             <div class="stat col-3 p-4">
                                 <h2 class="stat-title">Jobs Per Minute</h2>


### PR DESCRIPTION
we want the container to always take up the full width of the card body.  it just happens to work correctly right now because the parent is smaller than the container breakpoint.