### PR TITLE
[3.0] Fix autobalancer

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -96,8 +96,10 @@ class AutoScaler
 
         return $timeToClear->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll) {
             return $timeToClearAll > 0 && $supervisor->options->autoScaling()
-                    ? [$queue => (($timeToClear / $timeToClearAll) * $supervisor->options->maxProcesses)]
-                    : [$queue => $supervisor->options->maxProcesses / count($supervisor->processPools)];
+                ? [$queue => (($timeToClear / $timeToClearAll) * $supervisor->options->maxProcesses)]
+                : ($timeToClearAll == 0 && $supervisor->options->autoScaling()
+                    ? [$queue => $supervisor->options->minProcesses]
+                    : [$queue => $supervisor->options->maxProcesses / count($supervisor->processPools)]);
         })->sort();
     }
 

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -95,11 +95,17 @@ class AutoScaler
         $timeToClearAll = $timeToClear->sum();
 
         return $timeToClear->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll) {
-            return $timeToClearAll > 0 && $supervisor->options->autoScaling()
-                ? [$queue => (($timeToClear / $timeToClearAll) * $supervisor->options->maxProcesses)]
-                : ($timeToClearAll == 0 && $supervisor->options->autoScaling()
-                    ? [$queue => $supervisor->options->minProcesses]
-                    : [$queue => $supervisor->options->maxProcesses / count($supervisor->processPools)]);
+
+            if ($timeToClearAll > 0 &&
+                $supervisor->options->autoScaling()) {
+                return [$queue => (($timeToClear / $timeToClearAll) * $supervisor->options->maxProcesses)];
+            } elseif ($timeToClearAll == 0 &&
+                      $supervisor->options->autoScaling()) {
+                return [$queue => $supervisor->options->minProcesses];
+            }
+
+            return [$queue => $supervisor->options->maxProcesses / count($supervisor->processPools)];
+
         })->sort();
     }
 

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -95,7 +95,6 @@ class AutoScaler
         $timeToClearAll = $timeToClear->sum();
 
         return $timeToClear->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll) {
-
             if ($timeToClearAll > 0 &&
                 $supervisor->options->autoScaling()) {
                 return [$queue => (($timeToClear / $timeToClearAll) * $supervisor->options->maxProcesses)];
@@ -105,7 +104,6 @@ class AutoScaler
             }
 
             return [$queue => $supervisor->options->maxProcesses / count($supervisor->processPools)];
-
         })->sort();
     }
 

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -70,6 +70,39 @@ class AutoScalerTest extends IntegrationTest
         $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
     }
 
+    public function test_balancer_assigns_more_processes_on_busy_queue()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'first' => ['current' => 1, 'size' => 50, 'runtime' => 50],
+            'second' => ['current' => 1, 'size' => 0, 'runtime' => 0],
+        ]);
+
+        $scaler->scale($supervisor);
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(5, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(7, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+        $scaler->scale($supervisor);
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(9, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+    }
+
     public function test_balancing_a_single_queue_assigns_it_the_min_workers_with_empty_queue()
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(5, [

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -51,18 +51,33 @@ class AutoScalerTest extends IntegrationTest
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(5, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(5, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertEquals(4, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(4, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(3, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(2, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(2, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(1, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
     }
 
-    public function test_balancing_a_single_queue_assigns_it_the_max_workers()
+    public function test_balancing_a_single_queue_assigns_it_the_min_workers_with_empty_queue()
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(5, [
-            'first' => ['current' => 4, 'size' => 0, 'runtime' => 0],
+            'first' => ['current' => 2, 'size' => 0, 'runtime' => 0],
         ]);
 
         $scaler->scale($supervisor);
-        $this->assertEquals(5, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(1, $supervisor->processPools['first']->totalProcessCount());
     }
 
     public function test_scaler_will_not_scale_past_max_process_threshold_under_high_load()


### PR DESCRIPTION
This updated-PR is a fix for #622. 

I have updated the function to not use ternary statements, as the previous PR was closed due to using nested ternary statements.

This PR changes the way the amount of desired workers is calculated.
When the total time needed to clear all jobs is zero, it returns the minimum amount of processes, instead of the max amount of processes. When the amount of time needed to clear the jobs increases, processes will automatically scale back up.