### PR TITLE
[1.0] pending signals

### DIFF
--- a/src/ListenForSignals.php
+++ b/src/ListenForSignals.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Laravel\Horizon;
+
+trait ListenForSignals
+{
+    /**
+     * The pending signals.
+     *
+     * @var array
+     */
+    protected $pendingSignals = [];
+
+    /**
+     * Listen for incoming process signals.
+     *
+     * @return void
+     */
+    protected function listenForSignals()
+    {
+        pcntl_async_signals(true);
+
+        pcntl_signal(SIGTERM, function () {
+            $this->pendingSignals['terminate'] = 'terminate';
+        });
+
+        pcntl_signal(SIGUSR1, function () {
+            $this->pendingSignals['restart'] = 'restart';
+        });
+
+        pcntl_signal(SIGUSR2, function () {
+            $this->pendingSignals['pause'] = 'pause';
+        });
+
+        pcntl_signal(SIGCONT, function () {
+            $this->pendingSignals['continue'] = 'continue';
+        });
+    }
+
+    /**
+     * Process the pending signals.
+     *
+     * @return void
+     */
+    protected function processPendingSignals()
+    {
+        while ($this->pendingSignals) {
+            $signal = array_first($this->pendingSignals);
+            $this->$signal();
+            unset($this->pendingSignals[$signal]);
+        }
+    }
+}


### PR DESCRIPTION
The main logic of handling each signal should be pending because chances are a signal arrives when a new child is created but hasn't been saved in the parent, therefore the parent cannot propagate the signal to it's unknown child.
I tried to make sure a signal is not pushed into `pendingSignals` twice before being processed, which is the case in the current behaviour as well.