### PR TITLE
[3.x] Add Horizon FlushCommand

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -22,7 +22,7 @@ class FlushCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Flush out all data for the Horizon Redis connection';
+    protected $description = 'Flush out all the Horizon meta information for the dashboard.';
 
     /**
      * Execute the console command.

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+
+class FlushCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:flush';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flush out all data for the Horizon Redis connection';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Contracts\Redis\Factory  $redis
+     * @return void
+     */
+    public function handle(RedisFactory $redis)
+    {
+        $redis->connection('horizon')->flushdb();
+    }
+}

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -32,6 +32,10 @@ class FlushCommand extends Command
      */
     public function handle(RedisFactory $redis)
     {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
         $redis->connection('horizon')->flushdb();
     }
 }

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -173,6 +173,7 @@ class HorizonServiceProvider extends ServiceProvider
             $this->commands([
                 Console\InstallCommand::class,
                 Console\AssetsCommand::class,
+                Console\FlushCommand::class,
                 Console\HorizonCommand::class,
                 Console\ListCommand::class,
                 Console\PurgeCommand::class,


### PR DESCRIPTION
This adds a new Horizon FlushCommand which will clear the meta data of Horizon from its Redis connection. Kudos to @freekmurze for the inspiration.
