### PR TITLE
[3.0] Fix deprecated process calls

### DIFF
--- a/src/MasterSupervisorCommands/AddSupervisor.php
+++ b/src/MasterSupervisorCommands/AddSupervisor.php
@@ -38,7 +38,7 @@ class AddSupervisor
     {
         $command = $options->toSupervisorCommand();
 
-        return (new Process($command, $options->directory ?? base_path()))
+        return Process::fromShellCommandline($command, $options->directory ?? base_path())
                     ->setTimeout(null)
                     ->disableOutput();
     }

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -179,8 +179,8 @@ class ProcessPool implements Countable
                     ? BackgroundProcess::class
                     : Process::class;
 
-        return new WorkerProcess((new $class(
-            $this->options->toWorkerCommand(), $this->options->directory)
+        return new WorkerProcess($class::fromShellCommandline(
+            $this->options->toWorkerCommand(), $this->options->directory
         )->setTimeout(null)->disableOutput());
     }
 

--- a/src/SystemProcessCounter.php
+++ b/src/SystemProcessCounter.php
@@ -21,7 +21,7 @@ class SystemProcessCounter
      */
     public function get($name)
     {
-        $process = new Process('exec ps aux | grep '.static::$command, null, ['COLUMNS' => '2000']);
+        $process = Process::fromShellCommandline('exec ps aux | grep '.static::$command, null, ['COLUMNS' => '2000']);
 
         $process->run();
 

--- a/tests/Feature/WorkerProcessTest.php
+++ b/tests/Feature/WorkerProcessTest.php
@@ -16,7 +16,7 @@ class WorkerProcessTest extends IntegrationTest
     {
         Event::fake();
 
-        $process = new Process('exit 1');
+        $process = new Process(['exit', 1]);
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });
@@ -31,7 +31,7 @@ class WorkerProcessTest extends IntegrationTest
     {
         Event::fake();
 
-        $process = new Process('exit 1');
+        $process = new Process(['exit', 1]);
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });
@@ -47,7 +47,7 @@ class WorkerProcessTest extends IntegrationTest
     {
         Event::fake();
 
-        $process = new Process('exit 1');
+        $process = new Process(['exit', 1]);
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });


### PR DESCRIPTION
Process now requires the command to be an array instead of a string. We can use the new `fromShellCommandline` as a BC fix: https://github.com/symfony/process/commit/d6f417d21efe2a2b91c0c8a19d938c5db18d81d3