### PR TITLE
[4.x] Fix dark mode config by checking for null value before assigning static property

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -6,6 +6,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Theme
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define which theme Horizon should load. Horizon currently
+    | provides a light theme and a dark theme, and you may provide one of
+    | those two values in order to determine which theme will get used.
+    |
+    | Supported: "light", "dark"
+    |
+    */
+
+    'theme' => 'light',
+
+    /*
+    |--------------------------------------------------------------------------
     | Horizon Domain
     |--------------------------------------------------------------------------
     |

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -49,7 +49,7 @@ class Horizon
      *
      * @var bool
      */
-    public static $useDarkTheme = false;
+    public static $useDarkTheme;
 
     /**
      * The database configuration methods.
@@ -60,6 +60,18 @@ class Horizon
         'Jobs', 'Supervisors', 'CommandQueue', 'Tags',
         'Metrics', 'Locks', 'Processes',
     ];
+
+    /**
+     * Create a new Horizon configuration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        if(is_null(static::$useDarkTheme)) {
+            static::$useDarkTheme = config('horizon.theme') === 'dark';
+        }
+    }
 
     /**
      * Determine if the given request can access the Horizon dashboard.
@@ -110,11 +122,12 @@ class Horizon
     /**
      * Specifies that Horizon should use the dark theme.
      *
+     * @param  bool  $on
      * @return static
      */
-    public static function night()
+    public static function night($on = true)
     {
-        static::$useDarkTheme = true;
+        static::$useDarkTheme = $on;
 
         return new static;
     }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -68,7 +68,7 @@ class Horizon
      */
     public function __construct()
     {
-        if(is_null(static::$useDarkTheme)) {
+        if (is_null(static::$useDarkTheme)) {
             static::$useDarkTheme = config('horizon.theme') === 'dark';
         }
     }


### PR DESCRIPTION
This fix should now properly assign the dark mode setting.

Via `SomeServiceProvider.php`:
```
// Set to night.
Horizon::night();

// Set to day.
Horizon::night(false);
```

or via `config/horizon.php`:
```
// Set to night.
'theme' => 'dark',

// Set to day (default).
'theme' => 'light',
```` 

The `Horizon::night()` function will take precedence over defining the theme in `config/horizon.php`.