### PR TITLE
Fix issue with metrics queue route not loading due to parameter name

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ Route::prefix('api')->group(function () {
 
     // Job Metric Routes...
     Route::get('/metrics/jobs', 'JobMetricsController@index')->name('horizon.jobs-metrics.index');
-    Route::get('/metrics/jobs/{id}', 'JobMetricsController@show')->name('horizon.jobs-metrics.show');
+    Route::get('/metrics/jobs/{slug}', 'JobMetricsController@show')->name('horizon.jobs-metrics.show');
 
     // Queue Metric Routes...
     Route::get('/metrics/queues', 'QueueMetricsController@index')->name('horizon.queues-metrics.index');;

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Route::prefix('api')->group(function () {
 
     // Queue Metric Routes...
     Route::get('/metrics/queues', 'QueueMetricsController@index')->name('horizon.queues-metrics.index');;
-    Route::get('/metrics/queues/{id}', 'QueueMetricsController@show')->name('horizon.queues-metrics.show');
+    Route::get('/metrics/queues/{slug}', 'QueueMetricsController@show')->name('horizon.queues-metrics.show');
 
     // Job Routes...
     Route::get('/jobs/recent', 'RecentJobsController@index')->name('horizon.recent-jobs.index');


### PR DESCRIPTION
This fixes the issue #377. The reason why this was happening is due to the fact that a queue name most likely will be alpha numeric. Since the route binding expects {id} the {id} in most applications (at least for us) has a global pattern set to [0-9]+ or \d+ this prevented the route from working properly since our queue was named 'default' the {id} didn't match to that pattern.

The change is simple, instead of {id} i changed it to {slug} (it also matches the parameter name in the controller action).
