### PR TITLE
Delete monitored tags

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -420,7 +420,7 @@ class RedisJobRepository implements JobRepository
     {
         $this->connection()->pipeline(function ($pipe) use ($ids) {
             foreach ($ids as $id) {
-                $pipe->expireat($id, Chronos::now()->addDays(7)->getTimestamp());
+                $pipe->expireat($id, Chronos::now()->subDays(7)->getTimestamp());
             }
         });
     }


### PR DESCRIPTION
As I understand the method, it's to force-expire a collection of job ids. addDays(7) prolongs the jobs another week instead of expiring as the method name implies.