### PR TITLE
[3.0] Allow custom dashboard failed jobs metric period

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -95,6 +95,7 @@ return [
 
     'trim' => [
         'recent' => 60,
+        'recent_failed' => 10080,
         'failed' => 10080,
         'monitored' => 10080,
     ],

--- a/src/Http/Controllers/DashboardStatsController.php
+++ b/src/Http/Controllers/DashboardStatsController.php
@@ -22,12 +22,12 @@ class DashboardStatsController extends Controller
             'processes' => $this->totalProcessCount(),
             'queueWithMaxRuntime' => app(MetricsRepository::class)->queueWithMaximumRuntime(),
             'queueWithMaxThroughput' => app(MetricsRepository::class)->queueWithMaximumThroughput(),
-            'failedJobs' => app(JobRepository::class)->countFailed(),
+            'failedJobs' => app(JobRepository::class)->countRecentlyFailed(),
             'recentJobs' => app(JobRepository::class)->countRecent(),
             'status' => $this->currentStatus(),
             'wait' => collect(app(WaitTimeCalculator::class)->calculate())->take(1),
             'periods' => [
-                'failedJobs' => config('horizon.trim.failed'),
+                'failedJobs' => config('horizon.trim.recent_failed', config('horizon.trim.recent')),
                 'recentJobs' => config('horizon.trim.recent'),
             ],
         ];

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -38,7 +38,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
         $this->app->instance(MetricsRepository::class, $metrics);
 
         $jobs = Mockery::mock(JobRepository::class);
-        $jobs->shouldReceive('countFailed')->andReturn(1);
+        $jobs->shouldReceive('countRecentlyFailed')->andReturn(1);
         $jobs->shouldReceive('countRecent')->andReturn(1);
         $this->app->instance(JobRepository::class, $jobs);
 


### PR DESCRIPTION
Enhancement: https://github.com/laravel/horizon/issues/637

Add `config('horizon.trim.recent_failed')` to control the dashboard "Failed Jobs" metric period. A typical use case is for Horizon to track the exceptions across the past 7 days but the dashboard only shows the failure count from the past 24 hours.

By default, it will fallback to `config('horizon.failed')` (past 7 days) since Laravel Horizon 3.0 installs will be missing config/horizon.php key `'recent_failed'`. This makes the 3.0 branch continue to behave as normal to users unaware this can be changed with a new config key.

The 4.0 branch can probably remove this fallback for a hardcoded 10080 minutes / 7 days.
