### PR TITLE
[2.0] Fix Failed Jobs page showing no results when failed jobs do exist

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -194,7 +194,7 @@ class RedisJobRepository implements JobRepository
             $job = is_array($job) ? array_values($job) : null;
 
             return is_array($job) && $job[0] !== null;
-        }), $indexFrom);
+        })->values(), $indexFrom);
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/laravel/horizon/issues/476, https://github.com/laravel/horizon/issues/458, https://github.com/laravel/horizon/issues/109

I've seen the Failed Jobs section behave like this since the Horizon beta was released.

The Vue component expects its `jobs` prop to be an `Array` but the API endpoint can return an `object` in its JSON body. A filtered PHP associative array needs to be kept as 0-indexed.

https://github.com/laravel/horizon/blob/032959e87c862070fe053f3b01f30bd9e4227e8d/resources/js/pages/Failed/Index.vue#L71-L73

https://github.com/laravel/horizon/issues/476#issuecomment-462529737 has a longer explanation of what I found. I wasn't able to figure out how to recreate the edge case in a PHPUnit test. Do we have an explanation of where this empty payload is coming from when fetching a set of jobs? https://github.com/laravel/horizon/blob/6db1be6a4dde066328d6e2a14acb543435bb837c/src/Repositories/RedisJobRepository.php#L193-L197

Does Redis `ZRANGE` (called in `RedisJobRepository@getJobsByType()`) sometimes return keys that don't exist? [This test attempt](https://github.com/laravel/horizon/compare/2.0...derekmd:fix-failed-jobs-empty-results-test) didn't seem to indicate that.