### PR TITLE
Forcing Vue to use the X-Requested-With header, set to XMLHttpRequest

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -11,6 +11,8 @@ require('bootstrap');
 
 let token = document.head.querySelector('meta[name="csrf-token"]');
 
+axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
 if (token) {
     axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
 }


### PR DESCRIPTION
-- resubmitting without compiled assets.

This PR is a fix for issue [Issue 639](https://github.com/laravel/horizon/issues/639)

This adds an additional header to every request to the horizon API routes. 
By setting the header `X-Requested-With` to `XMLHttpRequest`, Laravel knows the request is an `ajax`-request, so it does not update previous URL in the user session, which was undesired behavior.

Without this PR, users having Horizon open in one tab, and other parts of their project in another, might have their previous URL in their session updated to for example: `/horizon/api/workload`, so any part of their project using `URL::previous()` might return the user to an API resource, in stead of the previous URL the user visited manually



<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
