### PR TITLE
[3.x] Allow trimming completed jobs

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -95,6 +95,7 @@ return [
 
     'trim' => [
         'recent' => 60,
+        'completed' => 60,
         'recent_failed' => 10080,
         'failed' => 10080,
         'monitored' => 10080,

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -43,6 +43,13 @@ class RedisJobRepository implements JobRepository
     public $recentJobExpires;
 
     /**
+     * The number of minutes until completed jobs should be purged.
+     *
+     * @var int
+     */
+    public $recentCompletedExpires;
+
+    /**
      * The number of minutes until failed jobs should be purged.
      *
      * @var int
@@ -66,6 +73,7 @@ class RedisJobRepository implements JobRepository
     {
         $this->redis = $redis;
         $this->recentJobExpires = config('horizon.trim.recent', 60);
+        $this->recentCompletedExpires = config('horizon.trim.completed', 60);
         $this->failedJobExpires = config('horizon.trim.failed', 10080);
         $this->recentFailedJobExpires = config('horizon.trim.recent_failed', $this->failedJobExpires);
         $this->monitoredJobExpires = config('horizon.trim.monitored', 10080);
@@ -403,7 +411,7 @@ class RedisJobRepository implements JobRepository
             ? $pipe->hmset($id, ['status' => 'failed'])
             : $pipe->hmset($id, ['status' => 'completed', 'completed_at' => str_replace(',', '.', microtime(true))]);
 
-        $pipe->expireat($id, Chronos::now()->addMinutes($this->recentJobExpires)->getTimestamp());
+        $pipe->expireat($id, Chronos::now()->addMinutes($this->recentCompletedExpires)->getTimestamp());
     }
 
     /**


### PR DESCRIPTION
High memory consumption was reported in https://github.com/laravel/horizon/issues/715. Between v3.2.2 and the most recent version, I couldn't locate a change that may cause this.

However, the proposed solution in the issue seems useful. Basically, this PR adds the ability to purge completed jobs separately, so for example you may keep your recent jobs fo 60 minutes, failed jobs for 7 days, but purge completed jobs every 5 minutes.

One side effect of this change is that the list of recent jobs may include a lot of completed jobs that were purged but still exist in the `recent_jobs` set and thus paginated results will look strange.

One thing we can do is to have a separate list for:

- Pending Jobs
- Completed Jobs
- Failed jobs

