### PR TITLE
Change usages of `resolve` to `app`

### DIFF
--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -30,7 +30,7 @@ class ContinueCommand extends Command
      */
     public function handle()
     {
-        $masters = resolve(MasterSupervisorRepository::class)->all();
+        $masters = app(MasterSupervisorRepository::class)->all();
 
         $masters = collect($masters)->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -37,7 +37,7 @@ class HorizonCommand extends Command
      */
     public function handle()
     {
-        $repository = resolve(MasterSupervisorRepository::class);
+        $repository = app(MasterSupervisorRepository::class);
 
         if ($repository->find(MasterSupervisor::name())) {
             return $this->comment('A master supervisor is already running on this machine.');

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -28,7 +28,7 @@ class ListCommand extends Command
      */
     public function handle()
     {
-        $repository = resolve(MasterSupervisorRepository::class);
+        $repository = app(MasterSupervisorRepository::class);
 
         $masters = $repository->all();
 

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -30,7 +30,7 @@ class PauseCommand extends Command
      */
     public function handle()
     {
-        $masters = resolve(MasterSupervisorRepository::class)->all();
+        $masters = app(MasterSupervisorRepository::class)->all();
 
         $masters = collect($masters)->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -82,7 +82,7 @@ class PurgeCommand extends Command
     protected function recordOrphans($master, ProcessRepository $processes)
     {
         $processes->orphaned(
-            $master, $orphans = resolve(ProcessInspector::class)->orphaned()
+            $master, $orphans = app(ProcessInspector::class)->orphaned()
         );
 
         foreach ($orphans as $processId) {

--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -29,8 +29,8 @@ class SnapshotCommand extends Command
      */
     public function handle()
     {
-        if (resolve(Lock::class)->get('metrics:snapshot', 300)) {
-            resolve(MetricsRepository::class)->snapshot();
+        if (app(Lock::class)->get('metrics:snapshot', 300)) {
+            app(MetricsRepository::class)->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');
         }

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -50,7 +50,7 @@ class SupervisorCommand extends Command
      */
     public function handle()
     {
-        $supervisor = resolve(SupervisorFactory::class)->make(
+        $supervisor = app(SupervisorFactory::class)->make(
             $this->supervisorOptions()
         );
 

--- a/src/Console/SupervisorsCommand.php
+++ b/src/Console/SupervisorsCommand.php
@@ -28,7 +28,7 @@ class SupervisorsCommand extends Command
      */
     public function handle()
     {
-        $repository = resolve(SupervisorRepository::class);
+        $repository = app(SupervisorRepository::class);
 
         $supervisors = $repository->all();
 

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -30,7 +30,7 @@ class TerminateCommand extends Command
      */
     public function handle()
     {
-        $masters = resolve(MasterSupervisorRepository::class)->all();
+        $masters = app(MasterSupervisorRepository::class)->all();
 
         $masters = collect($masters)->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());

--- a/src/Http/Controllers/DashboardStatsController.php
+++ b/src/Http/Controllers/DashboardStatsController.php
@@ -18,14 +18,14 @@ class DashboardStatsController extends Controller
     public function index()
     {
         return [
-            'jobsPerMinute' => resolve(MetricsRepository::class)->jobsProcessedPerMinute(),
+            'jobsPerMinute' => app(MetricsRepository::class)->jobsProcessedPerMinute(),
             'processes' => $this->totalProcessCount(),
-            'queueWithMaxRuntime' => resolve(MetricsRepository::class)->queueWithMaximumRuntime(),
-            'queueWithMaxThroughput' => resolve(MetricsRepository::class)->queueWithMaximumThroughput(),
-            'recentlyFailed' => resolve(JobRepository::class)->countRecentlyFailed(),
-            'recentJobs' => resolve(JobRepository::class)->countRecent(),
+            'queueWithMaxRuntime' => app(MetricsRepository::class)->queueWithMaximumRuntime(),
+            'queueWithMaxThroughput' => app(MetricsRepository::class)->queueWithMaximumThroughput(),
+            'recentlyFailed' => app(JobRepository::class)->countRecentlyFailed(),
+            'recentJobs' => app(JobRepository::class)->countRecent(),
             'status' => $this->currentStatus(),
-            'wait' => collect(resolve(WaitTimeCalculator::class)->calculate())->take(1),
+            'wait' => collect(app(WaitTimeCalculator::class)->calculate())->take(1),
         ];
     }
 
@@ -36,7 +36,7 @@ class DashboardStatsController extends Controller
      */
     protected function totalProcessCount()
     {
-        $supervisors = resolve(SupervisorRepository::class)->all();
+        $supervisors = app(SupervisorRepository::class)->all();
 
         return collect($supervisors)->reduce(function ($carry, $supervisor) {
             return $carry + collect($supervisor->processes)->sum();
@@ -50,7 +50,7 @@ class DashboardStatsController extends Controller
      */
     protected function currentStatus()
     {
-        if (! $masters = resolve(MasterSupervisorRepository::class)->all()) {
+        if (! $masters = app(MasterSupervisorRepository::class)->all()) {
             return 'inactive';
         }
 

--- a/src/JobId.php
+++ b/src/JobId.php
@@ -24,7 +24,7 @@ class JobId
             return call_user_func(static::$generator);
         }
 
-        return resolve(JobRepository::class)->nextJobId();
+        return app(JobRepository::class)->nextJobId();
     }
 
     /**

--- a/src/Listeners/ExpireSupervisors.php
+++ b/src/Listeners/ExpireSupervisors.php
@@ -17,8 +17,8 @@ class ExpireSupervisors
      */
     public function handle(MasterSupervisorLooped $event)
     {
-        resolve(MasterSupervisorRepository::class)->flushExpired();
+        app(MasterSupervisorRepository::class)->flushExpired();
 
-        resolve(SupervisorRepository::class)->flushExpired();
+        app(SupervisorRepository::class)->flushExpired();
     }
 }

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -50,7 +50,7 @@ class MonitorWaitTimes
         // Here we will calculate the wait time in seconds for each of the queues that
         // the application is working. Then, we will filter the results to find the
         // queues with the longest wait times and raise events for each of these.
-        $results = resolve(WaitTimeCalculator::class)->calculate();
+        $results = app(WaitTimeCalculator::class)->calculate();
 
         $long = collect($results)->filter(function ($wait, $queue) {
             return $wait > (config("horizon.waits.{$queue}") ?? 60);

--- a/src/Listeners/SendNotification.php
+++ b/src/Listeners/SendNotification.php
@@ -18,7 +18,7 @@ class SendNotification
     {
         $notification = $event->toNotification();
 
-        if (! resolve(Lock::class)->get('notification:'.$notification->signature(), 300)) {
+        if (! app(Lock::class)->get('notification:'.$notification->signature(), 300)) {
             return;
         }
 

--- a/src/Listeners/TrimFailedJobs.php
+++ b/src/Listeners/TrimFailedJobs.php
@@ -39,7 +39,7 @@ class TrimFailedJobs
         }
 
         if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
-            resolve(JobRepository::class)->trimFailedJobs();
+            app(JobRepository::class)->trimFailedJobs();
 
             $this->lastTrimmed = Chronos::now();
         }

--- a/src/Listeners/TrimRecentJobs.php
+++ b/src/Listeners/TrimRecentJobs.php
@@ -39,7 +39,7 @@ class TrimRecentJobs
         }
 
         if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
-            resolve(JobRepository::class)->trimRecentJobs();
+            app(JobRepository::class)->trimRecentJobs();
 
             $this->lastTrimmed = Chronos::now();
         }

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -55,7 +55,7 @@ class ProcessInspector
      */
     public function monitoring()
     {
-        return collect(resolve(SupervisorRepository::class)->all())
+        return collect(app(SupervisorRepository::class)->all())
             ->pluck('pid')
             ->pipe(function ($processes) {
                 $processes->each(function ($process) use (&$processes) {
@@ -65,7 +65,7 @@ class ProcessInspector
                 return $processes;
             })
             ->merge(
-                array_pluck(resolve(MasterSupervisorRepository::class)->all(), 'pid')
+                array_pluck(app(MasterSupervisorRepository::class)->all(), 'pid')
             )->all();
     }
 }

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -106,7 +106,7 @@ class ProvisioningPlan
      */
     protected function add(SupervisorOptions $options)
     {
-        resolve(HorizonCommandQueue::class)->push(
+        app(HorizonCommandQueue::class)->push(
             MasterSupervisor::commandQueueFor($this->master),
             AddSupervisor::class,
             $options->toArray()

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -128,7 +128,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
             return;
         }
 
-        resolve(SupervisorRepository::class)->forget(
+        app(SupervisorRepository::class)->forget(
             $master->supervisors
         );
 

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -292,7 +292,7 @@ class RedisMetricsRepository implements MetricsRepository
             'snapshot:'.$key, $time = Chronos::now()->getTimestamp(), json_encode([
                 'throughput' => $data['throughput'],
                 'runtime' => $data['runtime'],
-                'wait' => resolve(WaitTimeCalculator::class)->calculateFor($queue),
+                'wait' => app(WaitTimeCalculator::class)->calculateFor($queue),
                 'time' => $time,
             ])
         );
@@ -358,7 +358,7 @@ class RedisMetricsRepository implements MetricsRepository
      */
     public function acquireWaitTimeMonitorLock()
     {
-        return resolve(Lock::class)->get('monitor:time-to-clear');
+        return app(Lock::class)->get('monitor:time-to-clear');
     }
 
     /**

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -82,7 +82,7 @@ class Supervisor implements Pausable, Restartable, Terminable
             //
         };
 
-        resolve(HorizonCommandQueue::class)->flush($this->name);
+        app(HorizonCommandQueue::class)->flush($this->name);
     }
 
     /**
@@ -217,7 +217,7 @@ class Supervisor implements Pausable, Restartable, Terminable
         // We will mark this supervisor as terminating so that any user interface can
         // correctly show the supervisor's status. Then, we will scale the process
         // pools down to zero workers to gracefully terminate them all out here.
-        resolve(SupervisorRepository::class)
+        app(SupervisorRepository::class)
                     ->forget($this->name);
 
         $this->processPools->each->scale(0);
@@ -260,7 +260,7 @@ class Supervisor implements Pausable, Restartable, Terminable
      */
     public function ensureNoDuplicateSupervisors()
     {
-        if (resolve(SupervisorRepository::class)->find($this->name) !== null) {
+        if (app(SupervisorRepository::class)->find($this->name) !== null) {
             throw new Exception("A supervisor with the name [{$this->name}] is already running.");
         }
     }
@@ -291,9 +291,9 @@ class Supervisor implements Pausable, Restartable, Terminable
 
             event(new SupervisorLooped($this));
         } catch (Exception $e) {
-            resolve(ExceptionHandler::class)->report($e);
+            app(ExceptionHandler::class)->report($e);
         } catch (Throwable $e) {
-            resolve(ExceptionHandler::class)->report(new FatalThrowableError($e));
+            app(ExceptionHandler::class)->report(new FatalThrowableError($e));
         }
     }
 
@@ -304,8 +304,8 @@ class Supervisor implements Pausable, Restartable, Terminable
      */
     protected function processPendingCommands()
     {
-        foreach (resolve(HorizonCommandQueue::class)->pending($this->name) as $command) {
-            resolve($command->command)->process($this, $command->options);
+        foreach (app(HorizonCommandQueue::class)->pending($this->name) as $command) {
+            app($command->command)->process($this, $command->options);
         }
     }
 
@@ -322,7 +322,7 @@ class Supervisor implements Pausable, Restartable, Terminable
         if (Chronos::now()->subSeconds($this->autoScaleCooldown)->gte($this->lastAutoScaled)) {
             $this->lastAutoScaled = Chronos::now();
 
-            resolve(AutoScaler::class)->scale($this);
+            app(AutoScaler::class)->scale($this);
         }
     }
 
@@ -333,7 +333,7 @@ class Supervisor implements Pausable, Restartable, Terminable
      */
     public function persist()
     {
-        resolve(SupervisorRepository::class)->update($this);
+        app(SupervisorRepository::class)->update($this);
     }
 
     /**
@@ -395,7 +395,7 @@ class Supervisor implements Pausable, Restartable, Terminable
      */
     public function totalSystemProcessCount()
     {
-        return resolve(SystemProcessCounter::class)->get($this->name);
+        return app(SystemProcessCounter::class)->get($this->name);
     }
 
     /**

--- a/src/SupervisorProcess.php
+++ b/src/SupervisorProcess.php
@@ -112,7 +112,7 @@ class SupervisorProcess extends WorkerProcess
      */
     protected function reprovision()
     {
-        resolve(HorizonCommandQueue::class)->push(
+        app(HorizonCommandQueue::class)->push(
             MasterSupervisor::commandQueue(),
             AddSupervisor::class,
             $this->options->toArray()
@@ -127,7 +127,7 @@ class SupervisorProcess extends WorkerProcess
      */
     public function terminateWithStatus($status)
     {
-        resolve(HorizonCommandQueue::class)->push(
+        app(HorizonCommandQueue::class)->push(
             $this->options->name, Terminate::class, ['status' => $status]
         );
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -56,7 +56,7 @@ abstract class IntegrationTest extends TestCase
      */
     protected function recentJobs()
     {
-        return resolve(JobRepository::class)->totalRecent();
+        return app(JobRepository::class)->totalRecent();
     }
 
     /**
@@ -67,7 +67,7 @@ abstract class IntegrationTest extends TestCase
      */
     protected function monitoredJobs($tag)
     {
-        return resolve(TagRepository::class)->count($tag);
+        return app(TagRepository::class)->count($tag);
     }
 
     /**
@@ -77,7 +77,7 @@ abstract class IntegrationTest extends TestCase
      */
     protected function failedJobs()
     {
-        return resolve(JobRepository::class)->totalFailed();
+        return app(JobRepository::class)->totalFailed();
     }
 
     /**
@@ -102,7 +102,7 @@ abstract class IntegrationTest extends TestCase
      */
     protected function worker()
     {
-        return resolve('queue.worker');
+        return app('queue.worker');
     }
 
     /**

--- a/tests/worker.php
+++ b/tests/worker.php
@@ -28,7 +28,7 @@ $app->register(Laravel\Horizon\HorizonServiceProvider::class);
 $app['config']->set('queue.default', 'redis');
 
 // Create the worker...
-$worker = resolve(Worker::class);
+$worker = app(Worker::class);
 
 // Pause the worker if needed...
 if (in_array('--paused', $_SERVER['argv'])) {


### PR DESCRIPTION
The `resolve` helper function in Laravel is a direct proxy to the `app` function, which itself is a proxy to the container `make` method. The one difference is that `resolve` takes no parameters, while `app` does.  https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/helpers.php#L724

This PR changes all instances of `resolve` to `app` to avoid conflicts with other projects that may have a `resolve` function of their own. This came up while I was implementing a websocket server to broadcast messages from my Redis queues using [Hoa\Websocket](https://github.com/hoaproject/Websocket). Hoa has their own `resolve` method.

Accepting this will improve interoperability between the projects.