### PR TITLE
[3.x] Support for viewing full recent job details

### DIFF
--- a/resources/js/routes.js
+++ b/resources/js/routes.js
@@ -64,6 +64,12 @@ export default [
     },
 
     {
+        path: '/recent-jobs/:jobId',
+        name: 'recent-jobs-preview',
+        component: require('./screens/recentJobs/job').default,
+    },
+
+    {
         path: '/failed',
         name: 'failed-jobs',
         component: require('./screens/failedJobs/index').default,

--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -182,8 +182,10 @@
 
                 <tr v-for="job in jobs" :key="job.id">
                     <td>
-                        <span v-if="job.status != 'failed'" :title="job.name">{{jobBaseName(job.name)}}</span>
-                        <router-link v-if="job.status === 'failed'" :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.id }}">
+                        <router-link v-if="job.status !== 'failed'" :title="job.name" :to="{ name: 'recent-jobs-preview', params: { jobId: job.id }}">
+                            {{ jobBaseName(job.name) }}
+                        </router-link>
+                        <router-link v-else :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.id }}">
                             {{ jobBaseName(job.name) }}
                         </router-link><br>
 

--- a/resources/js/screens/recentJobs/job.vue
+++ b/resources/js/screens/recentJobs/job.vue
@@ -1,0 +1,108 @@
+<script type="text/ecmascript-6">
+    import phpunserialize from 'phpunserialize'
+
+    export default {
+
+        /**
+         * The component's data.
+         */
+        data() {
+            return {
+                ready: false,
+                job: {}
+            };
+        },
+
+
+        /**
+         * Prepare the component.
+         */
+        mounted() {
+            this.loadJob(this.$route.params.jobId);
+
+            document.title = `Horizon - Job ${this.$route.params.jobId} details`;
+        },
+
+
+        methods: {
+            loadJob(id) {
+                this.ready = false;
+
+                this.$http.get('/' + Horizon.path + '/api/jobs/recent/' + id)
+                    .then(response => {
+                        this.job = response.data;
+
+                        this.ready = true;
+                    });
+            },
+
+
+            /**
+             * Pretty print serialized job.
+             *
+             * @param data
+             * @returns {string}
+             */
+            prettyPrintJob(data) {
+                return data.command ? phpunserialize(data.command) : data;
+            }
+        }
+    }
+</script>
+
+<template>
+    <div>
+        <div class="card">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h5 v-if="!ready">Job Preview</h5>
+                <h5 v-if="ready">{{job.name}}</h5>
+            </div>
+
+            <div v-if="!ready" class="d-flex align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon spin mr-2 fill-text-color">
+                    <path d="M12 10a2 2 0 0 1-3.41 1.41A2 2 0 0 1 10 8V0a9.97 9.97 0 0 1 10 10h-8zm7.9 1.41A10 10 0 1 1 8.59.1v2.03a8 8 0 1 0 9.29 9.29h2.02zm-4.07 0a6 6 0 1 1-7.25-7.25v2.1a3.99 3.99 0 0 0-1.4 6.57 4 4 0 0 0 6.56-1.42h2.1z"></path>
+                </svg>
+
+                <span>Loading...</span>
+            </div>
+
+            <div class="card-body card-bg-secondary" v-if="ready">
+                <div class="row mb-2">
+                    <div class="col-md-2"><strong>ID</strong></div>
+                    <div class="col">{{job.id}}</div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-md-2"><strong>Queue</strong></div>
+                    <div class="col">{{job.queue}}</div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-md-2"><strong>Status</strong></div>
+                    <div class="col">{{job.status}}</div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-md-2"><strong>Tags</strong></div>
+                    <div class="col">{{ job.payload.tags && job.payload.tags.length ? job.payload.tags.join(', ') : '' }}</div>
+                </div>
+                <div class="row mb-2" v-if="job.reserved_at">
+                    <div class="col-md-2"><strong>Reserved At</strong></div>
+                    <div class="col">{{readableTimestamp(job.reserved_at)}}</div>
+                </div>
+                <div class="row" v-if="job.completed_at">
+                    <div class="col-md-2"><strong>Completed At</strong></div>
+                    <div class="col">{{readableTimestamp(job.completed_at)}}</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card mt-4" v-if="ready">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h5>Data</h5>
+            </div>
+
+            <div class="card-body code-bg text-white">
+                <vue-json-pretty :data="prettyPrintJob(job.payload.data)"></vue-json-pretty>
+            </div>
+        </div>
+
+    </div>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::prefix('api')->group(function () {
 
     // Job Routes...
     Route::get('/jobs/recent', 'RecentJobsController@index')->name('horizon.recent-jobs.index');
+    Route::get('/jobs/recent/{id}', 'RecentJobsController@show')->name('horizon.recent-jobs.show');
     Route::get('/jobs/failed', 'FailedJobsController@index')->name('horizon.failed-jobs.index');
     Route::get('/jobs/failed/{id}', 'FailedJobsController@show')->name('horizon.failed-jobs.show');
     Route::post('/jobs/retry/{id}', 'RetryController@store')->name('horizon.retry-jobs.show');

--- a/src/Http/Controllers/RecentJobsController.php
+++ b/src/Http/Controllers/RecentJobsController.php
@@ -93,6 +93,19 @@ class RecentJobsController extends Controller
     }
 
     /**
+     * Get a recent job instance.
+     *
+     * @param  string  $id
+     * @return mixed
+     */
+    public function show($id)
+    {
+        return (array) $this->jobs->getJobs([$id])->map(function ($job) {
+            return $this->decode($job);
+        })->first();
+    }
+
+    /**
      * Decode the given job.
      *
      * @param  object  $job


### PR DESCRIPTION
This PR adds a new `recent-jobs-preview` Vue component and associated routes for viewing full details of any queued, reserved or completed job.

Failed jobs will continue to use the old `failed-jobs-preview` view as before.

There is some argument to be made for combining these views into a single component, but I believe their functionality is probably different enough to warrant separate components.

Fixes #143 
