### PR TITLE
[2.0] Expire monitored jobs

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -70,6 +70,7 @@ return [
     'trim' => [
         'recent' => 60,
         'failed' => 10080,
+        'monitored' => 10080,
     ],
 
     /*

--- a/src/Contracts/JobRepository.php
+++ b/src/Contracts/JobRepository.php
@@ -156,6 +156,13 @@ interface JobRepository
     public function trimFailedJobs();
 
     /**
+     * Trim the monitored job list.
+     *
+     * @return void
+     */
+    public function trimMonitoredJobs();
+
+    /**
      * Find a failed job by ID.
      *
      * @param  string  $id

--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -45,6 +45,7 @@ trait EventMap
         Events\MasterSupervisorLooped::class => [
             Listeners\TrimRecentJobs::class,
             Listeners\TrimFailedJobs::class,
+            Listeners\TrimMonitoredJobs::class,
             Listeners\ExpireSupervisors::class,
             Listeners\MonitorMasterSupervisorMemory::class,
         ],

--- a/src/Listeners/TrimMonitoredJobs.php
+++ b/src/Listeners/TrimMonitoredJobs.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Horizon\Listeners;
+
+use Cake\Chronos\Chronos;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\Events\MasterSupervisorLooped;
+
+class TrimMonitoredJobs
+{
+    /**
+     * The last time the monitored jobs were trimmed.
+     *
+     * @var \Cake\Chronos\Chronos
+     */
+    public $lastTrimmed;
+
+    /**
+     * How many minutes to wait in between each trim.
+     *
+     * @var int
+     */
+    public $frequency = 1440;
+
+    /**
+     * Handle the event.
+     *
+     * @param  \Laravel\Horizon\Events\MasterSupervisorLooped  $event
+     * @return void
+     */
+    public function handle(MasterSupervisorLooped $event)
+    {
+        if (! isset($this->lastTrimmed)) {
+            $this->frequency = max(1, intdiv(
+                config('horizon.trim.monitored', 10080), 12
+            ));
+
+            $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
+        }
+
+        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+            app(JobRepository::class)->trimMonitoredJobs();
+
+            $this->lastTrimmed = Chronos::now();
+        }
+    }
+}

--- a/src/ServiceBindings.php
+++ b/src/ServiceBindings.php
@@ -15,6 +15,7 @@ trait ServiceBindings
         Contracts\HorizonCommandQueue::class => RedisHorizonCommandQueue::class,
         Listeners\TrimRecentJobs::class,
         Listeners\TrimFailedJobs::class,
+        Listeners\TrimMonitoredJobs::class,
         Lock::class,
         Stopwatch::class,
 

--- a/tests/Feature/MonitoringTest.php
+++ b/tests/Feature/MonitoringTest.php
@@ -53,7 +53,7 @@ class MonitoringTest extends IntegrationTest
         $id = Queue::push(new Jobs\BasicJob);
         $this->work();
         $this->assertEquals(1, $this->monitoredJobs('first'));
-        $this->assertEquals(-1, Redis::connection('horizon')->ttl($id));
+        $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($id));
     }
 
     public function test_completed_jobs_are_removed_from_database_when_their_tag_is_no_longer_monitored()

--- a/tests/Feature/TrimMonitoredJobsTest.php
+++ b/tests/Feature/TrimMonitoredJobsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Mockery;
+use Cake\Chronos\Chronos;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\Tests\IntegrationTest;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\Listeners\TrimMonitoredJobs;
+use Laravel\Horizon\Events\MasterSupervisorLooped;
+
+class TrimMonitoredJobsTest extends IntegrationTest
+{
+    public function test_trimmer_has_a_cooldown_period()
+    {
+        $trim = new TrimMonitoredJobs;
+
+        $repository = Mockery::mock(JobRepository::class);
+        $repository->shouldReceive('trimMonitoredJobs')->twice();
+        $this->app->instance(JobRepository::class, $repository);
+
+        // Should not be called first time since date is initialized...
+        $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
+
+        Chronos::setTestNow(Chronos::now()->addMinutes(1600));
+
+        // Should only be called twice...
+        $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
+        $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
+        $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
+
+        Chronos::setTestNow();
+    }
+}


### PR DESCRIPTION
This commit fixes the problem where completed jobs which were monitored by a tag are stored indefinitely and end up filling up the DB and cause the system to run out of memory. The main problem at hand was that these jobs were never cleaned up. By adding the max TTL and TrimMonitoredJobs listener the monitored jobs will be cleaned up after the given amount of time. By default this is set to 7 days. The listener itself will run one time each day.

This might be breaking because of the new method on the `JobRepository` interface. If you want me to send this to master instead please let me know. This would at the very least require a point release.

Fixes https://github.com/laravel/horizon/issues/333 https://github.com/laravel/horizon/issues/271