### PR TITLE
Fixed issue where metrics only showed CallQueuedListener

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -149,13 +149,13 @@ class JobPayload implements ArrayAccess
     }
 
     /**
-     * Get the "command name" for the job.
+     * Get the "display name" for the job.
      *
      * @return string
      */
-    public function commandName()
+    public function displayName()
     {
-        return Arr::get($this->decoded, 'data.commandName');
+        return Arr::get($this->decoded, 'displayName');
     }
 
     /**

--- a/src/Listeners/UpdateJobMetrics.php
+++ b/src/Listeners/UpdateJobMetrics.php
@@ -54,7 +54,7 @@ class UpdateJobMetrics
         );
 
         $this->metrics->incrementJob(
-            $event->payload->commandName(), $time
+            $event->payload->displayName(), $time
         );
     }
 }


### PR DESCRIPTION
When using the commandName of the jobs we would only get the class
Illuminate\Events\CallQueuedListener in our metrics tab.

Switching to using the displayName instead solves this issue.