### PR TITLE
[3.0] Make Year of readableTimestamp more readable

### DIFF
--- a/resources/js/base.js
+++ b/resources/js/base.js
@@ -84,7 +84,7 @@ export default {
          * Convert to human readable timestamp.
          */
         readableTimestamp(timestamp){
-            return this.formatDate(timestamp).format('YY-MM-DD HH:mm:ss');
+            return this.formatDate(timestamp).format('YYYY-MM-DD HH:mm:ss');
         },
 
 


### PR DESCRIPTION
This will solve 

> Failed Jobs date format can be ambiguous #526 