### PR TITLE
Let user choose custom env

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -48,7 +48,7 @@ class HorizonCommand extends Command
         });
 
         ProvisioningPlan::get(MasterSupervisor::name())->deploy(
-            config('app.env')
+            config('horizon.env') ?? config('app.env')
         );
 
         $this->info('Horizon started successfully.');


### PR DESCRIPTION
I have 2 Horizon servers which handle different `supervisor`. For example, currently I have to use like the following and I need to update my `.env` file `environment` as `workerOne` and `workerTwo` separately. 

```php
'workerOne' => [
    'supervisor-1' => [
        'connection' => 'redis',
        'queue' => ['default'],
        'balance' => 'simple',
        'processes' => 10,
        'tries' => 3,
    ],
]
'workerTwo' => [
    'supervisor-2' => [
        'connection' => 'redis',
        'queue' => ['default'],
        'balance' => 'simple',
        'processes' => 10,
        'tries' => 3,
    ],
]
```

What happened was some worker check `.env` environment as well. So, I got environment sharing problems. Can we use separately? If that's open for PR. I would submit.