### PR TITLE
Custom MasterSupervisor name breaks dashboard

### DIFF
--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -117,7 +117,7 @@ class RedisSupervisorRepository implements SupervisorRepository
             $pipe->hmset(
                 'supervisor:'.$supervisor->name, [
                     'name' => $supervisor->name,
-                    'master' => explode(':', $supervisor->name)[0],
+                    'master' => implode(':',explode(':', $supervisor->name, -1)),
                     'pid' => $supervisor->pid(),
                     'status' => $supervisor->working ? 'running' : 'paused',
                     'processes' => $processes,

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -117,7 +117,7 @@ class RedisSupervisorRepository implements SupervisorRepository
             $pipe->hmset(
                 'supervisor:'.$supervisor->name, [
                     'name' => $supervisor->name,
-                    'master' => implode(':',explode(':', $supervisor->name, -1)),
+                    'master' => implode(':', explode(':', $supervisor->name, -1)),
                     'pid' => $supervisor->pid(),
                     'status' => $supervisor->working ? 'running' : 'paused',
                     'processes' => $processes,


### PR DESCRIPTION
As described in laravel/horizon#618 it is possible to break the return of the `GET /masters` if your MasterSupervisor has an extra ':' character in it. This PR fixes laravel/horizon#618