### PR TITLE
[3.0] Prevent A non-numeric value encountered

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -154,7 +154,7 @@ class RedisJobRepository implements JobRepository
      */
     protected function getJobsByType($type, $afterIndex)
     {
-        $afterIndex = $afterIndex === null ? -1 : $afterIndex;
+        $afterIndex = null === $afterIndex || '' === $afterIndex ? -1 : $afterIndex;
 
         return $this->getJobs($this->connection()->zrange(
             $type, $afterIndex + 1, $afterIndex + 50

--- a/src/Repositories/RedisTagRepository.php
+++ b/src/Repositories/RedisTagRepository.php
@@ -135,6 +135,8 @@ class RedisTagRepository implements TagRepository
      */
     public function paginate($tag, $startingAt = 0, $limit = 25)
     {
+		$startingAt = null === $startingAt || '' === $startingAt ? 0 : $startingAt;
+
         $tags = (array) $this->connection()->zrevrange(
             $tag, $startingAt, $startingAt + $limit - 1
         );


### PR DESCRIPTION
At the moment strict comparison with null causes an error because frontend sends an empty string and it passes as `$afterIndex` parameter. After that executes `$afterIndex + 1` and php >= 7.1 generates an `A non-numeric value encountered` E_WARNING