### PR TITLE
[3.x] Use 'default' connection as a default redis connection

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -127,7 +127,7 @@ class HorizonServiceProvider extends ServiceProvider
             __DIR__.'/../config/horizon.php', 'horizon'
         );
 
-        Horizon::use(config('horizon.use'));
+        Horizon::use(config('horizon.use', 'default'));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR will fix the issue when the `horizon` is used as a dependency on another package. As an example, it was used by @freekmurze (https://github.com/freekmurze) in the https://mailcoach.app/ package, and the installation was stopped because of the value received in the `Laravel\Horizon@use` method was `null` (since I didn't have the `config/horizon.php` file locally).

