### PR TITLE
Fix Purge always reporting 1 orphan process issue

### DIFF
--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -33,7 +33,7 @@ class ProcessInspector
     public function current()
     {
         return array_diff(
-            $this->exec->run('pgrep -f horizon'),
+            $this->exec->run('pgrep -f [h]orizon'),
             $this->exec->run('pgrep -f horizon:purge')
         );
     }

--- a/tests/Feature/ProcessInspectorTest.php
+++ b/tests/Feature/ProcessInspectorTest.php
@@ -14,7 +14,7 @@ class ProcessInspectorTest extends IntegrationTest
     public function test_finds_orphaned_process_ids()
     {
         $exec = Mockery::mock(Exec::class);
-        $exec->shouldReceive('run')->with('pgrep -f horizon')->andReturn([1, 2, 3, 4, 5, 6]);
+        $exec->shouldReceive('run')->with('pgrep -f [h]orizon')->andReturn([1, 2, 3, 4, 5, 6]);
         $exec->shouldReceive('run')->with('pgrep -f horizon:purge')->andReturn([]);
         $exec->shouldReceive('run')->with('pgrep -P 2')->andReturn([4]);
         $exec->shouldReceive('run')->with('pgrep -P 3')->andReturn([5]);


### PR DESCRIPTION
Related to https://github.com/laravel/horizon/issues/178: Every single time "purge" runs, it always reports finding 1 process as an orphan, as it turns out that this case is kind of a false positive.

`ProcessInspector`'s `current` method runs the command `pgrep -f horizon` (within a process whose ID is `X`), this process ID `X` is reported back as a result of the same command (since it contains "horizon"). 

Running `pgrep -lf horizon` from the purge command confirms this, it returns something that looks like this:
```
14302 php
14306 php7.2
15912 php7.2
15945 php7.2
16765 php
16771 sh        ---> Used to be reported as an orphan process
```

I have used a simple regular expression that would match `horizon` (An actual process) but not `[h]orizon` (The process that runs `pgrep`).