### PR TITLE
[4.0] Changed default Redis prefix

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -52,7 +54,10 @@ return [
     |
     */
 
-    'prefix' => env('HORIZON_PREFIX', 'horizon:'),
+    'prefix' => env(
+        'HORIZON_PREFIX',
+        Str::slug(env('APP_NAME', 'laravel'), '_').'_horizon:'
+    ),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
When you are running multiple installations of Horizon on the same server you have to change HORIZON_PREFIX environment variable to unique value for every installation.
Sometimes I was forgetting to change HORIZON_PREFIX when I ran multiple installations of Horizon on the same server. And I found that many people have had this problem too.
So I provide more flexible default Redis prefix based on APP_NAME variable (inspired by default session prefix in Laravel).
I talked with @driesvints and he suggested that this improvement can affect existing projects. I agree with him and I think that it will be better to add this improvement in a next major release (like 4.0.0).