### PR TITLE
[3.0] set default 'tries' to 1

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -146,7 +146,7 @@ return [
                 'queue' => ['default'],
                 'balance' => 'simple',
                 'processes' => 10,
-                'tries' => 3,
+                'tries' => 1,
             ],
         ],
 
@@ -156,7 +156,7 @@ return [
                 'queue' => ['default'],
                 'balance' => 'simple',
                 'processes' => 3,
-                'tries' => 3,
+                'tries' => 1,
             ],
         ],
     ],


### PR DESCRIPTION
trying a Job more than 1 time can have unintended side effects, and for the less experienced developer, defaulting to 3 tries could cause problems.

my opinion would be that we default to 1 try, and allow the developer who understands the considerations for running a Job multiple times to increase this if they like.

### Scenario

```php
class PlaceOrder implement ShouldQueue
{
    public $tries = 3;

    public function __construct(array $products)
    {
        $this->products = $products;
    }

    public function handle()
    {
        //create the Order
        $order = new Order;
        $order->product = $this->products;
        $order->save();

        //do something that could generate an Exception
    }
}
```

If an Exception is generated, the Job will fail and retry. However, the Order has already been created and saved, and it will do so again on the following try, possibly resulting in 3 Orders when there should have only been one.

