### PR TITLE
Add Symfony 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0",
         "predis/predis": "^1.1",
         "ramsey/uuid": "^3.5",
-        "symfony/process": "^4.2",
-        "symfony/debug": "^4.2"
+        "symfony/process": "^5.0",
+        "symfony/error-handler": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -15,7 +15,7 @@ use Laravel\Horizon\Contracts\Restartable;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\Terminable;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Throwable;
 
 class MasterSupervisor implements Pausable, Restartable, Terminable
@@ -249,7 +249,7 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
         } catch (Exception $e) {
             app(ExceptionHandler::class)->report($e);
         } catch (Throwable $e) {
-            app(ExceptionHandler::class)->report(new FatalThrowableError($e));
+            app(ExceptionHandler::class)->report(new FlattenException($e));
         }
     }
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -13,7 +13,7 @@ use Laravel\Horizon\Contracts\Restartable;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\Terminable;
 use Laravel\Horizon\Events\SupervisorLooped;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Throwable;
 
 class Supervisor implements Pausable, Restartable, Terminable
@@ -311,7 +311,7 @@ class Supervisor implements Pausable, Restartable, Terminable
         } catch (Exception $e) {
             app(ExceptionHandler::class)->report($e);
         } catch (Throwable $e) {
-            app(ExceptionHandler::class)->report(new FatalThrowableError($e));
+            app(ExceptionHandler::class)->report(new FlattenException($e));
         }
     }
 


### PR DESCRIPTION
Add Symfony 5 support for the following components : 
- `symfony/process`
- `symfony/debug` => `symfony/error-handler`

#SymfonyHackday