### PR TITLE
[3.0] Allow UI timezone to be customized

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -50,6 +50,13 @@ class Horizon
     public static $useDarkTheme = false;
 
     /**
+     * The timezone to use in the UI (defaults to app.timezone).
+     *
+     * @var string
+     */
+    public static $timezone;
+
+    /**
      * The database configuration methods.
      *
      * @var array
@@ -126,7 +133,7 @@ class Horizon
     {
         return [
             'path' => config('horizon.path'),
-            'timezone' => config('app.timezone'),
+            'timezone' => static::$timezone ?? config('app.timezone'),
         ];
     }
 


### PR DESCRIPTION
Ideally, I think the timezone should come from the browser like Nova/Telescope (or at least have the option) but [there seems to be a reason not to](https://github.com/laravel/horizon/issues/562#issuecomment-480788256). In fact, [it seems at one point it did come from the browser](https://github.com/laravel/horizon/issues/151#issuecomment-331892388) but this ability was removed.