### PR TITLE
Suggest predis instead of requiring it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "illuminate/contracts": "~5.5",
         "illuminate/queue": "~5.5",
         "illuminate/support": "~5.5",
-        "predis/predis": "^1.1",
         "ramsey/uuid": "^3.5",
         "symfony/debug": "~3.3|~4.0"
     },
@@ -29,6 +28,9 @@
         "orchestra/database": "~3.5",
         "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "~6.0"
+    },
+    "suggest": {
+        "predis/predis": "Required to use the redis cache and queue drivers (^1.1)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Just like laravel/framework which suggests predis (and people can choose to use phpredis instead), Horizon should suggest it so people using phpredis do not needlessly install a dependency.

Horizon relies on the redis config in config/database.php anyway, and trusts that the user correctly fills in that information. Requiring the user to install phpredis or predis herself is no different from what other parts of Laravel using Redis already do.