### PR TITLE
Slugify hostname

### DIFF
--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -96,7 +96,7 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     {
         return static::$nameResolver
                         ? call_user_func(static::$nameResolver)
-                        : gethostname();
+                        : str_slug(gethostname());
     }
 
     /**


### PR DESCRIPTION
I found this to be an issue when running horizon on my macbook. It's hostname is `Jergus's MacBook
` and when horizon composes the shell command, the parentheses break it.

Thanks