### PR TITLE
Retry all failed jobs

### DIFF
--- a/src/Contracts/JobRepository.php
+++ b/src/Contracts/JobRepository.php
@@ -190,4 +190,28 @@ interface JobRepository
      * @return int
      */
     public function deleteFailed($id);
+
+    /**
+     * Get a chunk of jobs from the given type set.
+     *
+     * @param  string  $type
+     * @param  string  $afterIndex
+     * @return \Illuminate\Support\Collection
+     */
+    public function getJobsByType($type, $afterIndex);
+
+    /**
+     * Inserts a snapshot of the failed jobs into storage.
+     *
+     * @return string|null the snapshot ID or null if the operation fails.
+     */
+    public function snapshotFailedJobs();
+
+    /**
+     * Delete a snapshot of the failed jobs from storage by ID.
+     *
+     * @param  string  $id
+     * @return bool
+     */
+    public function deleteFailedJobsSnapshot($id);
 }

--- a/src/Jobs/RetryAllFailedJobs.php
+++ b/src/Jobs/RetryAllFailedJobs.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Laravel\Horizon\Jobs;
+
+use Laravel\Horizon\JobId;
+use Laravel\Horizon\Contracts\JobRepository;
+use Illuminate\Contracts\Queue\Factory as Queue;
+
+class RetryAllFailedJobs
+{
+    /**
+     * Execute the job.
+     *
+     * @param  \Illuminate\Contracts\Queue\Factory $queue
+     * @param  \Laravel\Horizon\Contracts\JobRepository $repository
+     * @return void
+     */
+    public function handle(Queue $queue, JobRepository $repository)
+    {
+        $snapshotId = $repository->snapshotFailedJobs();
+
+        $lastIndex = -1;
+        while (true) {
+            [$jobs, $count] = $this->getFailedJobsPage($repository, $snapshotId, $lastIndex);
+
+            if ($jobs->isEmpty()) {
+                break;
+            }
+
+            $this->pushJobsOnQueue($queue, $repository, $jobs);
+            $lastIndex += $count;
+        }
+
+        $repository->deleteFailedJobsSnapshot($snapshotId);
+    }
+
+    /**
+     * Gets a page of the failed jobs after a certain index.
+     *
+     * @param  \Laravel\Horizon\Contracts\JobRepository $repository
+     * @param  string $snapshotId
+     * @param  int $lastIndex
+     * @return array
+     */
+    protected function getFailedJobsPage(JobRepository $repository, string $snapshotId, int $lastIndex)
+    {
+        $failedJobs = $repository->getJobsByType($snapshotId, $lastIndex);
+        $count = $failedJobs->count();
+
+        $failedJobs = $failedJobs->reject(function ($job) {
+            return $this->jobHasNonFailedRetries($job) || $this->jobIsRetry($job);
+        })->map(function ($job) {
+            return [
+                'id'         => $job->id,
+                'queue'      => $job->queue,
+                'payload'    => $job->payload,
+                'connection' => $job->connection,
+            ];
+        });
+
+        return [$failedJobs, $count];
+    }
+
+    /**
+     * Whether or not a certain job has associated retries with pending or completed status.
+     *
+     * @param  object $job
+     * @return bool
+     */
+    protected function jobHasNonFailedRetries($job)
+    {
+        return collect(json_decode($job->retried_by ?? '[]'))
+            ->pluck('status')
+            ->reject(function ($status) {
+                return $status === 'failed';
+            })->isNotEmpty();
+    }
+
+    /**
+     * Whether or not the job is a retry of another job.
+     *
+     * @param  object $job
+     * @return bool
+     */
+    protected function jobIsRetry($job)
+    {
+        $payload = json_decode($job->payload ?? '{}');
+
+        return ! empty($payload->retry_of);
+    }
+
+    /**
+     * Push list of jobs on queue.
+     *
+     * @param  \Illuminate\Contracts\Queue\Factory $queue
+     * @param  \Laravel\Horizon\Contracts\JobRepository $repository
+     * @param  $jobs
+     */
+    private function pushJobsOnQueue(Queue $queue, JobRepository $repository, $jobs)
+    {
+        foreach ($jobs as $job) {
+            $payload = $this->preparePayload(
+                $id = JobId::generate(),
+                $job['id'],
+                $job['payload']
+            );
+
+            $queue->connection($job['connection'])->pushRaw($payload, $job['queue']);
+
+            $repository->storeRetryReference($job['id'], $id);
+        }
+    }
+
+    /**
+     * Prepare the payload for queueing.
+     *
+     * @param  string $id
+     * @param  string $retryOf
+     * @param  string $payload
+     * @return string
+     */
+    protected function preparePayload($id, $retryOf, $payload): string
+    {
+        return json_encode(array_merge(json_decode($payload, true), [
+            'id'       => $id,
+            'attempts' => 0,
+            'retry_of' => $retryOf,
+        ]));
+    }
+}

--- a/tests/Feature/Jobs/ConditionallyFailingJob.php
+++ b/tests/Feature/Jobs/ConditionallyFailingJob.php
@@ -8,6 +8,19 @@ class ConditionallyFailingJob
 {
     use InteractsWithQueue;
 
+    /**
+     * @var array
+     */
+    protected $tags;
+
+    /**
+     * @param array $tags
+     */
+    public function __construct(array $tags = ['first'])
+    {
+        $this->tags = $tags;
+    }
+
     public function handle()
     {
         if (isset($_SERVER['horizon.fail'])) {
@@ -17,6 +30,6 @@ class ConditionallyFailingJob
 
     public function tags()
     {
-        return ['first'];
+        return $this->tags;
     }
 }

--- a/tests/Feature/RetryJobTest.php
+++ b/tests/Feature/RetryJobTest.php
@@ -5,7 +5,9 @@ namespace Laravel\Horizon\Tests\Feature;
 use Laravel\Horizon\Jobs\MonitorTag;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
+use Laravel\Horizon\Jobs\RetryAllFailedJobs;
 use Laravel\Horizon\Jobs\RetryFailedJob;
+use Laravel\Horizon\Repositories\RedisJobRepository;
 use Laravel\Horizon\Tests\IntegrationTest;
 
 class RetryJobTest extends IntegrationTest
@@ -78,5 +80,193 @@ class RetryJobTest extends IntegrationTest
 
         // Test status is now failed on the retry...
         $this->assertSame('failed', $retried[0]['status']);
+    }
+
+    public function test_all_failed_jobs_can_be_retried_with_fresh_ids()
+    {
+        // Create 2 jobs
+        $first = Queue::push(new Jobs\ConditionallyFailingJob(['test', 'first']));
+        $second = Queue::push(new Jobs\ConditionallyFailingJob(['test', 'second']));
+
+        // Make them fail
+        $_SERVER['horizon.fail'] = true;
+        $this->work(2);
+
+        $this->assertEquals(2, $this->failedJobs());
+
+        // Monitor the tags from both jobs
+        dispatch(new MonitorTag('test'));
+        dispatch(new MonitorTag('first'));
+        dispatch(new MonitorTag('second'));
+
+        // Retry both of them
+        dispatch(new RetryAllFailedJobs());
+
+        // Test status is set to pending
+        $this->assertSame('pending', $this->getJobRetries($first)[0]['status']);
+        $this->assertSame('pending', $this->getJobRetries($second)[0]['status']);
+
+        // Work the now-passing jobs
+        unset($_SERVER['horizon.fail']);
+        $this->work(2);
+
+        // Test failed jobs and monitored tags count
+        $this->assertEquals(2, $this->failedJobs());
+        $this->assertEquals(2, $this->monitoredJobs('test'));
+        $this->assertEquals(1, $this->monitoredJobs('first'));
+        $this->assertEquals(1, $this->monitoredJobs('second'));
+
+        // Test if first job has been retried
+        $firstRetries = $this->getJobRetries($first);
+        $this->assertCount(1, $firstRetries);
+        $this->assertNotNull($firstRetries[0]['id']);
+        $this->assertNotNull($firstRetries[0]['retried_at']);
+        $this->assertSame('completed', $firstRetries[0]['status']);
+
+        // Test if second job has been retried
+        $secondRetries = $this->getJobRetries($second);
+        $this->assertCount(1, $secondRetries);
+        $this->assertNotNull($secondRetries[0]['id']);
+        $this->assertNotNull($secondRetries[0]['retried_at']);
+        $this->assertSame('completed', $secondRetries[0]['status']);
+    }
+
+    public function test_retry_all_failed_jobs_with_pagination()
+    {
+        // Create 101 jobs (3 pages)
+        $jobs = [];
+        for ($i = 0; $i <= 101; $i++) {
+            $jobs[] = Queue::push(new Jobs\ConditionallyFailingJob);
+        }
+
+        // Make all of them fail
+        $_SERVER['horizon.fail'] = true;
+        $this->work(count($jobs));
+
+        $this->assertEquals(count($jobs), $this->failedJobs());
+
+        // Monitor the job's tag
+        dispatch(new MonitorTag('first'));
+
+        // Retry all jobs
+        dispatch(new RetryAllFailedJobs());
+
+        // Test if all jobs have been retried
+        foreach ($jobs as $id) {
+            $this->assertSame('pending', $this->getJobRetries($id)[0]['status']);
+        }
+
+        // Work the now-passing jobs
+        unset($_SERVER['horizon.fail']);
+        $this->work(count($jobs));
+
+        // Test failed jobs and monitored tags count
+        $this->assertEquals(count($jobs), $this->failedJobs());
+        $this->assertEquals(count($jobs), $this->monitoredJobs('first'));
+
+        // Test if every job has been retried successfully
+        foreach ($jobs as $id) {
+            $retries = $this->getJobRetries($id);
+            $this->assertCount(1, $retries);
+            $this->assertNotNull($retries[0]['id']);
+            $this->assertNotNull($retries[0]['retried_at']);
+            $this->assertSame('completed', $retries[0]['status']);
+        }
+    }
+
+    public function test_retry_all_does_not_process_jobs_with_non_failed_retries()
+    {
+        // Create and fail a job
+        $first = Queue::push(new Jobs\ConditionallyFailingJob());
+        $_SERVER['horizon.fail'] = true;
+        $this->work();
+
+        $this->assertEquals(1, $this->failedJobs());
+
+        // Successfully retry the failed job
+        dispatch(new RetryFailedJob($first));
+        unset($_SERVER['horizon.fail']);
+        $this->work();
+
+        // Ensure that the retry has been completed
+        $firstRetries = $this->getJobRetries($first);
+        $this->assertSame('completed', $firstRetries[0]['status']);
+        $this->assertCount(1, $firstRetries);
+
+        // Create another failing job
+        $second = Queue::push(new Jobs\ConditionallyFailingJob);
+        $_SERVER['horizon.fail'] = true;
+        $this->work();
+
+        $this->assertEquals(2, $this->failedJobs());
+
+        // Retry all jobs
+        dispatch(new RetryAllFailedJobs());
+        unset($_SERVER['horizon.fail']);
+        $this->work();
+
+        // The 2nd job should have been retried
+        $secondRetries = $this->getJobRetries($second);
+        $this->assertSame('completed', $secondRetries[0]['status']);
+
+        // The first job should not have been retried again
+        $firstRetries = $this->getJobRetries($first);
+        $this->assertCount(1, $firstRetries);
+    }
+
+    public function test_retry_all_does_not_process_jobs_which_are_retries_of_another_job()
+    {
+        // Create a failing job
+        $id = Queue::push(new Jobs\FailingJob());
+        $this->work();
+
+        $this->assertEquals(1, $this->failedJobs());
+
+        // Retry the failing job
+        dispatch(new RetryFailedJob($id));
+        $this->work();
+
+        // We should have 2 failed jobs (an original job and its retry)
+        $this->assertEquals(2, $this->failedJobs());
+
+        // Retry all failed jobs
+        dispatch(new RetryAllFailedJobs());
+        $this->work(2);
+
+        // The failed jobs should be tried only once since they are duplicate
+        $this->assertEquals(3, $this->failedJobs());
+    }
+
+    public function test_failed_jobs_snapshot_gets_deleted_afterwards()
+    {
+        // Create a failing job
+        Queue::push(new Jobs\FailingJob());
+        $this->work();
+
+        // Retry all failed jobs
+        dispatch(new RetryAllFailedJobs());
+
+        // List of failed jobs snapshots
+        $snapshotKeys = collect(Redis::connection('horizon')->keys('*'))
+            ->filter(function ($key) {
+                $prefix = 'horizon:' . RedisJobRepository::FAILED_JOBS_SNAPSHOT_PREFIX;
+
+                return starts_with($key, $prefix);
+            });
+
+        // After RetryAllFailedJobs is done, there should be no remaining snapshots
+        $this->assertTrue($snapshotKeys->isEmpty(), 'Failed asserting that jobs snapshots are being deleted.');
+    }
+
+    /**
+     * @param string $originalId
+     * @return array
+     */
+    private function getJobRetries(string $originalId): array
+    {
+        $retriedJob = Redis::connection('horizon')->hget($originalId, 'retried_by');
+        $retriedJob = json_decode($retriedJob ?? '[]', true);
+
+        return $retriedJob;
     }
 }


### PR DESCRIPTION
I've implemented the logic to retry all failed jobs at once as requested here https://github.com/laravel/horizon/issues/182

### Approach:
1. Copy/Create a snapshot of the failed jobs.
2. Retrieve a page by page list of failed jobs.
3. For each page, re-push the failed jobs on queue excluding those with pending/completed retries and jobs which are already retries of other jobs (i.e., only the original job is re-queued).
4. Delete the snapshot created at step 1.

#### Why create a snapshot of the failed jobs and not process them directly?
The failed jobs Redis entry is a stack: recently failed jobs are always at the top. So, if for example while re-queueing the page no 1 of failed jobs (e.g. 50 jobs), 30 fresh jobs fail (and then added to the top of the stack), when processing page no 2, we would actually get 30 jobs that have already been processed. While I actually avoid re-queuing them, I guess this could lead to extended execution time in an unexpected way.

#### Creating a snapshot (Redis copying) approach:
I am not sure but I guess copying all the failed jobs could exhaust memory limits if done on Horizon level through the job repository. I decided to go for a Lua script. My knowledge of Redis is not profound but I came across [this article](https://redislabs.com/blog/the-7th-principle-of-redis-we-optimize-for-joy/ ) which provides a code snippet which is described as 

> The fastest, type-agnostic way to copy a Redis key

.

### Breaking changes
- Three methods have been added to the `JobRepository` interface.

--- 

If you agree with this approach, then there is another change I have in mind which I'd like to run by you: there could be only 1 "retry all failed jobs" process running at a given time.

