### PR TITLE
Don't display status icon until stats.status is initialised

### DIFF
--- a/resources/assets/js/pages/Dashboard.vue
+++ b/resources/assets/js/pages/Dashboard.vue
@@ -161,7 +161,7 @@
                                 <h3 class="stat-meta">&nbsp;</h3>
 
                                 <div class="d-flex align-items-center">
-                                    <status :active="stats.status == 'running'" :pending="stats.status == 'paused'" class="mr-2"/>
+                                    <status v-if="stats.status" :active="stats.status == 'running'" :pending="stats.status == 'paused'" class="mr-2"/>
                                     <span class="stat-value">
                                       {{ {running: 'Active', paused: 'Paused', inactive:'Inactive'}[stats.status] }}
                                     </span>


### PR DESCRIPTION
When you first load horizon the status box has a red x until the status has been retrieved. 

Too many times when loading horizon to look into an error email I have received, I've had a split second panic when I see the red before it quickly changes. :sweat_smile:

This PR is simply to hide the icon until we actually know the status.

**Before:**
![old](https://user-images.githubusercontent.com/9828591/47745303-43b7b080-dc7b-11e8-98be-8db37ad01c60.gif)


**After:**
![new](https://user-images.githubusercontent.com/9828591/47745318-487c6480-dc7b-11e8-9282-f6a45ede1f04.gif)
