### PR TITLE
[2.0] Ability to make authorization by gate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "ext-pcntl": "*",
         "ext-posix": "*",
         "cakephp/chronos": "^1.0",
+        "illuminate/auth": "~5.5",
         "illuminate/contracts": "~5.5",
         "illuminate/queue": "~5.5",
         "illuminate/support": "~5.5",

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon;
 
 use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -23,6 +24,20 @@ class HorizonServiceProvider extends ServiceProvider
         $this->registerRoutes();
         $this->registerResources();
         $this->defineAssetPublishing();
+        $this->authorization();
+    }
+
+    /**
+     * Configure the Telescope authorization services.
+     *
+     * @return void
+     */
+    protected function authorization()
+    {
+        Horizon::auth(function ($request) {
+            return app()->environment('local') ||
+                Gate::check('viewHorizon', [$request->user()]);
+        });
     }
 
     /**

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -10,6 +10,10 @@ class AuthTest extends IntegrationTest
 {
     public function test_authentication_callback_works()
     {
+        Horizon::auth(function () {
+            return true;
+        });
+
         $this->assertTrue(Horizon::check('taylor'));
 
         Horizon::auth(function ($request) {


### PR DESCRIPTION
Provide ability to **Horizon** dashboard access by gate. Like it possible in **Nova** and **Telescope**.
```php
Gate::define('viewHorizon', function ($user) {
    return true;
});
```