### PR TITLE
Support Laravel 5.7.2 - add missing option stop-when-empty

### DIFF
--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -18,6 +18,7 @@ class WorkCommand extends BaseWorkCommand
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
                             {--once : Only process the next job on the queue}
+                            {--stop-when-empty : Stop when the queue is empty}
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--supervisor= : The name of the supervisor the worker belongs to}


### PR DESCRIPTION
due to a change in the BaseWorkCommand (Illuminate\Queue\Console\WorkCommand) the --stop-when-empty option is missing in Horizon\Console\WorkCommand. 

The missing option causes the Exception **The "stop-when-empty" option does not exist.** when running **php artisan horizon**