### PR TITLE
Add staging into environments

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -123,6 +123,16 @@ return [
             ],
         ],
 
+        'staging' => [
+            'supervisor-1' => [
+                'connection' => 'redis',
+                'queue' => ['default'],
+                'balance' => 'simple',
+                'processes' => 10,
+                'tries' => 3,
+            ],
+        ],
+
         'local' => [
             'supervisor-1' => [
                 'connection' => 'redis',


### PR DESCRIPTION
I almost opened an issue because our sub processes were not being executed because they're in the `staging` environment.

I think that local, staging and production are a common pattern,  and should be exemplified inside the settings file.

Another way is to failback for local (maybe?) or even thown an Exception when the settings for that environment are not found but I think its too agressive.

Anyway, hope thats help!