### PR TITLE
Removed middle alignment from ".card-table td".

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -152,7 +152,6 @@
 
     td {
         padding: 1.25rem;
-        vertical-align: middle;
     }
 }
 


### PR DESCRIPTION
When a job has lots of tags, you lose your other cells down the list (https://www.evernote.com/l/AAk61_xwr4BDcJBVvT2HGRwxjTBHk8hOTQM).

With this fix, all cells show at the top of the cell (https://www.evernote.com/l/AAlGOMfu-5dJ0qdDmB7BgnwXddcdX9cKIqk).