### PR TITLE
Allow Spaces in Queue Names

### DIFF
--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -13,7 +13,7 @@ class QueueCommandString
      */
     public static function toOptionsString(SupervisorOptions $options, $paused = false)
     {
-        $string = sprintf('--delay=%s --memory=%s --queue=%s --sleep=%s --timeout=%s --tries=%s',
+        $string = sprintf('--delay=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
             $options->delay, $options->memory, $options->queue,
             $options->sleep, $options->timeout, $options->maxTries
         );


### PR DESCRIPTION
Spaces in queue names might sound strange. But L5 allows it and Horizon should, too