### PR TITLE
fix count recent/failed jobs; trim more often

### DIFF
--- a/src/Listeners/TrimRecentJobs.php
+++ b/src/Listeners/TrimRecentJobs.php
@@ -20,7 +20,7 @@ class TrimRecentJobs
      *
      * @var int
      */
-    public $frequency = 5;
+    public $frequency = 1;
 
     /**
      * Handle the event.
@@ -31,10 +31,6 @@ class TrimRecentJobs
     public function handle(MasterSupervisorLooped $event)
     {
         if (! isset($this->lastTrimmed)) {
-            $this->frequency = max(1, intdiv(
-                config('horizon.trim.recent', 60), 12
-            ));
-
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -168,7 +168,10 @@ class RedisJobRepository implements JobRepository
      */
     protected function countJobsByType($type)
     {
-        return $this->connection()->zcard($type);
+        $minutes = $type === 'failed_jobs' ? $this->failedJobExpires : $this->recentJobExpires;
+        $score = Chronos::now()->subMinutes($minutes)->getTimestamp() * -1;
+
+        return $this->connection()->zcount($type, '-inf', $score);
     }
 
     /**


### PR DESCRIPTION
Related to #501 
This PR excludes recent jobs before `config('trim.recent')` to make number of recent jobs in horizon panel accurate. 

I also made a change to trim more often, every minute, because trimming time complexity is O(N) with N being the number of trimmed jobs; the higher the value of N the more Redis server blocks all other operations, which might be a trouble for high load uses.


PS: `JobRepository::totalRecent()` and `JobRepository::totalFailed()` functions are not changed because they are not actually used. Maybe they should be deprecated?