### PR TITLE
[3.0] Properly format numeric values

### DIFF
--- a/src/SystemProcessCounter.php
+++ b/src/SystemProcessCounter.php
@@ -28,7 +28,9 @@ class SystemProcessCounter
         $rows = explode("\n", $process->getOutput());
 
         return collect($rows)->filter()->map(function ($rows) {
-            $row = collect(explode(' ', $rows))->filter()->take(2);
+            $row = collect(explode(' ', $rows))->filter()->take(2)->map(function ($value) {
+                return str_replace(',', '.', $value);
+            });
 
             return ['cpu' => $row->first() / 100, 'mem' => $row->last()];
         });


### PR DESCRIPTION
Recently, Horizon introduced [worker CPU and memory utilization in supervisor list](https://github.com/laravel/horizon/pull/589), but there are locales that use a comma as a decimal separator. So, right now, you'll see a lot of exceptions in logs like this:

```
[0000-00-00 00:00:00] local.ERROR: A non well formed numeric value encountered {"exception":"[object] (ErrorException(code: 0): A non well formed numeric value encountered at /.../vendor/laravel/horizon/src/SystemProcessCounter.php:33)
```

because Horizon expects values like `0.25` instead of `0,25`.