### PR TITLE
fixes deprecated way of passing string to Symfony Process

### DIFF
--- a/src/Factories/ProcessFactory.php
+++ b/src/Factories/ProcessFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Laravel\Horizon\Factories;
+
+use Laravel\Horizon\BackgroundProcess;
+use Symfony\Component\Process\Process;
+
+class ProcessFactory
+{
+    /**
+     * Create a standard Process
+     *
+     * @param array          $command The command to run and its arguments listed as separate entries
+     * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
+     * @param mixed|null     $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param int|float|null $timeout The timeout in seconds or null to disable
+     *
+     * @return Process
+     */
+    public static function createProcess(
+        $command,
+        string $cwd = null,
+        array $env = null,
+        $input = null,
+        ?float $timeout = 60
+    ): Process {
+        return static::make(Process::class, $command, $cwd, $env, $input, $timeout);
+    }
+
+    /**
+     * Create a Background Process
+     *
+     * @param array          $command The command to run and its arguments listed as separate entries
+     * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
+     * @param mixed|null     $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param int|float|null $timeout The timeout in seconds or null to disable
+     *
+     * @return Process
+     */
+    public static function createBackgroundProcess(
+        $command,
+        string $cwd = null,
+        array $env = null,
+        $input = null,
+        ?float $timeout = 60
+    ): Process {
+        return static::make(BackgroundProcess::class, $command, $cwd, $env, $input, $timeout);
+    }
+
+    /**
+     * Create a process depending on the type.
+     *
+     * @param string         $class   The process class to be created.
+     * @param string         $command The command line to pass to the shell of the OS
+     * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
+     * @param mixed|null     $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param int|float|null $timeout The timeout in seconds or null to disable
+     *
+     * @return Process
+     */
+    protected static function make(
+        $class,
+        $command,
+        string $cwd = null,
+        array $env = null,
+        $input = null,
+        ?float $timeout = 60
+    ): Process {
+        if (method_exists($class, 'fromShellCommandline')) {
+            return $class::fromShellCommandline($command, $cwd, $env, $input, $timeout);
+        }
+
+        return new $class($command, $cwd, $env, $input, $timeout);
+    }
+}

--- a/src/MasterSupervisorCommands/AddSupervisor.php
+++ b/src/MasterSupervisorCommands/AddSupervisor.php
@@ -5,7 +5,7 @@ namespace Laravel\Horizon\MasterSupervisorCommands;
 use Laravel\Horizon\MasterSupervisor;
 use Laravel\Horizon\SupervisorOptions;
 use Laravel\Horizon\SupervisorProcess;
-use Symfony\Component\Process\Process;
+use Laravel\Horizon\Factories\ProcessFactory;
 
 class AddSupervisor
 {
@@ -27,7 +27,7 @@ class AddSupervisor
         );
     }
 
-    /**
+     /**
      * Create the Symfony process instance.
      *
      * @param  \Laravel\Horizon\MasterSupervisor  $master
@@ -38,8 +38,8 @@ class AddSupervisor
     {
         $command = $options->toSupervisorCommand();
 
-        return (new Process($command, $options->directory ?? base_path()))
-                    ->setTimeout(null)
-                    ->disableOutput();
+        $process = ProcessFactory::createProcess($command, $options->directory ?? base_path());
+
+        return $process->setTimeout(null)->disableOutput();
     }
 }

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -5,7 +5,7 @@ namespace Laravel\Horizon;
 use Closure;
 use Countable;
 use Cake\Chronos\Chronos;
-use Symfony\Component\Process\Process;
+use Laravel\Horizon\Factories\ProcessFactory;
 
 class ProcessPool implements Countable
 {
@@ -141,7 +141,7 @@ class ProcessPool implements Countable
         ];
     }
 
-    /**
+     /**
      * Remove the given number of processes from the process array.
      *
      * @param  int  $count
@@ -175,16 +175,14 @@ class ProcessPool implements Countable
      */
     protected function createProcess()
     {
-        $class = config('horizon.fast_termination')
-                    ? BackgroundProcess::class
-                    : Process::class;
+        $process = config('horizon.fast_termination')
+                    ? ProcessFactory::createBackgroundProcess($this->options->toWorkerCommand(), $this->options->directory)
+                    : ProcessFactory::createProcess($this->options->toWorkerCommand(), $this->options->directory);
 
-        return new WorkerProcess((new $class(
-            $this->options->toWorkerCommand(), $this->options->directory)
-        )->setTimeout(null)->disableOutput());
+        return new WorkerProcess($process->setTimeout(null)->disableOutput());
     }
 
-    /**
+     /**
      * Evaluate the current state of all of the processes.
      *
      * @return void

--- a/src/SystemProcessCounter.php
+++ b/src/SystemProcessCounter.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon;
 
-use Symfony\Component\Process\Process;
+use Laravel\Horizon\Factories\ProcessFactory;
 
 class SystemProcessCounter
 {
@@ -21,7 +21,7 @@ class SystemProcessCounter
      */
     public function get($name)
     {
-        $process = new Process('exec ps aux | grep '.static::$command, null, ['COLUMNS' => '2000']);
+        $process = ProcessFactory::createProcess('exec ps aux | grep '.static::$command, null, ['COLUMNS' => '2000']);
 
         $process->run();
 

--- a/tests/Feature/WorkerProcessTest.php
+++ b/tests/Feature/WorkerProcessTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\Process\Process;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Laravel\Horizon\Events\UnableToLaunchProcess;
 use Laravel\Horizon\Events\WorkerProcessRestarting;
+use Laravel\Horizon\Factories\ProcessFactory;
 
 class WorkerProcessTest extends IntegrationTest
 {
@@ -16,7 +17,7 @@ class WorkerProcessTest extends IntegrationTest
     {
         Event::fake();
 
-        $process = new Process('exit 1');
+        $process = ProcessFactory::createProcess('exit 1');
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });
@@ -31,7 +32,7 @@ class WorkerProcessTest extends IntegrationTest
     {
         Event::fake();
 
-        $process = new Process('exit 1');
+        $process = ProcessFactory::createProcess('exit 1');
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });
@@ -47,7 +48,7 @@ class WorkerProcessTest extends IntegrationTest
     {
         Event::fake();
 
-        $process = new Process('exit 1');
+        $process = ProcessFactory::createProcess('exit 1');
         $workerProcess = new WorkerProcess($process);
         $workerProcess->start(function () {
         });


### PR DESCRIPTION
This change introduces a factory to fix the deprecated way of creating a new Symfony `Process`. It gives preference to the `fromShellCommandline` method which was introduced in Symfony 4.2.