### PR TITLE
Fix pagination for recent jobs

### DIFF
--- a/src/Http/Controllers/RecentJobsController.php
+++ b/src/Http/Controllers/RecentJobsController.php
@@ -49,7 +49,7 @@ class RecentJobsController extends Controller
                 ? $this->paginate($request)
                 : $this->paginateByTag($request, $request->query('tag'));
 
-        $total = ! $request->query('tag')
+        $total = $request->query('tag')
                  ? $this->tags->count('recent:'.$request->query('tag'))
                  : $this->jobs->countRecent();
 


### PR DESCRIPTION
This fixes a bug that was introduced by #665, where the next/previous pagination buttons were not working on the recent jobs page.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
