### PR TITLE
Upgrade to Chronos 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
-        "cakephp/chronos": "^1.0",
+        "cakephp/chronos": "^2.0",
         "illuminate/contracts": "^7.0",
         "illuminate/queue": "^7.0",
         "illuminate/support": "^7.0",


### PR DESCRIPTION
PR bumps [cakephp/chronos](https://github.com/cakephp/chronos) from `^1.0` to `^2.0`.

I've had a lingering composer alert that Chronos is outdated. I went through  Horizon and didn't find any breaking changes aside from `Date and MutableDate now use server default time zone instead of UTC.` which might be noted in the next upgrade guide. Attached is the [changelog](https://github.com/cakephp/chronos/releases):


> # Breaking Changes
> 
> - PHP 7.2 required.
> - Date and MutableDate now use server default time zone instead of UTC. This makes using Date objects easier for time zones that are far away from UTC as Date::today() will not be wrong as often.
> - Additional typehints added to methods.
> - addYears() no longer overflows months. For example adding (new Chronos('2012-02-29'))->addYears(1);Results in 2013-02-28 not 2013-03-01.
> 
> # New Features
> 
> - Strict mode enabled for all files in chronos.
> - Add Chronos\DifferenceFormatterInterface.
> - Chronos::copy() returns a new instance now.
> - Date and MutableDate constructor now allow time zones to be passed in. This allows you to take dates from other time zones. The default time zone is used if not specified.
> - ChronosInterval now supports microseconds.
> - Added addYearsWithOverflow() to retain backwards compatibility with the previous behavior of addYears().
> - Added createFromArray() to ease creating instances from array data.
> 