### PR TITLE
[3.0] Display worker CPU and memory utilization in supervisor list

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -300,6 +300,8 @@
                 <tr>
                     <th>Supervisor</th>
                     <th>Processes</th>
+                    <th>CPU Threads</th>
+                    <th>Memory</th>
                     <th>Queues</th>
                     <th class="text-right">Balancing</th>
                 </tr>
@@ -309,6 +311,8 @@
                 <tr v-for="supervisor in worker.supervisors">
                     <td>{{ superVisorDisplayName(supervisor.name, worker.name) }}</td>
                     <td>{{ countProcesses(supervisor.processes) }}</td>
+                    <td>{{ supervisor.cpu }}</td>
+                    <td>{{ supervisor.mem }}%</td>
                     <td>{{ supervisor.options.queue.replace(/,/g, ', ') }}</td>
                     <td class="text-right">
                         ({{ supervisor.options.balance.charAt(0).toUpperCase() + supervisor.options.balance.slice(1) }})

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -71,7 +71,7 @@ class RedisSupervisorRepository implements SupervisorRepository
     {
         $records = $this->connection()->pipeline(function ($pipe) use ($names) {
             foreach ($names as $name) {
-                $pipe->hmget('supervisor:'.$name, ['name', 'master', 'pid', 'status', 'processes', 'options']);
+                $pipe->hmget('supervisor:'.$name, ['name', 'master', 'pid', 'status', 'processes', 'options', 'cpu', 'mem']);
             }
         });
 
@@ -85,6 +85,8 @@ class RedisSupervisorRepository implements SupervisorRepository
                 'status' => $record[3],
                 'processes' => json_decode($record[4], true),
                 'options' => json_decode($record[5], true),
+                'cpu' => $record[6],
+                'mem' => $record[7],
             ];
         })->filter()->all();
     }
@@ -114,6 +116,7 @@ class RedisSupervisorRepository implements SupervisorRepository
         })->toJson();
 
         $this->connection()->pipeline(function ($pipe) use ($supervisor, $processes) {
+            $workerStats = $supervisor->workerStats();
             $pipe->hmset(
                 'supervisor:'.$supervisor->name, [
                     'name' => $supervisor->name,
@@ -122,6 +125,8 @@ class RedisSupervisorRepository implements SupervisorRepository
                     'status' => $supervisor->working ? 'running' : 'paused',
                     'processes' => $processes,
                     'options' => $supervisor->options->toJson(),
+                    'cpu' => number_format($workerStats->sum('cpu'), 2),
+                    'mem' => round($workerStats->sum('mem')),
                 ]
             );
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -407,6 +407,16 @@ class Supervisor implements Pausable, Restartable, Terminable
     }
 
     /**
+     * Get CPU and memory usage for the active workers by asking the OS.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function workerStats()
+    {
+        return app(SystemProcessCounter::class)->getWorkerStats($this->name);
+    }
+
+    /**
      * Get the total active process count by asking the OS.
      *
      * @return int


### PR DESCRIPTION
So here is my first PR in relation to #586

This adds information about how much system resources (CPU and memory) the workers are currently consuming:
![image](https://user-images.githubusercontent.com/204594/57295832-a460f380-70cb-11e9-855c-552f17457024.png)

I have tried to communicate this in the most user friendly way possible, but here are some additional details:
 - CPU Threads shows how many logical CPU cores the workers are currently occupying, if the number is close to the actual number of logical CPU cores then the system is probably being maxed out by the workers. Other process will also take resources, so this is not meant to show you system load but rather how much is being used by the workers. As such if the server is doing other tasks it might not be a replacement for other devops tools.
- Memory, this shows how much memory is currently being used by the workers. This is shown as a percentage of total system memory.