### PR TITLE
[5.6] Support block_for config option

### DIFF
--- a/src/Connectors/RedisConnector.php
+++ b/src/Connectors/RedisConnector.php
@@ -19,7 +19,8 @@ class RedisConnector extends BaseConnector
         return new RedisQueue(
             $this->redis, $config['queue'],
             Arr::get($config, 'connection', $this->connection),
-            Arr::get($config, 'retry_after', 60)
+            Arr::get($config, 'retry_after', 60),
+            Arr::get($config, 'block_for', 0)
         );
     }
 }


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/22284

I actually find Horizon without `blpop` to have really bad latency in processing new jobs if idle. Using blocking pop reduces latency significantly. Personally, I think it should default to using `blpop`. Without it, you need to wait until the next worker ends its cooldown cycle for the job to get picked up. If it's doing a blocking pop, redis will instead serve a job to a worker immediately as it enters the queue if there's an idle worker waiting for them. This _really_ speeds things up.

This option is in the 5.6 branch, so I guess this'll need to wait until 5.6 is released, but I'd love it if this was also backported to 5.5 (I don't think it should break BC?)