### PR TITLE
[4.x] Fix for job rows on monitoring tags screen

### DIFF
--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -26,11 +26,11 @@
             {{ readableTimestamp(job.payload.pushedAt) }}
         </td>
 
-        <td v-if="$route.params.type=='completed'" class="table-fit">
-            {{ readableTimestamp(job.completed_at) }}
+        <td v-if="$parent.type == 'jobs'" class="table-fit">
+            {{ job.completed_at ? readableTimestamp(job.completed_at) : '-' }}
         </td>
 
-        <td v-if="$route.params.type=='completed'" class="table-fit">
+        <td v-if="$parent.type == 'jobs'" class="table-fit">
             <span>{{ job.completed_at ? (job.completed_at - job.reserved_at).toFixed(2)+'s' : '-' }}</span>
         </td>
     </tr>


### PR DESCRIPTION
Hey there,

Thanks everyone for your work on Horizon and all of the recent updates.

I noticed on the 4.1.0 release that the columns for **Runtime** and **Status** are not populated when monitoring tags. I've made sure that assets are being republished on deployment, but they still were not populating:

![image](https://user-images.githubusercontent.com/3619398/78033622-a0b60b00-7334-11ea-9bd1-aac858fd96b9.png)


## Fix

After digging in I found that the v-if in the new `job-row` component is using `$route.params.type` when previously it relied on the `type` prop passed into the parent component. This PR changes the v-if to use the $parent `type` prop to fix this issue. It also changes the **Runtime** column to a dash (consistent with the status column) when a job isn't completed yet. 

![image](https://user-images.githubusercontent.com/3619398/78033235-1f5e7880-7334-11ea-9da1-a365290864e6.png)

I used $parent to retrieve the prop instead of passing into the new job-row component as it's already already being used on line 4:

![image](https://user-images.githubusercontent.com/3619398/78033380-516fda80-7334-11ea-9ab3-c22f6190b611.png)
 

