### PR TITLE
[4.x]  Add metrics options and dark mode config

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -109,6 +109,38 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Metrics
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure how many snapshots should be kept to display in
+    | the metrics graph. You should use this in conjunction with the
+    | `horizon:snapshot` schedule to define how long of a timespan
+    | you want to see in the metrics.
+    |
+    */
+
+    'metrics' => [
+        'trim_snapshots' => [
+            'job' => 24,
+            'queue' => 24,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Theme
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define which theme Horizon should load.
+    |
+    | Supported: "light", "dark"
+    |
+    */
+
+    'theme' => 'light',
+
+    /*
+    |--------------------------------------------------------------------------
     | Fast Termination
     |--------------------------------------------------------------------------
     |

--- a/resources/js/components/LineChart.vue
+++ b/resources/js/components/LineChart.vue
@@ -62,6 +62,6 @@
 
 <template>
     <div style="position: relative;">
-        <canvas ref="canvas" height="70"></canvas>
+        <canvas ref="canvas" height="120"></canvas>
     </div>
 </template>

--- a/resources/js/screens/metrics/preview.vue
+++ b/resources/js/screens/metrics/preview.vue
@@ -57,7 +57,7 @@
             prepareData(data) {
                 return _.chain(data)
                     .map(value => {
-                        value.time = this.formatDate(value.time).format("hh:mmA");
+                        value.time = this.formatDate(value.time).format("MMM-D hh:mmA");
 
                         return value;
                     })
@@ -86,10 +86,11 @@
                             label: label,
                             data: _.map(data, attribute),
                             lineTension: 0,
-                            backgroundColor: 'rgba(235, 243, 249, 0.4)',
-                            pointBackgroundColor: '#3981B4',
-                            borderColor: '#3981B4',
-                            borderWidth: 4,
+                            backgroundColor: 'transparent',
+                            pointBackgroundColor: '#fff',
+                            pointBorderColor: '#7746ec',
+                            borderColor: '#7746ec',
+                            borderWidth: 2,
                         },
                     ],
                 };

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -61,6 +61,11 @@ class Horizon
         'Metrics', 'Locks', 'Processes',
     ];
 
+    public function __construct()
+    {
+        static::$useDarkTheme = config('horizon.theme') === 'dark';
+    }
+
     /**
      * Determine if the given request can access the Horizon dashboard.
      *
@@ -110,11 +115,12 @@ class Horizon
     /**
      * Specifies that Horizon should use the dark theme.
      *
+     * @param  boolean  $on
      * @return static
      */
-    public static function night()
+    public static function night($on = true)
     {
-        static::$useDarkTheme = true;
+        static::$useDarkTheme = $on;
 
         return new static;
     }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -115,7 +115,7 @@ class Horizon
     /**
      * Specifies that Horizon should use the dark theme.
      *
-     * @param  boolean  $on
+     * @param  bool  $on
      * @return static
      */
     public static function night($on = true)

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -274,7 +274,7 @@ class RedisMetricsRepository implements MetricsRepository
         );
 
         $this->connection()->zremrangebyrank(
-            'snapshot:'.$key, 0, -25
+            'snapshot:'.$key, 0, -abs(1 + config('horizon.metrics.trim_snapshots.job', 24))
         );
     }
 
@@ -298,7 +298,7 @@ class RedisMetricsRepository implements MetricsRepository
         );
 
         $this->connection()->zremrangebyrank(
-            'snapshot:'.$key, 0, -25
+            'snapshot:'.$key, 0, -abs(1 + config('horizon.metrics.trim_snapshots.queue', 24))
         );
     }
 


### PR DESCRIPTION
I wanted to have some more control over how the Metrics graphs were shown. It turns out only the last 24 snapshots are saved, so when creating a snapshot every 5 minutes that would result in (just) 2 hours of data. With the new `metrics.trim_snapshots.job` option, you are able to keep an x amount of snapshots, thus increasing the amount of points on the graph and showing you a bigger timespan.

The following screenshots show the new metrics, with about 200 plot points (which is working on my machine without performance impact). Notice changed colors and the new date format.
![dark](https://i.imgur.com/Nb4R5eM.png)
![light](https://i.imgur.com/GcgwOd4.png)

In addition, I added the `'theme' => 'light'` config, because I think this file should be the place to define such options (not in the service provider).

Feedback is very welcome.