### PR TITLE
[3.x] Add 'view details' to tag-jobs screen

### DIFF
--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -175,6 +175,7 @@
                     </router-link><br>
 
                     <small class="text-muted">
+                        <router-link :to="{name: 'recent-jobs-preview', params: {jobId: job.id}}">View detail</router-link> | 
                         Queue: {{job.queue}} | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.join(', ') : '' }}
                     </small>
                 </td>


### PR DESCRIPTION
In addition to the awesome PR #751  we just add the missing view details link to the monitoring tags screen to be able to view details of a monitored job.
