### PR TITLE
[3.x] Pass the job-in-queue to the tags() function.

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -41,7 +41,7 @@ class Tags
     {
         return $job instanceof CallQueuedListener
                     ? static::tagsForListener($job)
-                    : static::explicitTags(static::targetsFor($job),$job);
+                    : static::explicitTags(static::targetsFor($job), $job);
     }
 
     /**

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -41,7 +41,7 @@ class Tags
     {
         return $job instanceof CallQueuedListener
                     ? static::tagsForListener($job)
-                    : static::explicitTags(static::targetsFor($job));
+                    : static::explicitTags(static::targetsFor($job),$job);
     }
 
     /**
@@ -62,13 +62,14 @@ class Tags
     /**
      * Determine tags for the given job.
      *
-     * @param  array  $jobs
+     * @param array $jobs
+     * @param $queuedJob
      * @return mixed
      */
-    protected static function explicitTags(array $jobs)
+    protected static function explicitTags(array $jobs, $queuedJob)
     {
-        return collect($jobs)->map(function ($job) {
-            return method_exists($job, 'tags') ? $job->tags() : [];
+        return collect($jobs)->map(function ($job) use ($queuedJob) {
+            return method_exists($job, 'tags') ? $job->tags($queuedJob) : [];
         })->collapse()->unique()->all();
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Primarily for the purpose of adding the notification channel as a tag, pass the actual queued job to the target when calling the tags function. This also allows a Notification to access the Notifiable while generating tags.

Additionally, my apologies for my previous (vastly over-complicated) pull request. Once I took a look at refactoring, this much simpler solution became apparent.
