### PR TITLE
[3.x] Scale to the maxProcesses if timeToClearAll is zero

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -81,7 +81,7 @@ class AutoScaler
 
             return [$queue => [
                 'size' => $size,
-                'time' =>  ($size * $this->metrics->runtimeForQueue($queue))
+                'time' =>  ($size * $this->metrics->runtimeForQueue($queue)),
             ]];
         });
     }
@@ -105,7 +105,7 @@ class AutoScaler
                       $supervisor->options->autoScaling()) {
                 return [
                     $queue =>  $timeToClear['size'] ?
-                        $supervisor->options->maxProcesses : $supervisor->options->minProcesses
+                        $supervisor->options->maxProcesses : $supervisor->options->minProcesses,
                 ];
             }
 

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -79,7 +79,10 @@ class AutoScaler
         return $pools->mapWithKeys(function ($pool, $queue) use ($supervisor) {
             $size = $this->queue->connection($supervisor->options->connection)->readyNow($queue);
 
-            return [$queue => ($size * $this->metrics->runtimeForQueue($queue))];
+            return [$queue => [
+                'size' => $size,
+                'time' =>  ($size * $this->metrics->runtimeForQueue($queue))
+            ]];
         });
     }
 
@@ -87,20 +90,23 @@ class AutoScaler
      * Get the number of workers needed per queue for proper balance.
      *
      * @param  \Laravel\Horizon\Supervisor  $supervisor
-     * @param  \Illuminate\Support\Collection  $timeToClear
+     * @param  \Illuminate\Support\Collection  $queues
      * @return \Illuminate\Support\Collection
      */
-    protected function numberOfWorkersPerQueue(Supervisor $supervisor, Collection $timeToClear)
+    protected function numberOfWorkersPerQueue(Supervisor $supervisor, Collection $queues)
     {
-        $timeToClearAll = $timeToClear->sum();
+        $timeToClearAll = $queues->sum('time');
 
-        return $timeToClear->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll) {
+        return $queues->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll) {
             if ($timeToClearAll > 0 &&
                 $supervisor->options->autoScaling()) {
-                return [$queue => (($timeToClear / $timeToClearAll) * $supervisor->options->maxProcesses)];
+                return [$queue => (($timeToClear['time'] / $timeToClearAll) * $supervisor->options->maxProcesses)];
             } elseif ($timeToClearAll == 0 &&
                       $supervisor->options->autoScaling()) {
-                return [$queue => $supervisor->options->minProcesses];
+                return [
+                    $queue =>  $timeToClear['size'] ?
+                        $supervisor->options->maxProcesses : $supervisor->options->minProcesses
+                ];
             }
 
             return [$queue => $supervisor->options->maxProcesses / count($supervisor->processPools)];


### PR DESCRIPTION
Ref: https://github.com/laravel/horizon/issues/667

When you first start Horizon, before finishing any jobs, the `timeToClearAll` will be equal to zero. This will make Horizon scale down to the `minProcesses` set on the supervisor.

Once your first job finishes, `timeToClearAll` will start having values that the auto scaler can use to decide if it should scale up or down.

The problem is that before finishing any jobs, even if you have 10 jobs waiting, Horizon will scale down to `minProcesses` because `timeToClearAll` is still zero.

This PR changes the behaviour by checking if there are any jobs waiting and only scale down if there aren't any.