### PR TITLE
[3.0] Correct dashboard "Failed Jobs Past 7 Days" metric

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -51,10 +51,10 @@
             /**
              * Determine the recently failed job period label.
              */
-            recentlyFailedPeriod() {
+            failedJobsPeriod() {
                 return !this.ready
                     ? 'Failed jobs past 7 days'
-                    : `Failed jobs past ${this.determinePeriod(this.stats.periods.recentlyFailed)}`;
+                    : `Failed jobs past ${this.determinePeriod(this.stats.periods.failedJobs)}`;
             },
         },
 
@@ -184,10 +184,10 @@
 
                     <div class="w-25 border-right border-bottom">
                         <div class="p-4">
-                            <small class="text-uppercase" v-text="recentlyFailedPeriod"></small>
+                            <small class="text-uppercase" v-text="failedJobsPeriod"></small>
 
                             <h4 class="mt-4 mb-0">
-                                {{ stats.recentlyFailed ? stats.recentlyFailed.toLocaleString() : 0 }}
+                                {{ stats.failedJobs ? stats.failedJobs.toLocaleString() : 0 }}
                             </h4>
                         </div>
                     </div>

--- a/src/Http/Controllers/DashboardStatsController.php
+++ b/src/Http/Controllers/DashboardStatsController.php
@@ -22,13 +22,13 @@ class DashboardStatsController extends Controller
             'processes' => $this->totalProcessCount(),
             'queueWithMaxRuntime' => app(MetricsRepository::class)->queueWithMaximumRuntime(),
             'queueWithMaxThroughput' => app(MetricsRepository::class)->queueWithMaximumThroughput(),
-            'recentlyFailed' => app(JobRepository::class)->countRecentlyFailed(),
+            'failedJobs' => app(JobRepository::class)->countFailed(),
             'recentJobs' => app(JobRepository::class)->countRecent(),
             'status' => $this->currentStatus(),
             'wait' => collect(app(WaitTimeCalculator::class)->calculate())->take(1),
             'periods' => [
+                'failedJobs' => config('horizon.trim.failed'),
                 'recentJobs' => config('horizon.trim.recent'),
-                'recentlyFailed' => config('horizon.trim.failed'),
             ],
         ];
     }

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -38,7 +38,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
         $this->app->instance(MetricsRepository::class, $metrics);
 
         $jobs = Mockery::mock(JobRepository::class);
-        $jobs->shouldReceive('countRecentlyFailed')->andReturn(1);
+        $jobs->shouldReceive('countFailed')->andReturn(1);
         $jobs->shouldReceive('countRecent')->andReturn(1);
         $this->app->instance(JobRepository::class, $jobs);
 
@@ -58,13 +58,13 @@ class DashboardStatsControllerTest extends AbstractControllerTest
             'wait' => ['first' => 20],
             'processes' => 30,
             'status' => 'inactive',
-            'recentlyFailed' => 1,
+            'failedJobs' => 1,
             'recentJobs' => 1,
             'queueWithMaxRuntime' => 'default',
             'queueWithMaxThroughput' => 'default',
             'periods' => [
+                'failedJobs' => 10080,
                 'recentJobs' => 60,
-                'recentlyFailed' => 10080,
             ],
         ]);
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/horizon/issues/621

![option-1-week](https://user-images.githubusercontent.com/823566/60773931-aef33580-a0da-11e9-8501-f883be0bbdc4.png)

The dashboard "Failed Jobs Past 7 Days" metric almost always shows zero because out-of-the-box the counter is actually from the past _1 hour_ of failed jobs. The time period label is calculated from `config('horizon.trim.failed')` but the Redis count query is filtered by `config('horizon.trim.recent')` minutes ago, same as the "Jobs Past Hour" label in the above screenshot.

This change makes the metric match the time period label so the count matches the number of results under the "Failed Jobs" page at URI /horizon/failed.

## Other possible implementations

I described two other possible approaches in the issue thread: https://github.com/laravel/horizon/issues/621#issuecomment-509032941

Another config/horizon.php option could be added to give devs more control over the failed job count filtered by timestamp.

## Possible deprecations for Laravel Horizon 4.0+

With this merged, `RedisJobRepository::countRecentlyFailed()` and Redis set `'recent_failed_jobs'` would no longer be used in Horizon. They could be earmarked for removal in 4.0? In the 3.0 branch, it's possible userland calls these in custom queue dashboards.