### PR TITLE
Added name to catch-all route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -34,4 +34,4 @@ Route::prefix('api')->group(function () {
 });
 
 // Catch-all Route...
-Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)')->name('horizon.view');
+Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)')->name('horizon.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,4 +34,4 @@ Route::prefix('api')->group(function () {
 });
 
 // Catch-all Route...
-Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)');
+Route::get('/{view?}', 'HomeController@index')->where('view', '(.*)')->name('horizon.view');


### PR DESCRIPTION
When we need to use the route name to give access to user, mapping to user profile or anything else, the catch-all route is the only one that does not have a defined name.