### PR TITLE
[3.x] Set same ttl for tags as same as recent jobs

### DIFF
--- a/src/Listeners/StoreTagsForRecentJob.php
+++ b/src/Listeners/StoreTagsForRecentJob.php
@@ -38,7 +38,7 @@ class StoreTagsForRecentJob
         })->all();
 
         $this->tags->addTemporary(
-            config('horizon.trim.recent_failed', config('horizon.trim.recent', 60)),
+            config('horizon.trim.recent', 60),
             $event->payload->id(),
             $tags
         );


### PR DESCRIPTION
After introducing **Filter recent jobs by tag** feature in PR #665, my Redis storage size started increasing gradually. When I started analysing the keyspace usage, I found out 70-75% of my Redis memory is occupied by recent tags.

My horizon trim configuration is

```php
'trim' => [
    'recent' => 15,
    'recent_failed' => 10080,
    'failed' => 10080,
    'monitored' => 10080,
],
```

Based on the above configuration my recent jobs are cleared after **15 minutes**, but recent tags will be cleared only after **7 days**.

My PR will set TTL for recent tags as same as recent jobs.
