### PR TITLE
[3.x] Prevent 'memory exhausted' when deleting monitored tag

### DIFF
--- a/src/Jobs/StopMonitoringTag.php
+++ b/src/Jobs/StopMonitoringTag.php
@@ -41,7 +41,8 @@ class StopMonitoringTag
         while (count($tagJobs) !== 0) {
             $jobs->deleteMonitored($tagJobs);
 
-            $tagJobs = $tags->paginate($this->tag);
+            $offset = array_keys($tagJobs)[count($tagJobs) - 1] + 1;
+            $tagJobs = $tags->paginate($this->tag, $offset);
         }
 
         $tags->forget($this->tag);

--- a/src/Jobs/StopMonitoringTag.php
+++ b/src/Jobs/StopMonitoringTag.php
@@ -36,7 +36,13 @@ class StopMonitoringTag
     {
         $tags->stopMonitoring($this->tag);
 
-        $jobs->deleteMonitored($tags->jobs($this->tag));
+        $tagJobs = $tags->paginate($this->tag);
+
+        while (count($tagJobs) !== 0) {
+            $jobs->deleteMonitored($tagJobs);
+
+            $tagJobs = $tags->paginate($this->tag);
+        }
 
         $tags->forget($this->tag);
     }


### PR DESCRIPTION
Fixes #625.

**What?**

When you monitor a tag and a lot of jobs are attached to tag, you will get a 'memory exhausted' php error when you remove the tag from monitoring list. This is caused by fetching all jobs of that tag in one query (in order to delete them all).

**How?**

Instead of fetching all jobs of the tag in one query, I used the `paginate()` method that is already present in `TagRepository`. By fetching and deleting small batches of jobs we will keep the php memory usage low at all times.

_By default the pagination has a limit of 25 per page. Maybe we should use a limit that's a bit higher in this case (50, 100, ...)?_ 