### PR TITLE
[3.0] orchestra/testbench doesn't need orchestra/database since Laravel 5.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/database": "^3.7",
         "orchestra/testbench": "^3.7",
         "phpunit/phpunit": "^7.0"
     },


### PR DESCRIPTION
Laravel 5.6.0 introduced support for `--realpath` for migration which has made `orchestra/database` a irrelevant requirement.

p/s: Also notice that Nova requiring it, might want to look into that as well <https://github.com/laravel/nova-issues/issues/986>