### PR TITLE
[3.x] Fix webpack config to use terser

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,8 +13,8 @@ const webpack = require('webpack');
  */
 
 mix.options({
-    uglify: {
-        uglifyOptions: {
+    terser: {
+        terserOptions: {
             compress: {
                 drop_console: true,
             },


### PR DESCRIPTION
Hi,

Laravel mix v4.0+ is using terser js, it is instructed to update the config, see release docs
https://github.com/JeffreyWay/laravel-mix/releases?after=v4.0.6