### PR TITLE
Add redirect on Horizon logo

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -4,6 +4,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Horizon Configuration
+    |--------------------------------------------------------------------------
+    |
+    | To return to your application, you can define a URL here for the logo.
+    | Clicking on the logo will redirect you to the preferred URL.
+    |
+    */
+
+    'logo_url' => '/horizon',
+
+    /*
+    |--------------------------------------------------------------------------
     | Horizon Redis Connection
     |--------------------------------------------------------------------------
     |

--- a/resources/assets/js/layouts/MainLayout.vue
+++ b/resources/assets/js/layouts/MainLayout.vue
@@ -3,7 +3,15 @@
     import MainSidebar from './MainSidebar.vue'
 
     export default {
-        components: {Status, MainSidebar}
+        components: {Status, MainSidebar},
+        data() {
+            return {
+                logo_url: false
+            }
+        },
+        mounted(){
+            this.logo_url = window.HORIZON.logo_url;
+        }
     }
 </script>
 
@@ -12,7 +20,10 @@
         <div id="mainHeader" class="pt-4 pb-4">
             <div class="row">
                 <div class="col">
-                    <img src="/vendor/horizon/img/horizon.svg">
+                    <a v-if="logo_url" :href="logo_url">
+                        <img src="/vendor/horizon/img/horizon.svg">
+                    </a>
+                    <img v-else src="/vendor/horizon/img/horizon.svg">
                 </div>
             </div>
         </div>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -5,6 +5,12 @@
         <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="{{ mix('css/app.css', 'vendor/horizon') }}">
         <link rel="icon" href="/vendor/horizon/img/favicon.png" />
+        <script type="text/javascript">
+            window.HORIZON = {
+                logo_url: '{{e(config('horizon.logo_url'))}}'
+            };
+
+        </script>
     </head>
 
     <body>


### PR DESCRIPTION
I've added a config option to set a url. Once filled in, you can click the logo to get redirected to any path you would like. Added this so you can return easily to your own application.