### PR TITLE
[4.x] Align design with Pending/Completed jobs screen

### DIFF
--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -171,12 +171,25 @@
                 <td>
                     <router-link :title="job.name" :to="{ name: $route.params.type+'-jobs-preview', params: { jobId: job.id }}">
                         {{ jobBaseName(job.name) }}
-                    </router-link><br>
+                    </router-link>
+
+                    <small class="badge badge-secondary badge-sm"
+                            v-tooltip:top="`Delayed for ${delayed}`"
+                            v-if="delayed && (job.status == 'reserved' || job.status == 'pending')">
+                        Delayed
+                    </small>
+
+                    <br>
 
                     <small class="text-muted">
-                        Queue: {{job.queue}} | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.join(', ') : '' }}
+                        Queue: {{job.queue}}
+
+                        <span v-if="job.payload.tags.length">
+                            | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.slice(0,3).join(', ') : '' }}<span v-if="job.payload.tags.length > 3"> ({{ job.payload.tags.length - 3 }} more)</span>
+                        </span>
                     </small>
-                </td>
+                </td>>
+                
                 <td class="table-fit">
                     {{ readableTimestamp(job.payload.pushedAt) }}
                 </td>

--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -169,13 +169,11 @@
 
             <tr v-for="job in jobs" :key="job.id">
                 <td>
-                    <span v-if="job.status != 'failed'" :title="job.name">{{jobBaseName(job.name)}}</span>
-                    <router-link v-if="job.status === 'failed'" :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.id }}">
+                    <router-link :title="job.name" :to="{ name: $route.params.type+'-jobs-preview', params: { jobId: job.id }}">
                         {{ jobBaseName(job.name) }}
                     </router-link><br>
 
                     <small class="text-muted">
-                        <router-link :to="{name: 'recent-jobs-preview', params: {jobId: job.id}}">View detail</router-link> | 
                         Queue: {{job.queue}} | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.join(', ') : '' }}
                     </small>
                 </td>


### PR DESCRIPTION
With this PR we align the monitoring screen to reflect changes of v4 for completed/pending screen pages.

Currently the view-details doesn't work on monitoring screen as it got changed in between v3->v4.