### PR TITLE
[3.0] New supervisor config option 'once' makes workers run one job then restart

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -24,6 +24,7 @@ class SupervisorCommand extends Command
                             {--min-processes=1 : The minimum number of workers to assign per queue}
                             {--memory=128 : The memory limit in megabytes}
                             {--nice=0 : The process priority}
+                            {--once : Worker processes will only process the next job on the queue and then be re-started}
                             {--paused : Start the supervisor in a paused state}
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
@@ -112,7 +113,8 @@ class SupervisorCommand extends Command
             $this->option('sleep'),
             $this->option('tries'),
             $this->option('force'),
-            $this->option('nice')
+            $this->option('nice'),
+            $this->option('once')
         );
     }
 

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -181,7 +181,7 @@ class ProcessPool implements Countable
 
         return new WorkerProcess($class::fromShellCommandline(
             $this->options->toWorkerCommand(), $this->options->directory
-        )->setTimeout(null)->disableOutput());
+        )->setTimeout(null)->disableOutput(), $this->options->once);
     }
 
     /**

--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -22,6 +22,10 @@ class QueueCommandString
             $string .= ' --force';
         }
 
+        if ($options->once) {
+            $string .= ' --once';
+        }
+
         if ($paused) {
             $string .= ' --paused';
         }

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -56,6 +56,13 @@ class SupervisorOptions extends WorkerOptions
     public $nice = 0;
 
     /**
+     * Worker processes will only process the next job on the queue and then be re-started
+     *
+     * @var bool
+     */
+    public $once = false;
+
+    /**
      * The working directories that new workers should be started from.
      *
      * @var string
@@ -78,13 +85,15 @@ class SupervisorOptions extends WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      * @param  int  $nice
+     * @param  bool  $once
      */
     public function __construct($name, $connection, $queue = null, $balance = 'off',
                                 $delay = 0, $maxProcesses = 1, $minProcesses = 1, $memory = 128,
-                                $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $nice = 0)
+                                $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $nice = 0, $once = false)
     {
         $this->name = $name;
         $this->nice = $nice;
+        $this->once = $once;
         $this->balance = $balance;
         $this->connection = $connection;
         $this->maxProcesses = $maxProcesses;
@@ -175,6 +184,7 @@ class SupervisorOptions extends WorkerOptions
             'maxTries' => $this->maxTries,
             'memory' => $this->memory,
             'nice' => $this->nice,
+            'once' => $this->once,
             'name' => $this->name,
             'sleep' => $this->sleep,
             'timeout' => $this->timeout,

--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -35,11 +35,13 @@ class WorkerProcess
      * Create a new worker process instance.
      *
      * @param  \Symfony\Component\Process\Process  $process
+     * @param  bool  $once
      * @return void
      */
-    public function __construct($process)
+    public function __construct($process, $once = false)
     {
         $this->process = $process;
+        $this->once = $once;
     }
 
     /**
@@ -52,9 +54,12 @@ class WorkerProcess
     {
         $this->output = $callback;
 
-        $this->cooldown();
-
-        $this->process->start($callback);
+        if ($this->once) {
+            $this->process->start($callback);
+        } else {
+            $this->cooldown();
+            $this->process->start($callback);
+        }
 
         return $this;
     }


### PR DESCRIPTION
Re #624 

Some long-running processes leave open files in the file system. After some time, this eventually can cause the number of open files to exhaust the operating system limits, which then can cause Horizon workers to cease working until Horizon is restarted.

Horizon currently runs all commands like `queue:work` does, which can leave these files open piling up (see #624 for information).

This pull-request adds an optional parameter to the configuration for each Supervisor. By setting `once` to `true` in `config\horizon.php`, Horizon will run worker processes similar to `queue:listen` does, and will restart each process after each job.

This change should have no affect on deployments that don't include `once`, or that set `once` to `false`. In this way, this change should be non-breaking.

Thank you for your consideration!