### PR TITLE
[3.0] Setting the default queue in the config to use the base laravel queue config env variables

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -142,7 +142,7 @@ return [
         'production' => [
             'supervisor-1' => [
                 'connection' => 'redis',
-                'queue' => ['default'],
+                'queue' => [env('REDIS_QUEUE', 'default')],
                 'balance' => 'simple',
                 'processes' => 10,
                 'tries' => 3,
@@ -152,7 +152,7 @@ return [
         'local' => [
             'supervisor-1' => [
                 'connection' => 'redis',
-                'queue' => ['default'],
+                'queue' => [env('REDIS_QUEUE', 'default')],
                 'balance' => 'simple',
                 'processes' => 3,
                 'tries' => 3,


### PR DESCRIPTION
When I install horizon I always have to (and frequently forget to) set the queue to match the redis queue setting in my Laravel project.  This pull request set the default config/horizon.php queues to prefer the REDIS_QUEUE environment variable instead of being hard-coded as 'default.'

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
