### PR TITLE
block_for should default to null

### DIFF
--- a/src/Connectors/RedisConnector.php
+++ b/src/Connectors/RedisConnector.php
@@ -20,7 +20,7 @@ class RedisConnector extends BaseConnector
             $this->redis, $config['queue'],
             Arr::get($config, 'connection', $this->connection),
             Arr::get($config, 'retry_after', 60),
-            Arr::get($config, 'block_for', 0)
+            Arr::get($config, 'block_for', null)
         );
     }
 }


### PR DESCRIPTION
The `block_for` option defaults to `0`, which means the blocking pop queue is enabled. This differs from the [Laravel default](https://github.com/laravel/framework/blob/56a58e0fa3d845bb992d7c64ac9bb6d0c24b745a/src/Illuminate/Queue/Connectors/RedisConnector.php#L49) (`null`). Other than that, the blocking pop queue [has some issues](https://github.com/laravel/framework/issues/22939) and therefore should be disabled as default for now.

Fixes #292