### PR TITLE
Another attempt on horizon orphans

### DIFF
--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -5,10 +5,13 @@ namespace Laravel\Horizon\Console;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Laravel\Horizon\MasterSupervisor;
+use Illuminate\Support\InteractsWithTime;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 
 class TerminateCommand extends Command
 {
+    use InteractsWithTime;
+
     /**
      * The name and signature of the console command.
      *
@@ -41,5 +44,7 @@ class TerminateCommand extends Command
 
             posix_kill($processId, SIGTERM);
         }
+
+        $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
     }
 }

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -159,10 +159,10 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
         // First we will terminate all child supervisors so they will gracefully scale
         // down to zero. We'll also grab the longest expiration times of any of the
         // active supervisors so we know the maximum amount of time to wait here.
-        $this->supervisors->each->terminate();
-
         $longest = app(SupervisorRepository::class)
-                    ->longestActiveTimeout();
+            ->longestActiveTimeout();
+        
+        $this->supervisors->each->terminate();
 
         // We will go ahead and remove this master supervisor's record from storage so
         // another master supervisor could get started in its place without waiting

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -283,6 +283,18 @@ class ProcessPool implements Countable
     }
 
     /**
+     * Get all of the current running processes as a collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function runningProcesses()
+    {
+        return collect($this->processes)->filter(function ($process) {
+            return $process->process->isRunning();
+        });
+    }
+
+    /**
      * Get the total active process count, including processes pending termination.
      *
      * @return int

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -217,14 +217,11 @@ class Supervisor implements Pausable, Restartable, Terminable
         // We will mark this supervisor as terminating so that any user interface can
         // correctly show the supervisor's status. Then, we will scale the process
         // pools down to zero workers to gracefully terminate them all out here.
-        app(SupervisorRepository::class)
-                    ->forget($this->name);
+        app(SupervisorRepository::class)->forget($this->name);
 
-        $this->processPools->each(function($pool){
-            $pool->processes()->each(function($process){
-                $process->terminate();
-            });
-        });
+        while ($this->processPools->map->runningProcesses()->collapse()->count()) {
+            sleep(1);
+        }
 
         $this->exit($status);
     }


### PR DESCRIPTION
In this PR we're doing 3 things:

1. Instead of manually terminating the worker processes on termination we store a cache value similar to what happens in `queue:restart`
2. On Supervisor termination we wait until all worker processes aren't running anymore before we exit
3. We calculate the longest timeout before terminating the supervisors to prevent a case where it returns zero causing the master supervisor to terminate rightaway killing the child supervisor process before it kills all the workers.