### PR TITLE
[3.0] Adjust auto scaling to always use the max processes

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -115,10 +115,10 @@ class AutoScaler
 
         $poolProcesses = $pool->totalProcessCount();
 
-        if (round($workers) > $poolProcesses &&
+        if (ceil($workers) > $poolProcesses &&
             $this->wouldNotExceedMaxProcesses($supervisor)) {
             $pool->scale($poolProcesses + 1);
-        } elseif (round($workers) < $poolProcesses &&
+        } elseif (ceil($workers) < $poolProcesses &&
                   $poolProcesses > $supervisor->options->minProcesses) {
             $pool->scale($poolProcesses - 1);
         }


### PR DESCRIPTION
As reported in https://github.com/laravel/horizon/issues/486

If the max. number of processes is 4, while you're balancing 3 queues. The number of workers per processes needed per queue will be 1.3. When using `round()` Horizon will assign 1 process per queue and then it's done.

However if we use `ceil()` Horizon will assign 1 process per queue and then it'll assign a process for the first queue since each queue will require 2 instead of 1.

- 4 / 3 = 1.3
- round(1.3) = 1 (That's the current case)
- ceil(1.3) = 2 (That's what this PR changes)