### PR TITLE
[2.0] Set the Horizon environment via command option

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -14,7 +14,7 @@ class HorizonCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon';
+    protected $signature = 'horizon {--environment= : The environment name}';
 
     /**
      * The console command description.
@@ -47,7 +47,7 @@ class HorizonCommand extends Command
         });
 
         ProvisioningPlan::get(MasterSupervisor::name())->deploy(
-            config('horizon.env') ?? config('app.env')
+            $this->option('environment') ?? config('horizon.env') ?? config('app.env')
         );
 
         $this->info('Horizon started successfully.');


### PR DESCRIPTION
The reasoning for this is because we use Envoyer to deploy our application to all machines (including workers) and use config caching to speed up the boot times of the workers.

By allowing a separated config option for setting the environment (`horizon.env`) doesn't work for us since we have all web nodes also run a light version of the worker and have our worker servers run many processes for the heavy lifting and thus need to differentiate which because of config caching we can't do with .env vars.

Long story short, this allows us to run `php artisan horizon --environment=worker` in our supervisor config on the worker servers.

