### PR TITLE
[2.0] Display error when posix_kill fails

### DIFF
--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -39,7 +39,9 @@ class ContinueCommand extends Command
         foreach (array_pluck($masters, 'pid') as $processId) {
             $this->info("Sending CONT Signal To Process: {$processId}");
 
-            posix_kill($processId, SIGCONT);
+            if (! posix_kill($processId, SIGCONT)) {
+                $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+            }
         }
     }
 }

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -39,7 +39,9 @@ class PauseCommand extends Command
         foreach (array_pluck($masters, 'pid') as $processId) {
             $this->info("Sending USR2 Signal To Process: {$processId}");
 
-            posix_kill($processId, SIGUSR2);
+            if (! posix_kill($processId, SIGUSR2)) {
+                $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+            }
         }
     }
 }

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -88,8 +88,8 @@ class PurgeCommand extends Command
         foreach ($orphans as $processId) {
             $this->info("Observed Orphan: {$processId}");
 
-            if (function_exists('posix_kill')) {
-                posix_kill($processId, SIGTERM);
+            if (! posix_kill($processId, SIGTERM)) {
+                $this->error("Failed to kill process for Orphan: {$processId} (".posix_strerror(posix_get_last_error()).')');
             }
         }
     }

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -50,7 +50,9 @@ class TerminateCommand extends Command
         foreach (array_pluck($masters, 'pid') as $processId) {
             $this->info("Sending TERM Signal To Process: {$processId}");
 
-            posix_kill($processId, SIGTERM);
+            if (! posix_kill($processId, SIGTERM)) {
+                $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+            }
         }
 
         $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());


### PR DESCRIPTION
At the moment when the posix_kill call for various commands fails the developer is left in the dark as to why this might be. By displaying the error it could give them an indication where to look for (file permissions, etc).