### PR TITLE
[4.x] Graceful shutdown on SIGTERM also

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -54,11 +54,13 @@ class HorizonCommand extends Command
 
         pcntl_async_signals(true);
 
-        pcntl_signal(SIGINT, function () use ($master) {
+        $termFunc = function () use ($master) {
             $this->line('Shutting down...');
 
             return $master->terminate();
-        });
+        }
+        pcntl_signal(SIGINT, $termFunc);
+        pcntl_signal(SIGTERM, $termFunc);
 
         $master->monitor();
     }

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -58,7 +58,7 @@ class HorizonCommand extends Command
             $this->line('Shutting down...');
 
             return $master->terminate();
-        }
+        };
         pcntl_signal(SIGINT, $termFunc);
         pcntl_signal(SIGTERM, $termFunc);
 

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -54,13 +54,14 @@ class HorizonCommand extends Command
 
         pcntl_async_signals(true);
 
-        $termFunc = function () use ($master) {
+        $terminate = function () use ($master) {
             $this->line('Shutting down...');
 
             return $master->terminate();
         };
-        pcntl_signal(SIGINT, $termFunc);
-        pcntl_signal(SIGTERM, $termFunc);
+
+        pcntl_signal(SIGINT, $terminate);
+        pcntl_signal(SIGTERM, $terminate);
 
         $master->monitor();
     }


### PR DESCRIPTION
This can be useful when run horizon in docker for example. 
Docker by default send SIGTERM on stop container

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
