### PR TITLE
[2.0] Inject dependencies with handle method in commands

### DIFF
--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -26,13 +26,12 @@ class ContinueCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle()
+    public function handle(MasterSupervisorRepository $masters)
     {
-        $masters = app(MasterSupervisorRepository::class)->all();
-
-        $masters = collect($masters)->filter(function ($master) {
+        $masters = collect($masters->all())->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();
 

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -33,13 +33,12 @@ class HorizonCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle()
+    public function handle(MasterSupervisorRepository $masters)
     {
-        $repository = app(MasterSupervisorRepository::class);
-
-        if ($repository->find(MasterSupervisor::name())) {
+        if ($masters->find(MasterSupervisor::name())) {
             return $this->comment('A master supervisor is already running on this machine.');
         }
 

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -24,13 +24,12 @@ class ListCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle()
+    public function handle(MasterSupervisorRepository $masters)
     {
-        $repository = app(MasterSupervisorRepository::class);
-
-        $masters = $repository->all();
+        $masters = $masters->all();
 
         if (empty($masters)) {
             return $this->info('No machines are running.');

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -26,13 +26,12 @@ class PauseCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle()
+    public function handle(MasterSupervisorRepository $masters)
     {
-        $masters = app(MasterSupervisorRepository::class)->all();
-
-        $masters = collect($masters)->filter(function ($master) {
+        $masters = collect($masters->all())->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();
 

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -27,20 +27,51 @@ class PurgeCommand extends Command
     protected $description = 'Terminate any rogue Horizon processes';
 
     /**
+     * @var \Laravel\Horizon\Contracts\SupervisorRepository
+     */
+    private $supervisors;
+
+    /**
+     * @var \Laravel\Horizon\Contracts\ProcessRepository
+     */
+    private $processes;
+
+    /**
+     * @var \Laravel\Horizon\ProcessInspector
+     */
+    private $inspector;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
+     * @param  \Laravel\Horizon\Contracts\ProcessRepository  $processes
+     * @param  \Laravel\Horizon\ProcessInspector  $inspector
+     * @return void
+     */
+    public function __construct(
+        SupervisorRepository $supervisors,
+        ProcessRepository $processes,
+        ProcessInspector $inspector
+    ) {
+        parent::__construct();
+
+        $this->supervisors = $supervisors;
+        $this->processes = $processes;
+        $this->inspector = $inspector;
+    }
+
+    /**
      * Execute the console command.
      *
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
-     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
-     * @param  \Laravel\Horizon\Contracts\ProcessRepository  $processes
      * @return void
      */
-    public function handle(MasterSupervisorRepository $masters,
-                           SupervisorRepository $supervisors,
-                           ProcessRepository $processes)
+    public function handle(MasterSupervisorRepository $masters)
     {
         foreach ($masters->names() as $master) {
             if (Str::startsWith($master, MasterSupervisor::basename())) {
-                $this->purge($master, $supervisors, $processes);
+                $this->purge($master);
             }
         }
     }
@@ -49,26 +80,22 @@ class PurgeCommand extends Command
      * Purge any orphan processes.
      *
      * @param  string  $master
-     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
-     * @param  \Laravel\Horizon\Contracts\ProcessRepository  $processes
      * @return void
      */
-    public function purge($master,
-                          SupervisorRepository $supervisors,
-                          ProcessRepository $processes)
+    public function purge($master)
     {
-        $this->recordOrphans($master, $processes);
+        $this->recordOrphans($master);
 
-        $expired = $processes->orphanedFor(
-            $master, $supervisors->longestActiveTimeout()
+        $expired = $this->processes->orphanedFor(
+            $master, $this->supervisors->longestActiveTimeout()
         );
 
-        collect($expired)->each(function ($processId) use ($master, $processes) {
+        collect($expired)->each(function ($processId) use ($master) {
             $this->comment("Killing Process: {$processId}");
 
             exec("kill {$processId}");
 
-            $processes->forgetOrphans($master, [$processId]);
+            $this->processes->forgetOrphans($master, [$processId]);
         });
     }
 
@@ -76,13 +103,12 @@ class PurgeCommand extends Command
      * Record the orphaned Horizon processes.
      *
      * @param  string  $master
-     * @param  \Laravel\Horizon\Contracts\ProcessRepository  $processes
      * @return void
      */
-    protected function recordOrphans($master, ProcessRepository $processes)
+    protected function recordOrphans($master)
     {
-        $processes->orphaned(
-            $master, $orphans = app(ProcessInspector::class)->orphaned()
+        $this->processes->orphaned(
+            $master, $orphans = $this->inspector->orphaned()
         );
 
         foreach ($orphans as $processId) {

--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -25,12 +25,14 @@ class SnapshotCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Lock  $lock
+     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
      * @return void
      */
-    public function handle()
+    public function handle(Lock $lock, MetricsRepository $metrics)
     {
-        if (app(Lock::class)->get('metrics:snapshot', 300)) {
-            app(MetricsRepository::class)->snapshot();
+        if ($lock->get('metrics:snapshot', 300)) {
+            $metrics->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');
         }

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -46,11 +46,12 @@ class SupervisorCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @param  \Laravel\Horizon\SupervisorFactory  $factory
+     * @return int
      */
-    public function handle()
+    public function handle(SupervisorFactory $factory)
     {
-        $supervisor = app(SupervisorFactory::class)->make(
+        $supervisor = $factory->make(
             $this->supervisorOptions()
         );
 

--- a/src/Console/SupervisorsCommand.php
+++ b/src/Console/SupervisorsCommand.php
@@ -24,13 +24,12 @@ class SupervisorsCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
      * @return void
      */
-    public function handle()
+    public function handle(SupervisorRepository $supervisors)
     {
-        $repository = app(SupervisorRepository::class);
-
-        $supervisors = $repository->all();
+        $supervisors = $supervisors->all();
 
         if (empty($supervisors)) {
             return $this->info('No supervisors are running.');

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -31,19 +31,19 @@ class TerminateCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Contracts\Cache\Factory $cache
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle()
+    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters)
     {
         if (config('horizon.fast_termination')) {
-            app(CacheFactory::class)->forever(
+            $cache->forever(
                 'horizon:terminate:wait', $this->option('wait')
             );
         }
 
-        $masters = app(MasterSupervisorRepository::class)->all();
-
-        $masters = collect($masters)->filter(function ($master) {
+        $masters = collect($masters->all())->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();
 

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -43,6 +43,6 @@ class WorkCommand extends BaseWorkCommand
             ignore_user_abort(true);
         }
 
-        return parent::handle();
+        parent::handle();
     }
 }

--- a/tests/Feature/Fixtures/FakeSupervisorFactory.php
+++ b/tests/Feature/Fixtures/FakeSupervisorFactory.php
@@ -2,9 +2,10 @@
 
 namespace Laravel\Horizon\Tests\Feature\Fixtures;
 
+use Laravel\Horizon\SupervisorFactory;
 use Laravel\Horizon\Tests\Feature\Fakes\SupervisorWithFakeMonitor;
 
-class FakeSupervisorFactory
+class FakeSupervisorFactory extends SupervisorFactory
 {
     public $supervisor;
 


### PR DESCRIPTION
Now that commands can make use of method injection on their handle method we can use this instead of app calls everywhere. This gives better type-hinting and overall cleans up the internals quite a bit. The `PurgeCommand` was already making use of this and this PR applies the same convention to the other commands.