### PR TITLE
[1.0] isolate tests

### DIFF
--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -10,7 +10,7 @@ class AuthTest extends IntegrationTest
 {
     public function test_authentication_callback_works()
     {
-        $this->assertTrue(Horizon::check('taylor'));
+        $this->assertFalse(Horizon::check('taylor'));
 
         Horizon::auth(function ($request) {
             return $request === 'taylor';

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -295,7 +295,9 @@ class SupervisorTest extends IntegrationTest
         $process->terminate();
         usleep(500 * 1000);
 
-        $this->assertFalse($process->isRunning());
+        retry(10, function () use ($process) {
+            $this->assertFalse($process->isRunning());
+        }, 1000);
     }
 
     public function test_supervisor_can_prune_terminating_processes_and_return_total_process_count()

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Tests;
 
+use Laravel\Horizon\Horizon;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Facades\Redis;
@@ -34,6 +35,7 @@ abstract class IntegrationTest extends TestCase
         Redis::flushall();
         WorkerCommandString::reset();
         SupervisorCommandString::reset();
+        Horizon::$authUsing = null;
 
         parent::tearDown();
     }


### PR DESCRIPTION
1. Make tests independent of each other by `Horizon::$authUsing = null;`
2. retry assertions that need "some" time to be passed, just to make sure travis doesn't give false positive:
```
1) Laravel\Horizon\Tests\Feature\SupervisorTest::test_supervisor_processes_can_be_terminated
Failed asserting that true is false.
```