### PR TITLE
[3.0] Rename asset command to publish

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -4,21 +4,21 @@ namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
 
-class AssetsCommand extends Command
+class PublishCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'horizon:assets';
+    protected $signature = 'horizon:publish';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Re-publish the Horizon assets';
+    protected $description = 'Publish all of the Horizon resources';
 
     /**
      * Execute the console command.

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -171,13 +171,13 @@ class HorizonServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                Console\InstallCommand::class,
-                Console\AssetsCommand::class,
-                Console\HorizonCommand::class,
-                Console\ListCommand::class,
-                Console\PurgeCommand::class,
-                Console\PauseCommand::class,
                 Console\ContinueCommand::class,
+                Console\HorizonCommand::class,
+                Console\InstallCommand::class,
+                Console\ListCommand::class,
+                Console\PauseCommand::class,
+                Console\PublishCommand::class,
+                Console\PurgeCommand::class,
                 Console\StatusCommand::class,
                 Console\SupervisorCommand::class,
                 Console\SupervisorsCommand::class,


### PR DESCRIPTION
I noticed that Horizon is the odd one out when it comes to the naming the command to re-publish assets.

```
roomies git:(master) ✗ php artisan | grep publish
  horizon:assets       Re-publish the Horizon assets
  nova:publish         Publish all of the Nova resources
  telescope:publish    Publish all of the Telescope resources
  vendor:publish       Publish any publishable assets from vendor packages
```

This simply updates the command to match - `horizon:publish`.

In addition it adjusts the order of commands in the service provider - the bottom half appeared to be alphabetical but the top half was not, so I made it all alphabetical.