### PR TITLE
Fix delayed message error when time zone is not UTC

### DIFF
--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -68,8 +68,9 @@
             },
 
             delayed() {
-                if (this.unserialized && this.unserialized.delay){
-                    return moment.utc(this.unserialized.delay.date).fromNow(true);
+                if (this.unserialized && this.unserialized.delay) {
+                    return moment.tz(this.unserialized.delay.date, this.unserialized.delay.timezone)
+                        .fromNow(true);
                 }
 
                 return null;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When the delay time is not UTC, the delay information cannot be displayed as the correct time.
I fixed it and it's already in use on my program.

If you can't understand the meaning of the content correctly, please forgive me for my poor English.