### PR TITLE
[3.0] Supervisor nice option

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -23,6 +23,7 @@ class SupervisorCommand extends Command
                             {--max-processes=1 : The maximum number of total workers to start}
                             {--min-processes=1 : The minimum number of workers to assign per queue}
                             {--memory=128 : The memory limit in megabytes}
+                            {--nice=0 : The process niceness}
                             {--paused : Start the supervisor in a paused state}
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
@@ -74,6 +75,10 @@ class SupervisorCommand extends Command
      */
     protected function start($supervisor)
     {
+        if ($supervisor->options->nice > 0) {
+            proc_nice($supervisor->options->nice);
+        }
+
         $supervisor->handleOutputUsing(function ($type, $line) {
             $this->output->write($line);
         });
@@ -106,7 +111,8 @@ class SupervisorCommand extends Command
             $this->option('timeout'),
             $this->option('sleep'),
             $this->option('tries'),
-            $this->option('force')
+            $this->option('force'),
+            $this->option('nice')
         );
     }
 

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -23,7 +23,7 @@ class SupervisorCommand extends Command
                             {--max-processes=1 : The maximum number of total workers to start}
                             {--min-processes=1 : The minimum number of workers to assign per queue}
                             {--memory=128 : The memory limit in megabytes}
-                            {--nice=0 : The process niceness}
+                            {--nice=0 : Increment to the process niceness}
                             {--paused : Start the supervisor in a paused state}
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
@@ -75,7 +75,7 @@ class SupervisorCommand extends Command
      */
     protected function start($supervisor)
     {
-        if ($supervisor->options->nice > 0) {
+        if ($supervisor->options->nice) {
             proc_nice($supervisor->options->nice);
         }
 

--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -13,8 +13,8 @@ class QueueCommandString
      */
     public static function toOptionsString(SupervisorOptions $options, $paused = false)
     {
-        $string = sprintf('--delay=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
-            $options->delay, $options->memory, $options->queue,
+        $string = sprintf('--delay=%s --memory=%s --nice=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
+            $options->delay, $options->memory, $options->nice, $options->queue,
             $options->sleep, $options->timeout, $options->maxTries
         );
 

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -49,6 +49,13 @@ class SupervisorOptions extends WorkerOptions
     public $minProcesses = 1;
 
     /**
+     * The process niceness.
+     *
+     * @var int
+     */
+    public $nice = 0;
+
+    /**
      * The working directories that new workers should be started from.
      *
      * @var string
@@ -70,10 +77,11 @@ class SupervisorOptions extends WorkerOptions
      * @param  int  $sleep
      * @param  int  $maxTries
      * @param  bool  $force
+     * @param  int  $nice
      */
     public function __construct($name, $connection, $queue = null, $balance = 'off',
                                 $delay = 0, $maxProcesses = 1, $minProcesses = 1, $memory = 128,
-                                $timeout = 60, $sleep = 3, $maxTries = 0, $force = false)
+                                $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $nice = 0)
     {
         $this->name = $name;
         $this->balance = $balance;
@@ -81,6 +89,7 @@ class SupervisorOptions extends WorkerOptions
         $this->maxProcesses = $maxProcesses;
         $this->minProcesses = $minProcesses;
         $this->queue = $queue ?: config('queue.connections.'.$connection.'.queue');
+        $this->nice = $nice;
 
         parent::__construct($delay, $memory, $timeout, $sleep, $maxTries, $force);
     }
@@ -165,6 +174,7 @@ class SupervisorOptions extends WorkerOptions
             'minProcesses' => $this->minProcesses,
             'maxTries' => $this->maxTries,
             'memory' => $this->memory,
+            'nice' => $this->nice,
             'name' => $this->name,
             'sleep' => $this->sleep,
             'timeout' => $this->timeout,

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -49,7 +49,7 @@ class SupervisorOptions extends WorkerOptions
     public $minProcesses = 1;
 
     /**
-     * The process niceness.
+     * Increment to the process niceness.
      *
      * @var int
      */

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertEquals(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --nice=0 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/SupervisorCommandTest.php
+++ b/tests/Feature/SupervisorCommandTest.php
@@ -24,4 +24,23 @@ class SupervisorCommandTest extends IntegrationTest
 
         $this->assertFalse($factory->supervisor->working);
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function test_supervisor_command_can_set_process_niceness()
+    {
+        $this->app->instance(SupervisorFactory::class, $factory = new FakeSupervisorFactory);
+        $this->artisan('horizon:supervisor', ['name' => 'foo', 'connection' => 'redis', '--nice' => 10]);
+
+        $this->assertEquals(10, $this->myNiceness());
+    }
+
+    private function myNiceness()
+    {
+        $pid = getmypid();
+
+        return (int) trim(`ps -p $pid -o nice=`);
+    }
 }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -53,7 +53,10 @@ class SupervisorTest extends IntegrationTest
         Queue::push(new Jobs\BasicJob);
         $this->assertEquals(1, $this->recentJobs());
 
-        $this->supervisor = $supervisor = new Supervisor($options = $this->options());
+        $options = $this->options();
+        $options->nice = 10;
+
+        $this->supervisor = $supervisor = new Supervisor($options);
 
         $supervisor->scale(1);
         $supervisor->loop();
@@ -66,7 +69,7 @@ class SupervisorTest extends IntegrationTest
 
         $host = MasterSupervisor::name();
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --nice=10 --queue="default" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
     }
@@ -84,12 +87,12 @@ class SupervisorTest extends IntegrationTest
         $host = MasterSupervisor::name();
 
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="first" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --nice=0 --queue="first" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
 
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="second" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --nice=0 --queue="second" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[1]->getCommandLine()
         );
     }


### PR DESCRIPTION
Closing #549 
This PR increments process niceness on each supervisor via config:
```php
            'supervisor-1' => [
                'connection' => 'redis',
                'queue' => ['default'],
                'balance' => 'simple',
                'processes' => 10,
                'tries' => 3,
                'nice' => 5,
            ],
```
The supervisor calls `proc_nice(5)` to set niceness:

I don't know if you can regard it as backward compatible because of the change in supervisor option constructor. Also not sure if it has to be sent to 3.0 or master.