### PR TITLE
[3.x] Pass the queued job to the notification tags function

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -119,7 +119,7 @@ class Tags
         $models = [];
 
         foreach ($targets as $target) {
-            if($target instanceof static::$notificationTagEnvelopeClass) {
+            if(static::$notificationTagEnvelopeClass && $target instanceof static::$notificationTagEnvelopeClass) {
                 $target = $target->job->notification;
             }
             $models[] = collect(

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -91,21 +91,26 @@ class Tags
                 return [
                     static::$notificationTagEnvelopeClass ?
                         new static::$notificationTagEnvelopeClass($job) :
-                        static::$notificationTagEnvelopeClass = new class ($job){
+                        static::$notificationTagEnvelopeClass = new class($job) {
                             public $job;
-                            public function __construct($job){
+
+                            public function __construct($job)
+                            {
                                 $this->job = $job;
                             }
-                            public function tags(){
+
+                            public function tags()
+                            {
                                 return method_exists($this->job->notification, 'tags') ?
                                     $this->job->notification->tags($this->job) : [];
                             }
-                        }
+                        },
                 ];
             default:
                 return [$job];
         }
     }
+
     private static $notificationTagEnvelopeClass;
 
     /**
@@ -119,7 +124,7 @@ class Tags
         $models = [];
 
         foreach ($targets as $target) {
-            if(static::$notificationTagEnvelopeClass && $target instanceof static::$notificationTagEnvelopeClass) {
+            if (static::$notificationTagEnvelopeClass && $target instanceof static::$notificationTagEnvelopeClass) {
                 $target = $target->job->notification;
             }
             $models[] = collect(


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I added an envelope (anonymous class) around SendQueuedNotification jobs in the Tags class, for the purpose of passing the job to the notification when getting tags, so the recipient and channel can be included in tags.

In my application, I'm using this change with this trait I add to my notifications:
```php
<?php

namespace App\Traits;

use App\Models\User;
use Illuminate\Notifications\SendQueuedNotifications;

trait hasNotificationTags
{
    /**
     * @param SendQueuedNotifications $job
     * @return array
     */
    public function tags($job = null){
        if(!empty($job) && $job instanceof SendQueuedNotifications){
            return [
                '#'.(head($job->channels)??'?'),
                ($job->notifiables instanceof User ? 'User:'.$job->notifiables->id : get_class($job->notifiables).':'.$job->notifiables->id??'?'),
            ];
        } else {
            return [];
        }
    }
}
```
Which adds a `User:{id}` and a `#{channel}` tag to the job. I don't actually need the conditionals, afaik. Anyway, there was just no other way to add the channel to the tags except to modify the Tags class.
