### PR TITLE
[4.0] Suggest predis instead of requiring it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "predis/predis": "^1.1"
     },
     "suggest": {
-        "ext-redis": "Required to use the redis cache and queue drivers (*).",
+        "ext-redis": "Required to use the redis cache and queue drivers.",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.1)."
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,11 @@
         "mockery/mockery": "^1.0",
         "orchestra/database": "^3.7",
         "orchestra/testbench": "^3.7",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "predis/predis": "^1.1"
     },
     "suggest": {
+        "ext-redis": "Required to use the redis cache and queue drivers (*).",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.1)."
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "predis/predis": "^1.1"
     },
     "suggest": {
-        "ext-redis": "Required to use the redis cache and queue drivers.",
-        "predis/predis": "Required to use the redis cache and queue drivers (^1.1)."
+        "ext-redis": "Required to use the Redis PHP driver.",
+        "predis/predis": "Required when not using the Redis PHP driver (^1.1)."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "illuminate/contracts": "~5.7.0|~5.8.0",
         "illuminate/queue": "~5.7.0|~5.8.0",
         "illuminate/support": "~5.7.0|~5.8.0",
-        "predis/predis": "^1.1",
         "ramsey/uuid": "^3.5",
         "symfony/process": "^4.2",
         "symfony/debug": "^4.2"
@@ -28,6 +27,9 @@
         "orchestra/database": "^3.7",
         "orchestra/testbench": "^3.7",
         "phpunit/phpunit": "^7.0"
+    },
+    "suggest": {
+        "predis/predis": "Required to use the redis cache and queue drivers (^1.1)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Follow-up to PR #381 

Just like laravel/framework which suggests predis (and people can choose to use phpredis instead), Horizon should suggest it so people using phpredis do not needlessly install a dependency. Horizon relies on the redis config in config/database.php anyway, and trusts that the user correctly fills in that information. Requiring the user to install phpredis or predis herself is no different from what other parts of Laravel using Redis already do.