### PR TITLE
[1.0] Make wait optional in horizon termination

### DIFF
--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -17,7 +17,8 @@ class TerminateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:terminate';
+    protected $signature = 'horizon:terminate
+                            {--wait : Horizon supervisors should wait for their workers to terminate}';
 
     /**
      * The console command description.
@@ -33,6 +34,8 @@ class TerminateCommand extends Command
      */
     public function handle()
     {
+        $this->laravel['cache']->forever('horizon:terminate:wait', $this->option('wait'));
+
         $masters = app(MasterSupervisorRepository::class)->all();
 
         $masters = collect($masters)->filter(function ($master) {

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -31,4 +31,16 @@ class WorkCommand extends BaseWorkCommand
      * @var bool
      */
     protected $hidden = true;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        ignore_user_abort(true);
+
+        return parent::handle();
+    }
 }

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -4,6 +4,7 @@ namespace Laravel\Horizon;
 
 use Closure;
 use Exception;
+use Illuminate\Support\Facades\Cache;
 use Throwable;
 use Cake\Chronos\Chronos;
 use Illuminate\Support\Str;
@@ -183,6 +184,8 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
 
             sleep(1);
         }
+
+        app('cache')->forget('horizon:terminate:wait');
 
         $this->exit($status);
     }

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -5,7 +5,6 @@ namespace Laravel\Horizon;
 use Closure;
 use Countable;
 use Cake\Chronos\Chronos;
-use Symfony\Component\Process\Process;
 
 class ProcessPool implements Countable
 {
@@ -175,7 +174,7 @@ class ProcessPool implements Countable
      */
     protected function createProcess()
     {
-        return new WorkerProcess((new Process(
+        return new WorkerProcess((new BackgroundProcess(
             $this->options->toWorkerCommand(), $this->options->directory)
         )->setTimeout(null)->disableOutput());
     }

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -225,11 +225,23 @@ class Supervisor implements Pausable, Restartable, Terminable
             });
         });
 
-        while ($this->processPools->map->runningProcesses()->collapse()->count()) {
-            sleep(1);
+        if ($this->shouldWait()) {
+            while ($this->processPools->map->runningProcesses()->collapse()->count()) {
+                sleep(1);
+            }
         }
 
         $this->exit($status);
+    }
+
+    /**
+     * Check if the supervisor should wait for all its workers to terminate.
+     *
+     * @return bool
+     */
+    protected function shouldWait()
+    {
+        return app('cache')->get('horizon:terminate:wait');
     }
 
     /**


### PR DESCRIPTION
Regarding #400 this PR is #402 plus making wait optional. As I mentioned in #402 wait option can be used if:
1. The server has not enough memory to run a new instance of horizon with the presence of workers of a previous horizon.
2. An application must be sure that there is no more than one worker on a queue.

I have this in production as well as local. It seems to be fine and my experience is that the deployment is now much smoother. So @taylorotwell I think it is OK to either merge this or revert #404.
Thanks.