### PR TITLE
Allow horizon to use all the width

### DIFF
--- a/resources/assets/js/layouts/MainLayout.vue
+++ b/resources/assets/js/layouts/MainLayout.vue
@@ -8,7 +8,7 @@
 </script>
 
 <template>
-    <div class="container">
+    <div class="container-fluid">
         <div id="mainHeader" class="pt-4 pb-4">
             <div class="row">
                 <div class="col">


### PR DESCRIPTION
This little change allows horizon to gain advantage of the entire browser width and being consistent with other layout~~s~~ such as ~~Telescope and~~ Nova