### PR TITLE
[3.0] Fix false jobs causing front-end not to display them

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -193,7 +193,7 @@ class RedisJobRepository implements JobRepository
         return $this->indexJobs(collect($jobs)->filter(function ($job) {
             $job = is_array($job) ? array_values($job) : null;
 
-            return is_array($job) && $job[0] !== null;
+            return is_array($job) && $job[0] !== null && $job[0] !== false;
         })->values(), $indexFrom);
     }
 


### PR DESCRIPTION
Fixes #304

I’ve ran into issues while running Horizon in production where some of the failed jobs that are collected from Redis have `false` as all the values on the job (including `name`, `id`, `connection` etc.). I’m not exactly sure how these occur (possibly from orphan processes?) Screenshot:

![image](https://user-images.githubusercontent.com/3619398/56827380-ae156c00-682c-11e9-94ea-8e29d5156b31.png)

This creates problem for Horizon’s front-end (gets stuck in loading state). This is because the front-end determines the job’s base name using JavaScript’s string.includes(). Unfortunately, when the id is a boolean this method falls `t.includes is not a function`

[horizon/base.js at 3.0 · laravel/horizon · GitHub](https://github.com/laravel/horizon/blob/3.0/resources/js/base.js#L60)

### Fix

In the `RedisJobRepository` `getJobs` method there is already a check to make sure that the job is an array and the the id of the job isn't null. This PR adds a check to make sure that the id of the job isn't `false` and filter those out.

```php
return is_array($job) && $job[0] !== null && $job[0] !== false;
```

Relevant line: 

https://github.com/laravel/horizon/blob/3.0/src/Repositories/RedisJobRepository.php#L196

I chose to explicitly check if the id is false as opposed to using PHP's `empty()` as empty("0") will return true and would filter a job id that is equal to 0.

