### PR TITLE
[2.0] Fix findFailed method

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -469,7 +469,13 @@ class RedisJobRepository implements JobRepository
             $id, $this->keys
         );
 
-        return is_array($attributes) && $attributes[0] !== null ? (object) array_combine($this->keys, $attributes) : null;
+        $job = is_array($attributes) && $attributes[0] !== null ? (object) array_combine($this->keys, $attributes) : null;
+
+        if ($job && $job->status !== 'failed') {
+            return null;
+        }
+
+        return $job;
     }
 
     /**

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Exception;
+use Laravel\Horizon\JobPayload;
+use Laravel\Horizon\Tests\IntegrationTest;
+use Laravel\Horizon\Contracts\JobRepository;
+
+class RedisJobRepositoryTest extends IntegrationTest
+{
+    public function test_it_can_find_a_failed_job_by_its_id()
+    {
+        $repository = $this->app->make(JobRepository::class);
+        $payload = new JobPayload(json_encode(['id' => 1, 'displayName' => 'foo']));
+
+        $repository->failed(new Exception('Failed Job'), 'redis', 'default', $payload);
+
+        $this->assertEquals(1, $repository->findFailed(1)->id);
+    }
+
+    public function test_it_will_not_find_a_failed_job_if_the_job_has_not_failed()
+    {
+        $repository = $this->app->make(JobRepository::class);
+        $payload = new JobPayload(json_encode(['id' => 1, 'displayName' => 'foo']));
+
+        $repository->pushed('redis', 'default', $payload);
+
+        $this->assertNull($repository->findFailed(1));
+    }
+}


### PR DESCRIPTION
The findFailed method was returning all kind of results, not just failed jobs

Fixes https://github.com/laravel/horizon/issues/340