### PR TITLE
[3.0] Fix nice option

### DIFF
--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -13,8 +13,8 @@ class QueueCommandString
      */
     public static function toOptionsString(SupervisorOptions $options, $paused = false)
     {
-        $string = sprintf('--delay=%s --memory=%s --nice=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
-            $options->delay, $options->memory, $options->nice, $options->queue,
+        $string = sprintf('--delay=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
+            $options->delay, $options->memory, $options->queue,
             $options->sleep, $options->timeout, $options->maxTries
         );
 

--- a/src/SupervisorCommandString.php
+++ b/src/SupervisorCommandString.php
@@ -36,9 +36,9 @@ class SupervisorCommandString
      */
     public static function toOptionsString(SupervisorOptions $options)
     {
-        return sprintf('%s --balance=%s --max-processes=%s --min-processes=%s',
+        return sprintf('%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s',
             QueueCommandString::toOptionsString($options), $options->balance,
-            $options->maxProcesses, $options->minProcesses
+            $options->maxProcesses, $options->minProcesses, $options->nice
         );
     }
 

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertEquals(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --nice=0 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1 --nice=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -53,10 +53,7 @@ class SupervisorTest extends IntegrationTest
         Queue::push(new Jobs\BasicJob);
         $this->assertEquals(1, $this->recentJobs());
 
-        $options = $this->options();
-        $options->nice = 10;
-
-        $this->supervisor = $supervisor = new Supervisor($options);
+        $this->supervisor = $supervisor = new Supervisor($this->options());
 
         $supervisor->scale(1);
         $supervisor->loop();
@@ -69,7 +66,7 @@ class SupervisorTest extends IntegrationTest
 
         $host = MasterSupervisor::name();
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --nice=10 --queue="default" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
     }
@@ -87,12 +84,12 @@ class SupervisorTest extends IntegrationTest
         $host = MasterSupervisor::name();
 
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --nice=0 --queue="first" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="first" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
 
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --nice=0 --queue="second" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
+            'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="second" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[1]->getCommandLine()
         );
     }


### PR DESCRIPTION
fixes #555 
--nice option was added to `QueueCommandString` by mistake, leading to failure in starting workers. It is now only in `SupervisorCommandString`