### PR TITLE
[4.x] Update to Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,10 @@ php:
 
 env:
   matrix:
-    - LARAVEL=^6.0
     - LARAVEL=^7.0
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: LARAVEL=^7.0
 
 before_install:
   - phpenv config-rm xdebug.ini || true

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "illuminate/queue": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0",
         "ramsey/uuid": "^3.5",
-        "symfony/process": "^4.3",
-        "symfony/debug": "^4.3"
+        "symfony/process": "^5.0",
+        "symfony/error-handler": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
         "ext-pcntl": "*",
         "ext-posix": "*",
         "cakephp/chronos": "^1.0",
-        "illuminate/contracts": "^6.0|^7.0",
-        "illuminate/queue": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0",
+        "illuminate/contracts": "^7.0",
+        "illuminate/queue": "^7.0",
+        "illuminate/support": "^7.0",
         "ramsey/uuid": "^3.5",
         "symfony/process": "^5.0",
         "symfony/error-handler": "^5.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^4.0|^5.0",
+        "orchestra/testbench": "^5.0",
         "phpunit/phpunit": "^8.0",
         "predis/predis": "^1.1"
     },

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,13 +3,10 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Support\Str;
 
 class InstallCommand extends Command
 {
-    use DetectsApplicationNamespace;
-
     /**
      * The name and signature of the console command.
      *
@@ -52,7 +49,7 @@ class InstallCommand extends Command
      */
     protected function registerHorizonServiceProvider()
     {
-        $namespace = Str::replaceLast('\\', '', $this->getAppNamespace());
+        $namespace = Str::replaceLast('\\', '', $this->laravel->getNamespace());
 
         $appConfig = file_get_contents(config_path('app.php'));
 

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -15,7 +15,6 @@ use Laravel\Horizon\Contracts\Restartable;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\Terminable;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 
 class MasterSupervisor implements Pausable, Restartable, Terminable
@@ -246,10 +245,8 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
             $this->persist();
 
             event(new MasterSupervisorLooped($this));
-        } catch (Exception $e) {
-            app(ExceptionHandler::class)->report($e);
         } catch (Throwable $e) {
-            app(ExceptionHandler::class)->report(new FatalThrowableError($e));
+            app(ExceptionHandler::class)->report($e);
         }
     }
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -13,7 +13,6 @@ use Laravel\Horizon\Contracts\Restartable;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\Terminable;
 use Laravel\Horizon\Events\SupervisorLooped;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 
 class Supervisor implements Pausable, Restartable, Terminable
@@ -308,10 +307,8 @@ class Supervisor implements Pausable, Restartable, Terminable
             $this->persist();
 
             event(new SupervisorLooped($this));
-        } catch (Exception $e) {
-            app(ExceptionHandler::class)->report($e);
         } catch (Throwable $e) {
-            app(ExceptionHandler::class)->report(new FatalThrowableError($e));
+            app(ExceptionHandler::class)->report($e);
         }
     }
 


### PR DESCRIPTION
Updates the components to Symfony 5. Because the debug component is swapped, we'll need to make Symfony 5 the new minimum version and we'll need to drop support for Laravel 6.x.

WIP until the follow pr on testbench is merged: https://github.com/orchestral/testbench-core/pull/32