### PR TITLE
New "Back to Site" link in the Horizon sidebar, controlled via config

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -56,6 +56,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Horizon Site Link
+    |--------------------------------------------------------------------------
+    |
+    | The URL set here will enable a new point in the sidebar of the Horizon
+    | dashboard which allows you to go back to your site, without having to
+    | modify the URL in the browsers' address bar or clicking back a few times.
+    |
+    */
+
+    'site_link' => url('/'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Horizon Route Middleware
     |--------------------------------------------------------------------------
     |

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -40,8 +40,18 @@
         <div class="row mt-4">
             <div class="col-2 sidebar">
                 <ul class="nav flex-column">
+                    @if(config('horizon.site_link'))
+                        <li class="nav-item">
+                            <a href="{{ config('horizon.site_link') }}" class="nav-link d-flex align-items-center pt-0">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                    <path d="M4.5 10l11-8v16z"/>
+                                </svg>
+                                <span>Back to Site</span>
+                            </a>
+                        </li>
+                    @endif
                     <li class="nav-item">
-                        <router-link active-class="active" to="/dashboard" class="nav-link d-flex align-items-center pt-0">
+                        <router-link active-class="active" to="/dashboard" class="nav-link d-flex align-items-center {{ config('horizon.site_link') ? '' : 'pt-0' }}">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                 <path d="M0 3c0-1.1.9-2 2-2h16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3zm2 2v12h16V5H2zm8 3l4 5H6l4-5z"></path>
                             </svg>


### PR DESCRIPTION
Adds a config option to display a link on the Horizon dashboard. This link may contain any site url, e.g. to the admin panel or just the front page, to allow the user to quickly return to their site from the Horizon dashboard without manually editing the URL in the browsers' address bar, or clicking back a few times. The link is only displayed if the corresponding config option is present and valid.
This is just a small change, but would have saved me some minutes already.

I used the arrow from the dashboard icon for the new link as I'm not sure which icon should be used instead.
If the link should be hidden by default I can update the config to be null and add a proper example to the description, if this is preferred. I may also move it to the bottom.

Preview:
![Screenshot 2019-10-20 at 16 24 53](https://user-images.githubusercontent.com/1816101/67160960-339a5480-f356-11e9-811c-ea2ab4853002.jpg)

Hope this get merged. 😊 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
