### PR TITLE
[3.0] Add individual/ping option to supervisors command

### DIFF
--- a/src/Console/SupervisorsCommand.php
+++ b/src/Console/SupervisorsCommand.php
@@ -12,7 +12,7 @@ class SupervisorsCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:supervisors';
+    protected $signature = 'horizon:supervisors {--individual=} {--ping}';
 
     /**
      * The console command description.
@@ -24,20 +24,76 @@ class SupervisorsCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
+     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisorsRepository
      * @return void
      */
-    public function handle(SupervisorRepository $supervisors)
+    public function handle(SupervisorRepository $supervisorsRepository)
     {
-        $supervisors = $supervisors->all();
+        $supervisors = collect($supervisorsRepository->all());
 
-        if (empty($supervisors)) {
+        if ($supervisors->count() == 0) {
             return $this->info('No supervisors are running.');
+        }
+
+        if ($this->option('ping')) {
+            $activeRunningSupervisor = $supervisors->where('status', 'running')->count();
+
+            return $this->info('Total active running supervisors ' . $activeRunningSupervisor);
+        }
+
+        $individualSupervisorName = $this->option('individual');
+
+        if ($individualSupervisorName) {
+            $individualSupervisor = $supervisorsRepository->find($individualSupervisorName);
+
+            if ($individualSupervisor) {
+                $headers = [
+                            'Name',
+                            'PID', 
+                            'Status',
+                            'Workers',
+                            'Balancing',
+                            'Connection',
+                            'Queue',
+                            'Delay',
+                            'Force',
+                            'Max Processes',
+                            'Min Processes',
+                            'Max Tries',
+                            'Memory',
+                            'Sleep',
+                            'Timeout'
+                        ];
+
+                $data[]  = [
+                    $individualSupervisor->name,
+                    $individualSupervisor->pid,
+                    $individualSupervisor->status,
+                    collect($individualSupervisor->processes)->map(function ($count, $queue) {
+                        return $queue.' ('.$count.')';
+                    })->implode(', '),
+                    $individualSupervisor->options['balance'],
+                    $individualSupervisor->options['connection'],
+                    $individualSupervisor->options['queue'],
+                    $individualSupervisor->options['delay'],
+                    $individualSupervisor->options['force'],
+                    $individualSupervisor->options['maxProcesses'],
+                    $individualSupervisor->options['minProcesses'],
+                    $individualSupervisor->options['maxTries'],
+                    $individualSupervisor->options['memory'],
+                    $individualSupervisor->options['sleep'],
+                    $individualSupervisor->options['timeout'],
+                ];
+
+                return $this->table($headers, $data);
+            }
+
+            return $this->error($individualSupervisorName . ' not found!');
         }
 
         $this->table([
             'Name', 'PID', 'Status', 'Workers', 'Balancing',
-        ], collect($supervisors)->map(function ($supervisor) {
+        ], $supervisors->map(function ($supervisor) {
             return [
                 $supervisor->name,
                 $supervisor->pid,


### PR DESCRIPTION
This is trying to solve #468 

Added two optional to `horizon:supervisors`.

By running `php artisan horizon:supervisors --ping`, will get current active running supervisor counts.

```
Total active running supervisors 8
```

By running `php artisan horizon:supervisors --individual='homestead-gDfu:supervisor-12'`, will get the result like the following. In this case `homestead-gDfu:supervisor-12` is the name of the individual supervisor.

```
+------------------------------+-------+---------+-----------------------+-----------+------------+-------------+-------+-------+---------------+---------------+-----------+--------+-------+---------+
| Name                         | PID   | Status  | Workers               | Balancing | Connection | Queue       | Delay | Force | Max Processes | Min Processes | Max Tries | Memory | Sleep | Timeout |
+------------------------------+-------+---------+-----------------------+-----------+------------+-------------+-------+-------+---------------+---------------+-----------+--------+-------+---------+
| homestead-gDfu:supervisor-12 | 12487 | running | redis:autobidding (3) | simple    | redis      | testing | 0     |       | 3             | 1             | 3         | 128    | 3     | 60      |
+------------------------------+-------+---------+-----------------------+-----------+------------+-------------+-------+-------+---------------+---------------+-----------+--------+-------+---------+
```

