### PR TITLE
[3.x] Trim job IDs from failed job tags

### DIFF
--- a/src/Contracts/TagRepository.php
+++ b/src/Contracts/TagRepository.php
@@ -87,4 +87,12 @@ interface TagRepository
      * @return void
      */
     public function forget($tag);
+
+    /**
+     * Trim the job IDs from the given tags.
+     *
+     * @param  array  $tags
+     * @return void
+     */
+    public function trim(array $tags);
 }

--- a/src/Listeners/StoreTagsForFailedJob.php
+++ b/src/Listeners/StoreTagsForFailedJob.php
@@ -40,5 +40,7 @@ class StoreTagsForFailedJob
         $this->tags->addTemporary(
             2880, $event->payload->id(), $tags
         );
+
+        $this->tags->trim($tags);
     }
 }


### PR DESCRIPTION
In light of #715 and #740, and after reading the insights from @travisaustin, I think I found where the memory hog comes from.

Everytime a job fails, the ID is added to each tag. If there is no other failure in the next 48 hours, the tags expires.  But otherwise, the `StoreTagsForFailedJob` keeps adding job IDs and updates the expiration date, but the previous IDs were **never** removed, which probably causes memory issues.

In this commit we'll remove the job IDs for that are older than 48 hours for each tag, in respect of the TTL in `StoreTagsForFailedJob`.

For example:
- On `2020-01-01 00:00:00` a job with ID of `1` and tagged `App\User:1` fails. The tag `failed:App\User:1` is added with the job ID 1.
- So after 2880 minutes, i.e. on `2020-01-03 00:00:00` the `failed:User:1` tag should expire.
- Meanwhile, on `2020-01-02 00:00:00` another job with ID of `2` and tagged `App\User:1` fails. The ID `2` is added to the `failed:App\User:1` tag, and the expiration of the tag is delayed for 2880 minutes, i.e. `2020-01-04 00:00:00`.
- If there are more failures in the next 2880 minutes, the new IDs will keep getting appended, and the previous IDs are never removed.

Now with this PR:
- If there is a failure on `2020-01-03 00:00:00` for a job with ID of `3`, it will be added as usual to the `failed:App\User:1` tag, along with the existing IDs 1 and 2, but now the score is the precise timestamp that it was added, like in `RedisJobRepository@storeJobReference`.
- Then, it will trim all the job IDs that were added 2880 minutes ago or earlier from this tag, like in `RedisJobRepository@trimFailedJobs`. So the id `1` will be removed.

If this is correct, then we could revert #741 and trim the job IDs from the `recent:` tags each time a job is added, like with the `failed:` tags.