### PR TITLE
[1.0] update Bootstrap to stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "axios": "^0.15.3",
-        "bootstrap": "^4.0.0-beta.2",
+        "bootstrap": "^4.0.0",
         "chart.js": "^2.5.0",
         "jquery": "^3.1.0",
         "less": "^3.0.0-alpha.3",


### PR DESCRIPTION
looking through the changelogs and the source code, it doesn't appear there were any breaking changes that affect this package.

http://getbootstrap.com/docs/4.1/migration/#beta-3-changes
http://getbootstrap.com/docs/4.1/migration/#stable-changes

both `npm run dev` and `npm run prod` still compile successfully.

good to get us on stable, and 4.2 will have some good container upgrades to help us take better advantage of screen real estate.