### PR TITLE
[3.0] Changed default Redis prefix

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -52,7 +54,10 @@ return [
     |
     */
 
-    'prefix' => env('HORIZON_PREFIX', 'horizon:'),
+    'prefix' => env(
+        'HORIZON_PREFIX',
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_horizon:'
+    ),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
When you are running multiple installations of Horizon on the same server you have to change `HORIZON_PREFIX` environment variable to unique value for every installation.
People often forget to do this. 
So I provide more flexible default Redis prefix based on `APP_NAME` variable (inspired by default session prefix in Laravel).
