### PR TITLE
Call a potential getReadableKey method instead of getKey

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -26,7 +26,7 @@ class Tags
         }
 
         return static::modelsFor(static::targetsFor($job))->map(function ($model) {
-            return get_class($model).':'.$model->getKey();
+            return get_class($model).':'.(method_exists($model, 'getReadableKey') ? $model->getReadableKey() : $model->getKey());
         })->all();
     }
 


### PR DESCRIPTION
If the key for your eloquent model is binary, such as when using spatie/laravel-binary-uuid , then horizon will fail when it attempts to generate the tags.  You could use the manual tags feature; however, this functionality won't work if you're using broadcast notifications (since we cannot set tags explicitly on the related BroadcastNotificationCreated job)

My suggestion is to have the Tags system of horizon look for an optional getReadableKey method. If it exists, it will utilize the return value of it instead of the raw value of getKey, which in this case would be a binary value and would fail serialization attempts.

This PR provides a solution for https://github.com/laravel/horizon/issues/264