### PR TITLE
[2.0] Fix storing floats in Redis

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -89,7 +89,7 @@ class JobPayload implements ArrayAccess
         return $this->set([
             'type' => $this->determineType($job),
             'tags' => $this->determineTags($job),
-            'pushedAt' => microtime(true),
+            'pushedAt' => str_replace(',', '.', microtime(true)),
         ]);
     }
 

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -218,7 +218,7 @@ class RedisJobRepository implements JobRepository
         $this->connection()->pipeline(function ($pipe) use ($connection, $queue, $payload) {
             $this->storeJobReferences($pipe, $payload->id());
 
-            $time = microtime(true);
+            $time = str_replace(',', '.', microtime(true));
 
             $pipe->hmset(
                 $payload->id(), [
@@ -261,7 +261,7 @@ class RedisJobRepository implements JobRepository
      */
     public function reserved($connection, $queue, JobPayload $payload)
     {
-        $time = microtime(true);
+        $time = str_replace(',', '.', microtime(true));
 
         $this->connection()->hmset(
             $payload->id(), [
@@ -287,7 +287,7 @@ class RedisJobRepository implements JobRepository
             $payload->id(), [
                 'status' => 'pending',
                 'payload' => $payload->value,
-                'updated_at' => microtime(true),
+                'updated_at' => str_replace(',', '.', microtime(true)),
             ]
         );
     }
@@ -311,7 +311,7 @@ class RedisJobRepository implements JobRepository
                     'name' => $payload->decoded['displayName'],
                     'status' => 'completed',
                     'payload' => $payload->value,
-                    'completed_at' => microtime(true),
+                    'completed_at' => str_replace(',', '.', microtime(true)),
                 ]
             );
 
@@ -335,7 +335,7 @@ class RedisJobRepository implements JobRepository
                     $payload->id(), [
                         'status' => 'pending',
                         'payload' => $payload->value,
-                        'updated_at' => microtime(true),
+                        'updated_at' => str_replace(',', '.', microtime(true)),
                     ]
                 );
             }
@@ -372,7 +372,7 @@ class RedisJobRepository implements JobRepository
     {
         $failed
             ? $pipe->hmset($id, ['status' => 'failed'])
-            : $pipe->hmset($id, ['status' => 'completed', 'completed_at' => microtime(true)]);
+            : $pipe->hmset($id, ['status' => 'completed', 'completed_at' => str_replace(',', '.', microtime(true))]);
 
         $pipe->expireat($id, Chronos::now()->addMinutes($this->recentJobExpires)->getTimestamp());
     }
@@ -501,7 +501,7 @@ class RedisJobRepository implements JobRepository
                     'status' => 'failed',
                     'payload' => $payload->value,
                     'exception' => (string) $exception,
-                    'failed_at' => microtime(true),
+                    'failed_at' => str_replace(',', '.', microtime(true)),
                 ]
             );
 

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -28,4 +28,19 @@ class RedisJobRepositoryTest extends IntegrationTest
 
         $this->assertNull($repository->findFailed(1));
     }
+
+    public function test_it_saves_microseconds_as_a_float_and_disregards_the_locale()
+    {
+        setlocale(LC_NUMERIC, 'fr_FR');
+
+        $repository = $this->app->make(JobRepository::class);
+        $payload = new JobPayload(json_encode(['id' => 1, 'displayName' => 'foo']));
+
+        $repository->pushed('redis', 'default', $payload);
+        $repository->reserved('redis', 'default', $payload);
+
+        $result = $repository->getRecent()[0];
+
+        $this->assertNotContains(',', $result->reserved_at);
+    }
 }


### PR DESCRIPTION
Redis will only accept floats with a point decimal sign and not a comma decimal sign. The sign is determined by the system's locale setting (LC_NUMERIC) and if set to one that prefers a comma will cause Redis to store the float as a string instead of a comma.

This change will make sure that before a float is stored it's always made sure that any comma is changed to a point. This was already done in some other parts of the system.

Fixes https://github.com/laravel/horizon/issues/371