### PR TITLE
[3.x] Prevent 'memory exhausted' when deleting monitored tag

### DIFF
--- a/src/Jobs/StopMonitoringTag.php
+++ b/src/Jobs/StopMonitoringTag.php
@@ -41,7 +41,8 @@ class StopMonitoringTag
         while (count($tagJobs) !== 0) {
             $jobs->deleteMonitored($tagJobs);
 
-            $tagJobs = $tags->paginate($this->tag);
+            $offset = array_keys($tagJobs)[count($tagJobs) - 1] + 1;
+            $tagJobs = $tags->paginate($this->tag, $offset);
         }
 
         $tags->forget($this->tag);

--- a/src/Jobs/StopMonitoringTag.php
+++ b/src/Jobs/StopMonitoringTag.php
@@ -36,7 +36,13 @@ class StopMonitoringTag
     {
         $tags->stopMonitoring($this->tag);
 
-        $jobs->deleteMonitored($tags->jobs($this->tag));
+        $tagJobs = $tags->paginate($this->tag);
+
+        while (count($tagJobs) !== 0) {
+            $jobs->deleteMonitored($tagJobs);
+
+            $tagJobs = $tags->paginate($this->tag);
+        }
 
         $tags->forget($this->tag);
     }

--- a/tests/Feature/MonitoringTest.php
+++ b/tests/Feature/MonitoringTest.php
@@ -64,4 +64,18 @@ class MonitoringTest extends IntegrationTest
         dispatch(new StopMonitoringTag('first'));
         $this->assertEquals(0, $this->monitoredJobs('first'));
     }
+
+    public function test_all_completed_jobs_are_removed_from_database_when_their_tag_is_no_longer_monitored()
+    {
+        dispatch(new MonitorTag('first'));
+
+        for ($i = 0; $i < 80; $i++) {
+            Queue::push(new Jobs\BasicJob);
+        }
+
+        $this->work();
+
+        dispatch(new StopMonitoringTag('first'));
+        $this->assertEquals(0, $this->monitoredJobs('first'));
+    }
 }


### PR DESCRIPTION
Fixes #625.
Same PR as #682, but with test.

**What?**

When you monitor a tag and a lot of jobs are attached to tag, you will get a 'memory exhausted' php error when you remove the tag from monitoring list. This is caused by fetching all jobs of that tag in one query (in order to delete them all).

**How?**

Instead of fetching all jobs of the tag in one query, I used the `paginate()` method that is already present in `TagRepository`. By fetching and deleting small batches of jobs we will keep the php memory usage low at all times.