### PR TITLE
[3.0] Absolute to Dynamic resource paths conversion

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -11,7 +11,7 @@
 
     <!-- Style sheets-->
     <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
-    <link href="{{ asset(mix($cssFile, 'vendor/horizon')) }}" rel="stylesheet">
+    <link href="{{ mix($cssFile, 'vendor/horizon') }}" rel="stylesheet">
 </head>
 <body>
 <div id="horizon" v-cloak>
@@ -95,6 +95,6 @@
     window.Horizon = @json($horizonScriptVariables);
 </script>
 
-<script src="{{asset(mix('app.js', 'vendor/horizon'))}}"></script>
+<script src="{{ mix('app.js', 'vendor/horizon') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Allow Horizon to load resources from dynamic path rather than absolute

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**Framework Version:** 5.8.29
**Horizon Version:** 3.2.6
**Fixes Issue:**  https://github.com/laravel/horizon/issues/631

### Problem
Right now, Horizon tries to fetch resources (CSS and JS) files from absolute paths, which sometimes may break the panel due to the files being fetches from the **http://** instead of **https://**
![Annotation 2019-07-07 161201](https://user-images.githubusercontent.com/1318627/60768942-a3037580-a0d2-11e9-8235-abb2d429c4f8.png)
### Possible solution
We can fix that by following the same code for loading resources as **Laravel Nova** is using.
![Annotation 2019-07-08 153130](https://user-images.githubusercontent.com/1318627/60810305-7f553380-a195-11e9-80a5-c347ee71599f.png)
This will force Horizon to fetch resources from relative paths rather than absolute.