### PR TITLE
[3.0] Serve content from https when site uses https as protocol

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -5,13 +5,21 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <link rel="shortcut icon" href="{{ asset('/vendor/horizon/img/favicon.png') }}">
+    @if (Str::startsWith(env('APP_URL'), 'https'))
+        <link rel="shortcut icon" href="{{ secure_asset('/vendor/horizon/img/favicon.png') }}">
+    @else
+        <link rel="shortcut icon" href="{{ asset('/vendor/horizon/img/favicon.png') }}">
+    @endif
 
     <title>Horizon</title>
 
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
-    <link href="{{ asset(mix($cssFile, 'vendor/horizon')) }}" rel="stylesheet" type="text/css">
+    @if (Str::startsWith(env('APP_URL'), 'https'))
+        <link href="{{ secure_asset(mix($cssFile, 'vendor/horizon')) }}" rel="stylesheet" type="text/css">
+    @else
+        <link href="{{ asset(mix($cssFile, 'vendor/horizon')) }}" rel="stylesheet" type="text/css">
+    @endif
 </head>
 <body>
 <div id="horizon" v-cloak>
@@ -95,6 +103,11 @@
     window.Horizon = @json($horizonScriptVariables);
 </script>
 
-<script src="{{asset(mix('app.js', 'vendor/horizon'))}}"></script>
+@if (Str::startsWith(env('APP_URL'), 'https'))
+    <script src="{{ secure_asset(mix('app.js', 'vendor/horizon')) }}"></script>
+@else
+    <script src="{{ asset(mix('app.js', 'vendor/horizon')) }}"></script>
+@endif
+
 </body>
 </html>


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Right now, when site is accessed through **_https://_**, content is still served via **_http://_**, and it doesn't matter if APP_URL is `https://site_name` or `http://site_name`.

With this pull request, assets will be served correctly based on the **_APP_URL_** variable, if it has **_https://_** in it, the `secure_asset` helper will be used