### PR TITLE
Fix php 7.4 tagged model typed props

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -121,14 +121,11 @@ class Tags
         return collect($models)->collapse()->unique();
     }
 
-    /**
-     * @return mixed|null
-     */
     protected static function getValue(ReflectionProperty $property, $target)
     {
         if (method_exists($property, 'isInitialized')) {
             if (! $property->isInitialized($target)) {
-                return null;
+                return;
             }
         }
 

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -124,7 +124,7 @@ class Tags
     protected static function getValue(ReflectionProperty $property, $target)
     {
         if (method_exists($property, 'isInitialized')) {
-            if(! $property->isInitialized($target)) {
+            if (! $property->isInitialized($target)) {
                 return null;
             }
         }

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -9,6 +9,7 @@ use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Notifications\SendQueuedNotifications;
 use ReflectionClass;
+use ReflectionProperty;
 use stdClass;
 
 class Tags
@@ -107,7 +108,7 @@ class Tags
             $models[] = collect((new ReflectionClass($target))->getProperties())->map(function ($property) use ($target) {
                 $property->setAccessible(true);
 
-                $value = $property->getValue($target);
+                $value = static::getValue($property, $target);
 
                 if ($value instanceof Model) {
                     return [$value];
@@ -118,6 +119,17 @@ class Tags
         }
 
         return collect($models)->collapse()->unique();
+    }
+
+    protected static function getValue(ReflectionProperty $property, $target)
+    {
+        if (method_exists($property, 'isInitialized')) {
+            if(!$property->isInitialized($target)) {
+                return null;
+            }
+        }
+
+        return $property->getValue($target);
     }
 
     /**

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -121,6 +121,9 @@ class Tags
         return collect($models)->collapse()->unique();
     }
 
+    /**
+     * @return mixed|null
+     */
     protected static function getValue(ReflectionProperty $property, $target)
     {
         if (method_exists($property, 'isInitialized')) {

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -124,7 +124,7 @@ class Tags
     protected static function getValue(ReflectionProperty $property, $target)
     {
         if (method_exists($property, 'isInitialized')) {
-            if(!$property->isInitialized($target)) {
+            if(! $property->isInitialized($target)) {
                 return null;
             }
         }

--- a/tests/Unit/Fixtures/FakeListenerWithProperties.php
+++ b/tests/Unit/Fixtures/FakeListenerWithProperties.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit\Fixtures;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+class FakeListenerWithProperties
+{
+    /**
+     * @var Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * @var FakeEventWithModel
+     */
+    protected $fakeModel;
+
+    public function __construct(Dispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function handle(FakeEventWithModel $fakeEventWithModel): void
+    {
+        $this->fakeModel = $fakeEventWithModel->model;
+    }
+}

--- a/tests/Unit/Fixtures/FakeListenerWithTypedProperties.php
+++ b/tests/Unit/Fixtures/FakeListenerWithTypedProperties.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit\Fixtures;
+
+use Illuminate\Contracts\Events\Dispatcher;
+
+class FakeListenerWithTypedProperties
+{
+    protected Dispatcher $dispatcher;
+
+    protected FakeEventWithModel $fakeModel;
+
+    public function __construct(Dispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function handle(FakeEventWithModel $fakeEventWithModel): void
+    {
+        $this->fakeModel = $fakeEventWithModel->model;
+    }
+}

--- a/tests/Unit/RedisPayloadTest.php
+++ b/tests/Unit/RedisPayloadTest.php
@@ -15,6 +15,7 @@ use Laravel\Horizon\Tests\Unit\Fixtures\FakeJobWithEloquentCollection;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeJobWithEloquentModel;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeJobWithTagsMethod;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeListener;
+use Laravel\Horizon\Tests\Unit\Fixtures\FakeListenerWithProperties;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeModel;
 use Laravel\Horizon\Tests\UnitTest;
 use Mockery;
@@ -92,6 +93,17 @@ class RedisPayloadTest extends UnitTest
         $this->assertEquals([
             'listenerTag1', 'listenerTag2', 'eventTag1', 'eventTag2',
         ], $JobPayload->decoded['tags']);
+    }
+
+    public function test_tags_are_correctly_determined_for_listeners()
+    {
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $job = new CallQueuedListener(FakeListenerWithProperties::class, 'handle', [new FakeEventWithModel(42)]);
+
+        $JobPayload->prepare($job);
+
+        $this->assertEquals([FakeModel::class.':42'], $JobPayload->decoded['tags']);
     }
 
     public function test_listener_and_event_tags_can_merge_auto_tag_events()

--- a/tests/Unit/RedisPayloadTest.php
+++ b/tests/Unit/RedisPayloadTest.php
@@ -16,6 +16,7 @@ use Laravel\Horizon\Tests\Unit\Fixtures\FakeJobWithEloquentModel;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeJobWithTagsMethod;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeListener;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeListenerWithProperties;
+use Laravel\Horizon\Tests\Unit\Fixtures\FakeListenerWithTypedProperties;
 use Laravel\Horizon\Tests\Unit\Fixtures\FakeModel;
 use Laravel\Horizon\Tests\UnitTest;
 use Mockery;
@@ -104,6 +105,20 @@ class RedisPayloadTest extends UnitTest
         $JobPayload->prepare($job);
 
         $this->assertEquals([FakeModel::class.':42'], $JobPayload->decoded['tags']);
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function test_tags_are_correctly_determined_for_listeners_with_property_types()
+    {
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $job = new CallQueuedListener(FakeListenerWithTypedProperties::class, 'handle', [new FakeEventWithModel(21)]);
+
+        $JobPayload->prepare($job);
+
+        $this->assertEquals([FakeModel::class.':21'], $JobPayload->decoded['tags']);
     }
 
     public function test_listener_and_event_tags_can_merge_auto_tag_events()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes #730 

php 7.4 introduced the new [reflection method `isInitialized`][isinit] to check for this exact case.

[isinit]:https://www.php.net/manual/en/reflectionproperty.isinitialized.php