### PR TITLE
[2.0] Add flush command

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -3,10 +3,13 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 
 class FlushCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
      *
@@ -28,6 +31,10 @@ class FlushCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $redis = app(RedisFactory::class);
 
         $redis->connection('horizon')->flushdb();

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+
+class FlushCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:flush';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flush Horizon queues';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $redis = app(RedisFactory::class);
+
+        $redis->connection('horizon')->flushdb();
+
+        return $this->info('Horizon queues flushed!');
+    }
+}


### PR DESCRIPTION
At the moment it is not possible to easily flush all the jobs in Horizon, this PR provides this functionality by providing following command:

```
php artisan horizon:flush
```

This feature is non-breaking.