### PR TITLE
[3.0] Fix no failing jobs problem

### DIFF
--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -67,7 +67,7 @@ class FailedJobsController extends Controller
      */
     protected function paginate(Request $request)
     {
-        return $this->jobs->getFailed($request->query('starting_at', -1))->map(function ($job) {
+        return $this->jobs->getFailed($request->query('starting_at') ?: -1)->map(function ($job) {
             return $this->decode($job);
         });
     }

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -63,7 +63,7 @@ class FailedJobsController extends Controller
      * Paginate the failed jobs for the request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     protected function paginate(Request $request)
     {
@@ -77,7 +77,7 @@ class FailedJobsController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $tag
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     protected function paginateByTag(Request $request, $tag)
     {


### PR DESCRIPTION
When a failed job is ready to be displayed the `startingAt` needs to be taken into account of being '0'. It'll later be added by 1 in the implementation below so we need to start with a `-1` instead.

Also fixed two incorrect return types.

Fixes laravel#530