### PR TITLE
[1.0] fast_termination config and --wait option

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -61,6 +61,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fast Termination
+    |--------------------------------------------------------------------------
+    |
+    | If this option is set horizon:terminate command don't wait for all the
+    | workers to terminate unless --wait option is provided. Fast termination
+    | minimizes the deployment delay on the queued jobs by letting a new
+    | instance of horizon gets started while the workers of a previously
+    | terminated horizon are still working on their last job.
+    |
+    */
+
+    'fast_termination' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Queue Worker Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -17,7 +17,8 @@ class TerminateCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:terminate';
+    protected $signature = 'horizon:terminate
+                            {--wait : Horizon supervisors should wait for their workers to terminate}';
 
     /**
      * The console command description.
@@ -33,6 +34,10 @@ class TerminateCommand extends Command
      */
     public function handle()
     {
+        if (config('horizon.fast_termination')) {
+            $this->laravel['cache']->forever('horizon:terminate:wait', $this->option('wait'));
+        }
+
         $masters = app(MasterSupervisorRepository::class)->all();
 
         $masters = collect($masters)->filter(function ($master) {

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -31,4 +31,18 @@ class WorkCommand extends BaseWorkCommand
      * @var bool
      */
     protected $hidden = true;
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (config('horizon.fast_termination')) {
+            ignore_user_abort(true);
+        }
+
+        return parent::handle();
+    }
 }

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -184,6 +184,10 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
             sleep(1);
         }
 
+        if (config('horizon.fast_termination')) {
+            app('cache')->forget('horizon:terminate:wait');
+        }
+
         $this->exit($status);
     }
 

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -175,7 +175,9 @@ class ProcessPool implements Countable
      */
     protected function createProcess()
     {
-        return new WorkerProcess((new Process(
+        $class = config('horizon.fast_termination') ? BackgroundProcess::class : Process::class;
+
+        return new WorkerProcess((new $class(
             $this->options->toWorkerCommand(), $this->options->directory)
         )->setTimeout(null)->disableOutput());
     }

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -225,11 +225,23 @@ class Supervisor implements Pausable, Restartable, Terminable
             });
         });
 
-        while ($this->processPools->map->runningProcesses()->collapse()->count()) {
-            sleep(1);
+        if ($this->shouldWait()) {
+            while ($this->processPools->map->runningProcesses()->collapse()->count()) {
+                sleep(1);
+            }
         }
 
         $this->exit($status);
+    }
+
+    /**
+     * Check if the supervisor should wait for all its workers to terminate.
+     *
+     * @return bool
+     */
+    protected function shouldWait()
+    {
+        return ! config('horizon.fast_termination') || app('cache')->get('horizon:terminate:wait');
     }
 
     /**


### PR DESCRIPTION
Reopening #406 to fix #400.

Installations of horizon don't see the change unless they opt-in by setting `'fast_termination' => true` in their horizon config file. Maybe in 2.0 release the default can be set to true.

After enabling fast_termination config, the previous behaviour can still be selected by `--wait` option in horizon:terminate command. I think by these settings its better to have `--wait` instead of `--dont-wait`.