### PR TITLE
[2.0] Refactor handle() methods.

### DIFF
--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -31,16 +31,17 @@ class ContinueCommand extends Command
      */
     public function handle(MasterSupervisorRepository $masters)
     {
-        $masters = collect($masters->all())->filter(function ($master) {
-            return Str::startsWith($master->name, MasterSupervisor::basename());
-        })->all();
+        collect($masters->all())
+            ->filter(function ($master) {
+                return Str::startsWith($master->name, MasterSupervisor::basename());
+            })
+            ->pluck('pid')
+            ->each(function ($processId) {
+                $this->info("Sending CONT Signal To Process: {$processId}");
 
-        foreach (array_pluck($masters, 'pid') as $processId) {
-            $this->info("Sending CONT Signal To Process: {$processId}");
-
-            if (! posix_kill($processId, SIGCONT)) {
-                $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
-            }
-        }
+                if (! posix_kill($processId, SIGCONT)) {
+                    $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+                }
+            });
     }
 }


### PR DESCRIPTION
This PR refactors the handle method of the following commands:
- ContinueCommand
- PauseCommand
- TerminateCommand

It removes the temporary `$masters` variable by chaining the methods on the `Collection` class.

This removes the use of  the `array_pluck` helper method as well, which will be deprecated in Laravel 5.8.