### PR TITLE
Horizon::night() move to boot()

### DIFF
--- a/stubs/HorizonServiceProvider.stub
+++ b/stubs/HorizonServiceProvider.stub
@@ -20,6 +20,8 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
         // Horizon::routeSmsNotificationsTo('15556667777');
         // Horizon::routeMailNotificationsTo('example@example.com');
         // Horizon::routeSlackNotificationsTo('slack-webhook-url', '#channel');
+        
+        // Horizon::night();
     }
 
     /**
@@ -45,6 +47,6 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
      */
     public function register()
     {
-        // Horizon::night();
+        //
     }
 }


### PR DESCRIPTION
After 3.0, the first deployment failed. 
This should be written in boot().