### PR TITLE
[3.0] Fix for missing first failed job when searching

### DIFF
--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -82,7 +82,7 @@ class FailedJobsController extends Controller
     protected function paginateByTag(Request $request, $tag)
     {
         $jobIds = $this->tags->paginate(
-            'failed:'.$tag, $request->query('starting_at', -1) + 1, 50
+            'failed:'.$tag, ($request->query('starting_at') ?: -1) + 1, 50
         );
 
         $startingAt = $request->query('starting_at', 0);


### PR DESCRIPTION
When searching failed jobs by tag, the oldest match is currently missing. I believe this is similar to #532.

Failed job list:

![failed-list](https://user-images.githubusercontent.com/127811/57795177-54a9aa00-7713-11e9-91ba-ebef72574b39.png)

Failed job search:

![failed-search](https://user-images.githubusercontent.com/127811/57795201-5f643f00-7713-11e9-95f7-7077e9458820.png)
