### PR TITLE
[3.0] Fix URL for retrying jobs

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -109,7 +109,7 @@
 
                 this.retryingJobs.push(id);
 
-                this.$http.post('/horizon/api/jobs/retry/' + id)
+                this.$http.post('/' + Horizon.path + '/api/jobs/retry/' + id)
                     .then(() => {
                         setTimeout(() => {
                             this.retryingJobs = _.reject(this.retryingJobs, job => job == id);


### PR DESCRIPTION
Horizon 3.0 added a config option for defining the Horizon path. The route for retrying failed jobs is still hardcoded to the default "horizon" path.