### PR TITLE
[4.x] Rename asset command

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -4,21 +4,21 @@ namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
 
-class AssetsCommand extends Command
+class PublishCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'horizon:assets';
+    protected $signature = 'horizon:publish';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Re-publish the Horizon assets';
+    protected $description = 'Publish all of the Horizon resources';
 
     /**
      * Execute the console command.

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -171,13 +171,13 @@ class HorizonServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                Console\InstallCommand::class,
-                Console\AssetsCommand::class,
-                Console\HorizonCommand::class,
-                Console\ListCommand::class,
-                Console\PurgeCommand::class,
-                Console\PauseCommand::class,
                 Console\ContinueCommand::class,
+                Console\HorizonCommand::class,
+                Console\InstallCommand::class,
+                Console\ListCommand::class,
+                Console\PauseCommand::class,
+                Console\PublishCommand::class,
+                Console\PurgeCommand::class,
                 Console\StatusCommand::class,
                 Console\SupervisorCommand::class,
                 Console\SupervisorsCommand::class,


### PR DESCRIPTION
Following up on #694 this makes the same command name change against master.

```sh
roomies git:(master) ✗ php artisan | grep publish
  horizon:assets       Re-publish the Horizon assets
  nova:publish         Publish all of the Nova resources
  telescope:publish    Publish all of the Telescope resources
  vendor:publish       Publish any publishable assets from vendor packages
```

It means all the first-party packages will have a consistent publish command.