### PR TITLE
[2.0] Upgrades Laravel Mix to v4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "devDependencies": {
         "cross-env": "^5.0.1",
         "es6-promise": "^4.0.5",
-        "laravel-mix": "^1.4.2"
+        "laravel-mix": "^4.0.14",
+        "resolve-url-loader": "2.3.1",
+        "sass": "^1.16.1",
+        "sass-loader": "7.*",
+        "vue-template-compiler": "^2.5.21"
     }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -22,7 +22,7 @@ Vue.prototype.$http = axios.create();
 
 window.Bus = new Vue({name: 'Bus'});
 
-Vue.component('loader', require('./components/Status/Loader.vue'));
+Vue.component('loader', require('./components/Status/Loader.vue').default);
 
 Vue.config.errorHandler = function (err, vm, info) {
     console.error(err);

--- a/resources/assets/js/router.js
+++ b/resources/assets/js/router.js
@@ -13,33 +13,33 @@ export default new Router({
         },
         {
             path: '/dashboard',
-            component: require('./pages/Dashboard.vue'),
+            component: require('./pages/Dashboard.vue').default,
         },
         {
             path: '/monitoring',
-            component: require('./pages/Monitoring/Index.vue'),
+            component: require('./pages/Monitoring/Index.vue').default,
         },
         {
             path: '/monitoring/:tag',
-            component: require('./pages/Monitoring/Tag.vue'),
+            component: require('./pages/Monitoring/Tag.vue').default,
             children: [
                 {
                     path: '/',
                     name: 'monitoring.detail.index',
-                    component: require('./pages/Monitoring/Jobs.vue'),
+                    component: require('./pages/Monitoring/Jobs.vue').default,
                     props: {type: 'index'}
                 },
                 {
                     path: 'failed',
                     name: 'monitoring.detail.failed',
-                    component: require('./pages/Monitoring/Jobs.vue'),
+                    component: require('./pages/Monitoring/Jobs.vue').default,
                     props: {type: 'failed'}
                 },
             ],
         },
         {
             path: '/metrics',
-            component: require('./pages/Metrics/Index.vue'),
+            component: require('./pages/Metrics/Index.vue').default,
             children: [
                 {
                     path: '/',
@@ -47,33 +47,33 @@ export default new Router({
                 },
                 {
                     path: 'jobs',
-                    component: require('./pages/Metrics/Jobs.vue')
+                    component: require('./pages/Metrics/Jobs.vue').default
                 },
                 {
                     path: 'queues',
-                    component: require('./pages/Metrics/Queues.vue')
+                    component: require('./pages/Metrics/Queues.vue').default
                 },
             ],
         },
         {
             path: '/metrics/:type/:slug',
             name: 'metrics.detail',
-            component: require('./pages/Metrics/Metric.vue'),
+            component: require('./pages/Metrics/Metric.vue').default,
             props: true,
         },
         {
             path: '/recent-jobs',
             name: 'recent-jobs.detail',
-            component: require('./pages/RecentJobs/Index.vue'),
+            component: require('./pages/RecentJobs/Index.vue').default,
         },
         {
             path: '/failed',
-            component: require('./pages/Failed/Index.vue'),
+            component: require('./pages/Failed/Index.vue').default,
         },
         {
             path: '/failed/:jobId',
             name: 'failed.detail',
-            component: require('./pages/Failed/Job.vue'),
+            component: require('./pages/Failed/Job.vue').default,
             props: true,
         },
     ],

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,8 +14,8 @@ const webpack = require('webpack');
 
 mix
     .options({
-        uglify: {
-            uglifyOptions: {
+        terser: {
+            terserOptions: {
                 compress: {
                     drop_console: true,
                 }


### PR DESCRIPTION
Laravel Mix v1.4.2 is outdated and has several dependencies with vulnerabilities.

This PR upgrades Laravel Mix to the latest version 4.0.14.