### PR TITLE
[3.0] Fix problem with too large payloads

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -23,6 +23,7 @@ class Controller extends BaseController
         return $collection->transform(function ($item, $key) {
             $item->payload->data = [];
             $item->exception = [];
+
             return $item;
         });
     }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -8,7 +8,6 @@ use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
-    protected $heavyFialds = ['payload', 'exception'];
     /**
      * Create a new controller instance.
      *
@@ -22,9 +21,8 @@ class Controller extends BaseController
     protected function filterHeavyFields(Collection $collection)
     {
         return $collection->transform(function ($item, $key) {
-            foreach ($this->heavyFialds as $field) {
-                $item->{$field} = json_encode([]);
-            }
+            $item->payload->data = [];
+            $item->exception = [];
             return $item;
         });
     }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -2,11 +2,13 @@
 
 namespace Laravel\Horizon\Http\Controllers;
 
+use Illuminate\Support\Collection;
 use Laravel\Horizon\Http\Middleware\Authenticate;
 use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
+    protected $heavyFialds = ['payload', 'exception'];
     /**
      * Create a new controller instance.
      *
@@ -15,5 +17,15 @@ class Controller extends BaseController
     public function __construct()
     {
         $this->middleware(Authenticate::class);
+    }
+
+    protected function filterHeavyFields(Collection $collection)
+    {
+        return $collection->transform(function ($item, $key) {
+            foreach ($this->heavyFialds as $field) {
+                $item->{$field} = json_encode([]);
+            }
+            return $item;
+        });
     }
 }

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -48,7 +48,7 @@ class FailedJobsController extends Controller
         $jobs = ! $request->query('tag')
                 ? $this->paginate($request)
                 : $this->paginateByTag($request, $request->query('tag'));
-        
+
         $total = $request->query('tag')
                 ? $this->tags->count('failed:'.$request->query('tag'))
                 : $this->jobs->countFailed();

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -48,13 +48,13 @@ class FailedJobsController extends Controller
         $jobs = ! $request->query('tag')
                 ? $this->paginate($request)
                 : $this->paginateByTag($request, $request->query('tag'));
-
+        
         $total = $request->query('tag')
                 ? $this->tags->count('failed:'.$request->query('tag'))
                 : $this->jobs->countFailed();
 
         return [
-            'jobs' => $jobs,
+            'jobs' => $this->filterHeavyFields($jobs),
             'total' => $total,
         ];
     }

--- a/src/Http/Controllers/RecentJobsController.php
+++ b/src/Http/Controllers/RecentJobsController.php
@@ -42,7 +42,7 @@ class RecentJobsController extends Controller
         })->values();
 
         return [
-            'jobs' => $jobs,
+            'jobs' => $this->filterHeavyFields($jobs),
             'total' => $this->jobs->countRecent(),
         ];
     }


### PR DESCRIPTION
Hi!
I would like to propose a solution for issue with unnecessary loading of jobs payload and exception description on the reports pages [issue 1](https://github.com/laravel/horizon/issues/192) , [issue 2](https://github.com/laravel/horizon/pull/191). In case with a timeout of 3 seconds between requests and a payload of 10MB, jobs request do not have enough time to be executed, which leads to accumulation of requests and freeze the application. The option to reduce jobs payload is not always suitable. My suggestion is to remove data from "heavy" fields such as `payload->data` and `exception` on the report pages, where they are don`t even uses. This change is safe because it does not affect the rest of the Horizon functionality.