### PR TITLE
[4.x] Show warning when manifest is outdated

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -92,6 +92,12 @@
             </div>
 
             <div class="col-10">
+                @if (! $assetsAreCurrent)
+                    <div class="alert alert-warning">
+                        The published Horizon assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan horizon:publish</code>
+                    </div>
+                @endif
+
                 <router-view></router-view>
             </div>
         </div>

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -4,6 +4,8 @@ namespace Laravel\Horizon;
 
 use Closure;
 use Exception;
+use RuntimeException;
+use Illuminate\Support\Facades\File;
 
 class Horizon
 {
@@ -168,5 +170,23 @@ class Horizon
         static::$smsNumber = $number;
 
         return new static;
+    }
+
+    /**
+     * Check if assets are up-to-date.
+     *
+     * @return bool
+     *
+     * @throws \RuntimeException
+     */
+    public static function assetsAreCurrent()
+    {
+        $publishedPath = public_path('vendor/horizon/mix-manifest.json');
+
+        if (! File::exists($publishedPath)) {
+            throw new RuntimeException('The Horizon assets are not published. Please run: php artisan horizon:publish');
+        }
+
+        return File::get($publishedPath) === File::get(__DIR__.'/../public/mix-manifest.json');
     }
 }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -173,7 +173,7 @@ class Horizon
     }
 
     /**
-     * Check if assets are up-to-date.
+     * Determine if Horizon's published assets are up-to-date.
      *
      * @return bool
      *
@@ -184,7 +184,7 @@ class Horizon
         $publishedPath = public_path('vendor/horizon/mix-manifest.json');
 
         if (! File::exists($publishedPath)) {
-            throw new RuntimeException('The Horizon assets are not published. Please run: php artisan horizon:publish');
+            throw new RuntimeException('Horizon assets are not published. Please run: php artisan horizon:publish');
         }
 
         return File::get($publishedPath) === File::get(__DIR__.'/../public/mix-manifest.json');

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -4,8 +4,8 @@ namespace Laravel\Horizon;
 
 use Closure;
 use Exception;
-use RuntimeException;
 use Illuminate\Support\Facades\File;
+use RuntimeException;
 
 class Horizon
 {

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -9,13 +9,14 @@ class HomeController extends Controller
     /**
      * Single page application catch-all route.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
     public function index()
     {
         return view('horizon::layout', [
             'cssFile' => Horizon::$useDarkTheme ? 'app-dark.css' : 'app.css',
             'horizonScriptVariables' => Horizon::scriptVariables(),
+            'assetsAreCurrent' => Horizon::assetsAreCurrent(),
         ]);
     }
 }


### PR DESCRIPTION
This adds a check to the base view to show a warning when the manifest file in the public folder is different from the one in the vendor dir. This prevents broken components or missing updates.

This PR is with the same implementation, title, and descriptions as done by @barryvdh for [Telescope](https://github.com/laravel/telescope/pull/729).

@driesvints I've reviewed the telescope PR and saw in your last reply that you encourage people to try a PR for Horizon to see if @taylorotwell will accept it, so this is it 🙌.
