### PR TITLE
[2.0] Fix jobs per minute over estimation

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -334,9 +334,9 @@ class RedisMetricsRepository implements MetricsRepository
         $lastSnapshotAt = $this->connection()->get('last_snapshot_at')
                     ?: $this->storeSnapshotTimestamp();
 
-        return round(max(
+        return max(
             (Chronos::now()->getTimestamp() - $lastSnapshotAt) / 60, 1
-        ));
+        );
     }
 
     /**


### PR DESCRIPTION
Partially fixes #501 It doesn't fix underestimate during the first minute after each snapshot which is mostly because of the lack of enough data in that period