### PR TITLE
[2.0] Remove array helpers

### DIFF
--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Laravel\Horizon\MasterSupervisor;
@@ -35,7 +36,7 @@ class ContinueCommand extends Command
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();
 
-        foreach (array_pluck($masters, 'pid') as $processId) {
+        foreach (Arr::pluck($masters, 'pid') as $processId) {
             $this->info("Sending CONT Signal To Process: {$processId}");
 
             if (! posix_kill($processId, SIGCONT)) {

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Laravel\Horizon\MasterSupervisor;
@@ -35,7 +36,7 @@ class PauseCommand extends Command
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();
 
-        foreach (array_pluck($masters, 'pid') as $processId) {
+        foreach (Arr::pluck($masters, 'pid') as $processId) {
             $this->info("Sending USR2 Signal To Process: {$processId}");
 
             if (! posix_kill($processId, SIGUSR2)) {

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Laravel\Horizon\MasterSupervisor;
@@ -47,7 +48,7 @@ class TerminateCommand extends Command
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();
 
-        foreach (array_pluck($masters, 'pid') as $processId) {
+        foreach (Arr::pluck($masters, 'pid') as $processId) {
             $this->info("Sending TERM Signal To Process: {$processId}");
 
             if (! posix_kill($processId, SIGTERM)) {

--- a/src/ProcessInspector.php
+++ b/src/ProcessInspector.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon;
 
+use Illuminate\Support\Arr;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 
@@ -65,7 +66,7 @@ class ProcessInspector
                 return $processes;
             })
             ->merge(
-                array_pluck(app(MasterSupervisorRepository::class)->all(), 'pid')
+                Arr::pluck(app(MasterSupervisorRepository::class)->all(), 'pid')
             )->all();
     }
 }

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -117,7 +117,7 @@ class Tags
             })->collapse()->filter()->all();
         }
 
-        return collect(array_collapse($models))->unique();
+        return collect($models)->collapse()->unique();
     }
 
     /**


### PR DESCRIPTION
All `array_*` helper methods will be deprecated in Laravel 5.8.

This PR removes those helpers.