### PR TITLE
Add ability to configure route domain setting

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,6 +1,17 @@
 <?php
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the domain of where Horizon will be accessible from. Do not
+    | change this setting if you'd want Horizon to live under the same
+    | domain as your app. Change this if you'd want to use sub-domain.
+    |
+    */
+    'domain' => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -49,6 +49,7 @@ class HorizonServiceProvider extends ServiceProvider
     protected function registerRoutes()
     {
         Route::group([
+            'domain' => config('horizon.domain', null),
             'prefix' => config('horizon.path'),
             'namespace' => 'Laravel\Horizon\Http\Controllers',
             'middleware' => config('horizon.middleware', 'web'),


### PR DESCRIPTION
Currently, there's no way to specify the domain of Horizon. To address this issue, we can specify the domain of where Horizon will be accessible from in the config file e.g `horizon.app.dev` . The parameter is optional and the default is to not use any subdomain.  We also added notes in the config comment blocks