### PR TITLE
[3.0] Change refresh interval

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -111,7 +111,7 @@
 
                     this.timeout = setTimeout(() => {
                         this.refreshStatsPeriodically(false);
-                    }, 5000);
+                    }, 500);
                 });
             },
 


### PR DESCRIPTION
Change the refresh interval of stats on dashboard to 500ms. 

The default is now the same as the default in Beanstalk.
