### PR TITLE
Removed overflow:scroll, as they show scroll bars when not needed

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -66,8 +66,6 @@
 }
 
 .stats {
-    overflow: scroll;
-
     .stat {
         border-right-style: solid;
         border-right-width: 1px;


### PR DESCRIPTION
Currently the property causes scrollbars to be always visible in Chrome, Firefox and Edge, as shown in below screenshot:

![before](https://user-images.githubusercontent.com/913981/47255877-53fbae80-d477-11e8-8faf-29f565ad6e60.png)

After this commit:
![after](https://user-images.githubusercontent.com/913981/47255886-6a096f00-d477-11e8-9747-b3b8849c9483.png)
