### PR TITLE
[2.0] Use router-link on recent jobs's failed jobs link

### DIFF
--- a/resources/assets/js/pages/RecentJobs/Jobs.vue
+++ b/resources/assets/js/pages/RecentJobs/Jobs.vue
@@ -133,9 +133,9 @@
             <tbody>
             <tr v-for="job in jobs">
                 <td>
-                    <a v-if="job.status == 'failed'" :href="'/horizon/failed/'+job.id"
-                       data-toggle="tooltip" :title="job.name">{{ jobBaseName(job.name) }}
-                    </a>
+                    <router-link v-if="job.status === 'failed'" data-toggle="tooltip" :to="{ name: 'failed.detail', params: { jobId: job.id }}" :title="job.name">
+                        {{ jobBaseName(job.name) }}
+                    </router-link>
                     <span data-toggle="tooltip" :title="job.name" v-else>{{ jobBaseName(job.name) }}</span>
                 </td>
                 <td>{{ job.queue }}</td>


### PR DESCRIPTION
So, because of some limitations on my production server I had to use this horizon.uri config option and got it working after some tweaking.

This PR fixes one link that wasn't using router-link and was not working for me.