### PR TITLE
[4.0] Remove Predis support

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -6,7 +6,7 @@ about: 'Report a general library issue. Please ensure your version is still supp
 - Horizon Version: #.#.#
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
-- Redis Driver & Version: predis/phpredis #.#.#
+- PhpRedis Version: #.#.#
 - Database Driver & Version:
 
 ### Description:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
+        "ext-redis": "*",
         "cakephp/chronos": "^1.0",
         "illuminate/contracts": "^6.0|^7.0",
         "illuminate/queue": "^6.0|^7.0",
@@ -25,12 +26,7 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^4.0|^5.0",
-        "phpunit/phpunit": "^8.0",
-        "predis/predis": "^1.1"
-    },
-    "suggest": {
-        "ext-redis": "Required to use the Redis PHP driver.",
-        "predis/predis": "Required when not using the Redis PHP driver (^1.1)."
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -394,7 +394,7 @@ class RedisJobRepository implements JobRepository
     /**
      * Mark a given job as completed and set it to expire.
      *
-     * @param  \Predis\Pipeline\Pipeline  $pipe
+     * @param  \Redis  $pipe
      * @param  string  $id
      * @param  bool  $failed
      * @return void

--- a/tests/worker.php
+++ b/tests/worker.php
@@ -28,6 +28,7 @@ $appLoader = new class {
 // Configure the application...
 $app = $appLoader->createApplication();
 $app->register(Laravel\Horizon\HorizonServiceProvider::class);
+$app->make('config')->set('database.redis.driver', 'phpredis');
 $app->make('config')->set('queue.default', 'redis');
 
 $worker = new Worker(


### PR DESCRIPTION
This will remove support for Predis as it's not maintained anymore. We've also begun to deprecate Predis support in Laravel itself.
