### PR TITLE
Show correct timescale on the Dashboard.

### DIFF
--- a/resources/assets/js/pages/Dashboard.vue
+++ b/resources/assets/js/pages/Dashboard.vue
@@ -143,14 +143,14 @@
                                 </span>
                             </div>
                             <div class="stat col-3 p-4">
-                                <h2 class="stat-title">Jobs past hour</h2>
+                                <h2 class="stat-title">Jobs past {{ stats.recency }} hour(s)</h2>
                                 <h3 class="stat-meta">&nbsp;</h3>
                                 <span class="stat-value">
                                     {{ stats.recentJobs }}
                                 </span>
                             </div>
                             <div class="stat col-3 p-4">
-                                <h2 class="stat-title">Failed Jobs past hour</h2>
+                                <h2 class="stat-title">Failed Jobs past {{ stats.recency }} hour(s)</h2>
                                 <h3 class="stat-meta">&nbsp;</h3>
                                 <span class="stat-value">
                                     {{ stats.recentlyFailed }}

--- a/src/Http/Controllers/DashboardStatsController.php
+++ b/src/Http/Controllers/DashboardStatsController.php
@@ -26,6 +26,7 @@ class DashboardStatsController extends Controller
             'recentJobs' => app(JobRepository::class)->countRecent(),
             'status' => $this->currentStatus(),
             'wait' => collect(app(WaitTimeCalculator::class)->calculate())->take(1),
+            'recency' => round(config('horizon.trim.recent')/60),
         ];
     }
 

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -50,6 +50,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
         ]);
         $this->app->instance(WaitTimeCalculator::class, $wait);
 
+
         $response = $this->actingAs(new Fakes\User)
                     ->get('/horizon/api/stats');
 
@@ -62,6 +63,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
             'recentJobs' => 1,
             'queueWithMaxRuntime' => 'default',
             'queueWithMaxThroughput' => 'default',
+            'recency' => 1,
         ]);
     }
 

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -50,7 +50,6 @@ class DashboardStatsControllerTest extends AbstractControllerTest
         ]);
         $this->app->instance(WaitTimeCalculator::class, $wait);
 
-
         $response = $this->actingAs(new Fakes\User)
                     ->get('/horizon/api/stats');
 


### PR DESCRIPTION
I find it mildly annoying that we have our `horizon.trim.recent` config set to 24 hours, but the dashboard still says `Failed Jobs past hour` etc.

This PR uses the config value to display the number of hours.

Before...
<img width="466" alt="screenshot 2018-09-27 at 19 32 47" src="https://user-images.githubusercontent.com/340752/46166877-295d7200-c28c-11e8-9ba3-56d950fcea9b.png">

After (assuming `horizon.trim.recent` set to `1440`)...
<img width="470" alt="screenshot 2018-09-27 at 19 32 28" src="https://user-images.githubusercontent.com/340752/46166887-2e222600-c28c-11e8-8bba-6827a026340d.png">

Not sure if this is the best implementation, but it was the best i could come up with.

Thanks