### PR TITLE
[2.0] Adding horizon:status command

### DIFF
--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+
+class StatusCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get the current status of Horizon.';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
+     * @return void
+     */
+    public function handle(MasterSupervisorRepository $masters)
+    {
+        $this->line($masters->currentStatus());
+    }
+}

--- a/src/Contracts/MasterSupervisorRepository.php
+++ b/src/Contracts/MasterSupervisorRepository.php
@@ -58,4 +58,11 @@ interface MasterSupervisorRepository
      * @return void
      */
     public function flushExpired();
+
+    /**
+     * Get the current status of Horizon.
+     *
+     * @return string
+     */
+    public function currentStatus();
 }

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -178,6 +178,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\TerminateCommand::class,
                 Console\TimeoutCommand::class,
                 Console\WorkCommand::class,
+                Console\StatusCommand::class,
             ]);
         }
 

--- a/src/Http/Controllers/DashboardStatsController.php
+++ b/src/Http/Controllers/DashboardStatsController.php
@@ -54,12 +54,6 @@ class DashboardStatsController extends Controller
      */
     protected function currentStatus()
     {
-        if (! $masters = app(MasterSupervisorRepository::class)->all()) {
-            return 'inactive';
-        }
-
-        return collect($masters)->contains(function ($master) {
-            return $master->status === 'paused';
-        }) ? 'paused' : 'running';
+        return app(MasterSupervisorRepository::class)->currentStatus();
     }
 }

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -150,6 +150,22 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     }
 
     /**
+     * Get the current status of Horizon.
+     *
+     * @return string
+     */
+    public function currentStatus()
+    {
+        if (! $masters = $this->all()) {
+            return 'inactive';
+        }
+
+        return collect($masters)->contains(function ($master) {
+            return $master->status === 'paused';
+        }) ? 'paused' : 'running';
+    }
+
+    /**
      * Get the Redis connection instance.
      *
      * @return \Illuminate\Redis\Connections\Connection

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -8,6 +8,7 @@ use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\Repositories\RedisMasterSupervisorRepository;
 
 class DashboardStatsControllerTest extends AbstractControllerTest
 {
@@ -71,7 +72,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
 
     public function test_paused_status_is_reflected_if_all_master_supervisors_are_paused()
     {
-        $masters = Mockery::mock(MasterSupervisorRepository::class);
+        $masters = Mockery::mock(RedisMasterSupervisorRepository::class)->makePartial();
         $masters->shouldReceive('all')->andReturn([
             (object) [
                 'status' => 'running',


### PR DESCRIPTION
Adding `horizon:status` command to be able to check via cli the status of Horizon.

I targeted to `2.0` because the project i need is still `Laravel 5.6`, this is mergeable to `3.0` (no conflicts).