### PR TITLE
Throw an exception in case of invalid Redis connection

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -87,7 +87,7 @@ class Horizon
      */
     public static function use($connection)
     {
-        if (is_null($config = config("database.redis.{$connection}"))){
+        if (is_null($config = config("database.redis.{$connection}"))) {
             throw new Exception("Redis connection [{$connection}] has not been configured.");
         }
 

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon;
 
 use Closure;
+use Exception;
 
 class Horizon
 {
@@ -82,10 +83,13 @@ class Horizon
      *
      * @param  string  $connection
      * @return void
+     * @throws Exception
      */
     public static function use($connection)
     {
-        $config = config("database.redis.{$connection}");
+        if (is_null($config = config("database.redis.{$connection}"))){
+            throw new Exception("Redis connection '{$connection}' is invalid.");
+        }
 
         config(['database.redis.horizon' => array_merge($config, [
             'options' => ['prefix' => config('horizon.prefix') ?: 'horizon:'],

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -88,7 +88,7 @@ class Horizon
     public static function use($connection)
     {
         if (is_null($config = config("database.redis.{$connection}"))){
-            throw new Exception("Redis connection '{$connection}' is invalid.");
+            throw new Exception("Redis connection [{$connection}] has not been configured.");
         }
 
         config(['database.redis.horizon' => array_merge($config, [


### PR DESCRIPTION
In case an invalid Redis connection name is provided, throw an exception with a clearer message:
```
[Exception]
Redis connection 'lorem' is invalid.

```
Currently with an invalid connection name, `php artisan horizon` would throw:
```
[ErrorException]
array_merge(): Argument #1 is not an array
```