### PR TITLE
[5.x] Switch from Chronos to Carbon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
-        "cakephp/chronos": "^2.0",
         "illuminate/contracts": "^7.0",
         "illuminate/queue": "^7.0",
         "illuminate/support": "^7.0",
+        "nesbot/carbon": "^2.17",
         "ramsey/uuid": "^3.5|^4.0",
         "symfony/process": "^5.0",
         "symfony/error-handler": "^5.0"

--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Jobs;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\JobId;
@@ -75,7 +75,7 @@ class RetryFailedJob
     protected function prepareNewTimeout($payload)
     {
         return $payload['timeoutAt']
-                        ? Chronos::now()->addSeconds(ceil($payload['timeoutAt'] - $payload['pushedAt']))->getTimestamp()
+                        ? CarbonImmutable::now()->addSeconds(ceil($payload['timeoutAt'] - $payload['pushedAt']))->getTimestamp()
                         : null;
     }
 }

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Listeners;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
 use Laravel\Horizon\Events\SupervisorLooped;
@@ -20,7 +20,7 @@ class MonitorWaitTimes
     /**
      * The time at which we last checked if monitoring was due.
      *
-     * @var \Cake\Chronos\Chronos
+     * @var \Carbon\CarbonImmutable
      */
     public $lastMonitored;
 
@@ -77,7 +77,7 @@ class MonitorWaitTimes
         // lock to monitor the wait times. We only want a single supervisor to run
         // the checks on a given interval so that we don't fire too many events.
         if (! $this->lastMonitored) {
-            $this->lastMonitored = Chronos::now();
+            $this->lastMonitored = CarbonImmutable::now();
         }
 
         if (! $this->timeToMonitor()) {
@@ -87,7 +87,7 @@ class MonitorWaitTimes
         // Next we will update the monitor timestamp and attempt to acquire a lock to
         // check the wait times. We use Redis to do it in order to have the atomic
         // operation required. This will avoid any deadlocks or race conditions.
-        $this->lastMonitored = Chronos::now();
+        $this->lastMonitored = CarbonImmutable::now();
 
         return $this->metrics->acquireWaitTimeMonitorLock();
     }
@@ -99,6 +99,6 @@ class MonitorWaitTimes
      */
     protected function timeToMonitor()
     {
-        return Chronos::now()->subMinutes(1)->lte($this->lastMonitored);
+        return CarbonImmutable::now()->subMinutes(1)->lte($this->lastMonitored);
     }
 }

--- a/src/Listeners/TrimFailedJobs.php
+++ b/src/Listeners/TrimFailedJobs.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Listeners;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
 
@@ -11,7 +11,7 @@ class TrimFailedJobs
     /**
      * The last time the recent jobs were trimmed.
      *
-     * @var \Cake\Chronos\Chronos
+     * @var \Carbon\CarbonImmutable
      */
     public $lastTrimmed;
 
@@ -35,13 +35,13 @@ class TrimFailedJobs
                 config('horizon.trim.failed', 10080), 12
             ));
 
-            $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
+            $this->lastTrimmed = CarbonImmutable::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lte(CarbonImmutable::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimFailedJobs();
 
-            $this->lastTrimmed = Chronos::now();
+            $this->lastTrimmed = CarbonImmutable::now();
         }
     }
 }

--- a/src/Listeners/TrimMonitoredJobs.php
+++ b/src/Listeners/TrimMonitoredJobs.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Listeners;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
 
@@ -11,7 +11,7 @@ class TrimMonitoredJobs
     /**
      * The last time the monitored jobs were trimmed.
      *
-     * @var \Cake\Chronos\Chronos
+     * @var \Carbon\CarbonImmutable
      */
     public $lastTrimmed;
 
@@ -35,13 +35,13 @@ class TrimMonitoredJobs
                 config('horizon.trim.monitored', 10080), 12
             ));
 
-            $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
+            $this->lastTrimmed = CarbonImmutable::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lte(CarbonImmutable::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimMonitoredJobs();
 
-            $this->lastTrimmed = Chronos::now();
+            $this->lastTrimmed = CarbonImmutable::now();
         }
     }
 }

--- a/src/Listeners/TrimRecentJobs.php
+++ b/src/Listeners/TrimRecentJobs.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Listeners;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
 
@@ -11,7 +11,7 @@ class TrimRecentJobs
     /**
      * The last time the recent jobs were trimmed.
      *
-     * @var \Cake\Chronos\Chronos
+     * @var \Carbon\CarbonImmutable
      */
     public $lastTrimmed;
 
@@ -31,13 +31,13 @@ class TrimRecentJobs
     public function handle(MasterSupervisorLooped $event)
     {
         if (! isset($this->lastTrimmed)) {
-            $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
+            $this->lastTrimmed = CarbonImmutable::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lte(CarbonImmutable::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimRecentJobs();
 
-            $this->lastTrimmed = Chronos::now();
+            $this->lastTrimmed = CarbonImmutable::now();
         }
     }
 }

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
@@ -172,13 +172,13 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
         app(MasterSupervisorRepository::class)
                     ->forget($this->name);
 
-        $startedTerminating = Chronos::now();
+        $startedTerminating = CarbonImmutable::now();
 
         // Here we will wait until all of the child supervisors finish terminating and
         // then exit the process. We will keep track of a timeout value so that the
         // process does not get stuck in an infinite loop here waiting for these.
         while (count($this->supervisors->filter->isRunning())) {
-            if (Chronos::now()->subSeconds($longest)
+            if (CarbonImmutable::now()->subSeconds($longest)
                         ->gte($startedTerminating)) {
                 break;
             }

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Closure;
 use Countable;
 use Symfony\Component\Process\Process;
@@ -137,7 +137,7 @@ class ProcessPool implements Countable
     public function markForTermination(WorkerProcess $process)
     {
         $this->terminatingProcesses[] = [
-            'process' => $process, 'terminatedAt' => Chronos::now(),
+            'process' => $process, 'terminatedAt' => CarbonImmutable::now(),
         ];
     }
 
@@ -270,7 +270,7 @@ class ProcessPool implements Countable
         foreach ($this->terminatingProcesses as $process) {
             $timeout = $this->options->timeout;
 
-            if ($process['terminatedAt']->addSeconds($timeout)->lte(Chronos::now())) {
+            if ($process['terminatedAt']->addSeconds($timeout)->lte(CarbonImmutable::now())) {
                 $process['process']->stop();
             }
         }

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Repositories;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -238,7 +238,7 @@ class RedisJobRepository implements JobRepository
         $minutes = $this->minutesForType($type);
 
         return $this->connection()->zcount(
-            $type, '-inf', Chronos::now()->subMinutes($minutes)->getTimestamp() * -1
+            $type, '-inf', CarbonImmutable::now()->subMinutes($minutes)->getTimestamp() * -1
         );
     }
 
@@ -334,7 +334,7 @@ class RedisJobRepository implements JobRepository
             ]);
 
             $pipe->expireat(
-                $payload->id(), Chronos::now()->addMinutes($this->pendingJobExpires)->getTimestamp()
+                $payload->id(), CarbonImmutable::now()->addMinutes($this->pendingJobExpires)->getTimestamp()
             );
         });
     }
@@ -406,7 +406,7 @@ class RedisJobRepository implements JobRepository
             );
 
             $pipe->expireat(
-                $payload->id(), Chronos::now()->addMinutes($this->monitoredJobExpires)->getTimestamp()
+                $payload->id(), CarbonImmutable::now()->addMinutes($this->monitoredJobExpires)->getTimestamp()
             );
         });
     }
@@ -458,7 +458,7 @@ class RedisJobRepository implements JobRepository
                 ]
             );
 
-            $pipe->expireat($payload->id(), Chronos::now()->addMinutes($this->completedJobExpires)->getTimestamp());
+            $pipe->expireat($payload->id(), CarbonImmutable::now()->addMinutes($this->completedJobExpires)->getTimestamp());
         });
     }
 
@@ -509,7 +509,7 @@ class RedisJobRepository implements JobRepository
     {
         $this->connection()->pipeline(function ($pipe) use ($ids) {
             foreach ($ids as $id) {
-                $pipe->expireat($id, Chronos::now()->addDays(7)->getTimestamp());
+                $pipe->expireat($id, CarbonImmutable::now()->addDays(7)->getTimestamp());
             }
         });
     }
@@ -524,25 +524,25 @@ class RedisJobRepository implements JobRepository
         $this->connection()->pipeline(function ($pipe) {
             $pipe->zremrangebyscore(
                 'recent_jobs',
-                Chronos::now()->subMinutes($this->recentJobExpires)->getTimestamp() * -1,
+                CarbonImmutable::now()->subMinutes($this->recentJobExpires)->getTimestamp() * -1,
                 '+inf'
             );
 
             $pipe->zremrangebyscore(
                 'recent_failed_jobs',
-                Chronos::now()->subMinutes($this->recentFailedJobExpires)->getTimestamp() * -1,
+                CarbonImmutable::now()->subMinutes($this->recentFailedJobExpires)->getTimestamp() * -1,
                 '+inf'
             );
 
             $pipe->zremrangebyscore(
                 'pending_jobs',
-                Chronos::now()->subMinutes($this->pendingJobExpires)->getTimestamp() * -1,
+                CarbonImmutable::now()->subMinutes($this->pendingJobExpires)->getTimestamp() * -1,
                 '+inf'
             );
 
             $pipe->zremrangebyscore(
                 'completed_jobs',
-                Chronos::now()->subMinutes($this->completedJobExpires)->getTimestamp() * -1,
+                CarbonImmutable::now()->subMinutes($this->completedJobExpires)->getTimestamp() * -1,
                 '+inf'
             );
         });
@@ -556,7 +556,7 @@ class RedisJobRepository implements JobRepository
     public function trimFailedJobs()
     {
         $this->connection()->zremrangebyscore(
-            'failed_jobs', Chronos::now()->subMinutes($this->failedJobExpires)->getTimestamp() * -1, '+inf'
+            'failed_jobs', CarbonImmutable::now()->subMinutes($this->failedJobExpires)->getTimestamp() * -1, '+inf'
         );
     }
 
@@ -568,7 +568,7 @@ class RedisJobRepository implements JobRepository
     public function trimMonitoredJobs()
     {
         $this->connection()->zremrangebyscore(
-            'monitored_jobs', Chronos::now()->subMinutes($this->monitoredJobExpires)->getTimestamp() * -1, '+inf'
+            'monitored_jobs', CarbonImmutable::now()->subMinutes($this->monitoredJobExpires)->getTimestamp() * -1, '+inf'
         );
     }
 
@@ -624,7 +624,7 @@ class RedisJobRepository implements JobRepository
             );
 
             $pipe->expireat(
-                $payload->id(), Chronos::now()->addMinutes($this->failedJobExpires)->getTimestamp()
+                $payload->id(), CarbonImmutable::now()->addMinutes($this->failedJobExpires)->getTimestamp()
             );
         });
     }
@@ -669,7 +669,7 @@ class RedisJobRepository implements JobRepository
         $retries[] = [
             'id' => $retryId,
             'status' => 'pending',
-            'retried_at' => Chronos::now()->getTimestamp(),
+            'retried_at' => CarbonImmutable::now()->getTimestamp(),
         ];
 
         $this->connection()->hmset($id, ['retried_by' => json_encode($retries)]);

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Repositories;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\Arr;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
@@ -37,7 +37,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     public function names()
     {
         return $this->connection()->zrevrangebyscore('masters', '+inf',
-            Chronos::now()->subSeconds(14)->getTimestamp()
+            CarbonImmutable::now()->subSeconds(14)->getTimestamp()
         );
     }
 
@@ -109,7 +109,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
             );
 
             $pipe->zadd('masters',
-                Chronos::now()->getTimestamp(), $master->name
+                CarbonImmutable::now()->getTimestamp(), $master->name
             );
 
             $pipe->expire('master:'.$master->name, 15);
@@ -145,7 +145,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     public function flushExpired()
     {
         $this->connection()->zremrangebyscore('masters', '-inf',
-            Chronos::now()->subSeconds(14)->getTimestamp()
+            CarbonImmutable::now()->subSeconds(14)->getTimestamp()
         );
     }
 

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Repositories;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Lock;
@@ -266,7 +266,7 @@ class RedisMetricsRepository implements MetricsRepository
         $data = $this->baseSnapshotData($key = 'job:'.$job);
 
         $this->connection()->zadd(
-            'snapshot:'.$key, $time = Chronos::now()->getTimestamp(), json_encode([
+            'snapshot:'.$key, $time = CarbonImmutable::now()->getTimestamp(), json_encode([
                 'throughput' => $data['throughput'],
                 'runtime' => $data['runtime'],
                 'time' => $time,
@@ -289,7 +289,7 @@ class RedisMetricsRepository implements MetricsRepository
         $data = $this->baseSnapshotData($key = 'queue:'.$queue);
 
         $this->connection()->zadd(
-            'snapshot:'.$key, $time = Chronos::now()->getTimestamp(), json_encode([
+            'snapshot:'.$key, $time = CarbonImmutable::now()->getTimestamp(), json_encode([
                 'throughput' => $data['throughput'],
                 'runtime' => $data['runtime'],
                 'wait' => app(WaitTimeCalculator::class)->calculateFor($queue),
@@ -335,7 +335,7 @@ class RedisMetricsRepository implements MetricsRepository
                     ?: $this->storeSnapshotTimestamp();
 
         return max(
-            (Chronos::now()->getTimestamp() - $lastSnapshotAt) / 60, 1
+            (CarbonImmutable::now()->getTimestamp() - $lastSnapshotAt) / 60, 1
         );
     }
 
@@ -346,7 +346,7 @@ class RedisMetricsRepository implements MetricsRepository
      */
     protected function storeSnapshotTimestamp()
     {
-        return tap(Chronos::now()->getTimestamp(), function ($timestamp) {
+        return tap(CarbonImmutable::now()->getTimestamp(), function ($timestamp) {
             $this->connection()->set('last_snapshot_at', $timestamp);
         });
     }

--- a/src/Repositories/RedisProcessRepository.php
+++ b/src/Repositories/RedisProcessRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Repositories;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Laravel\Horizon\Contracts\ProcessRepository;
 
@@ -48,7 +48,7 @@ class RedisProcessRepository implements ProcessRepository
      */
     public function orphaned($master, array $processIds)
     {
-        $time = Chronos::now()->getTimestamp();
+        $time = CarbonImmutable::now()->getTimestamp();
 
         $shouldRemove = array_diff($this->connection()->hkeys(
             $key = "{$master}:orphans"
@@ -74,7 +74,7 @@ class RedisProcessRepository implements ProcessRepository
      */
     public function orphanedFor($master, $seconds)
     {
-        $expiresAt = Chronos::now()->getTimestamp() - $seconds;
+        $expiresAt = CarbonImmutable::now()->getTimestamp() - $seconds;
 
         return collect($this->allOrphans($master))->filter(function ($recordedAt, $_) use ($expiresAt) {
             return $expiresAt > $recordedAt;

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Repositories;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\Arr;
 use Laravel\Horizon\Contracts\SupervisorRepository;
@@ -36,7 +36,7 @@ class RedisSupervisorRepository implements SupervisorRepository
     public function names()
     {
         return $this->connection()->zrevrangebyscore('supervisors', '+inf',
-            Chronos::now()->subSeconds(29)->getTimestamp()
+            CarbonImmutable::now()->subSeconds(29)->getTimestamp()
         );
     }
 
@@ -126,7 +126,7 @@ class RedisSupervisorRepository implements SupervisorRepository
             );
 
             $pipe->zadd('supervisors',
-                Chronos::now()->getTimestamp(), $supervisor->name
+                CarbonImmutable::now()->getTimestamp(), $supervisor->name
             );
 
             $pipe->expire('supervisor:'.$supervisor->name, 30);
@@ -162,7 +162,7 @@ class RedisSupervisorRepository implements SupervisorRepository
     public function flushExpired()
     {
         $this->connection()->zremrangebyscore('supervisors', '-inf',
-            Chronos::now()->subSeconds(14)->getTimestamp()
+            CarbonImmutable::now()->subSeconds(14)->getTimestamp()
         );
     }
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Closure;
 use Exception;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
@@ -50,7 +50,7 @@ class Supervisor implements Pausable, Restartable, Terminable
     /**
      * The time at which auto-scaling last ran for this supervisor.
      *
-     * @var \Cake\Chronos\Chronos
+     * @var \Carbon\CarbonImmutable
      */
     public $lastAutoScaled;
 
@@ -332,10 +332,10 @@ class Supervisor implements Pausable, Restartable, Terminable
     protected function autoScale()
     {
         $this->lastAutoScaled = $this->lastAutoScaled ?:
-                    Chronos::now()->subSeconds($this->autoScaleCooldown + 1);
+                    CarbonImmutable::now()->subSeconds($this->autoScaleCooldown + 1);
 
-        if (Chronos::now()->subSeconds($this->autoScaleCooldown)->gte($this->lastAutoScaled)) {
-            $this->lastAutoScaled = Chronos::now();
+        if (CarbonImmutable::now()->subSeconds($this->autoScaleCooldown)->gte($this->lastAutoScaled)) {
+            $this->lastAutoScaled = CarbonImmutable::now();
 
             app(AutoScaler::class)->scale($this);
         }

--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Closure;
 use Laravel\Horizon\Events\UnableToLaunchProcess;
 use Laravel\Horizon\Events\WorkerProcessRestarting;
@@ -27,7 +27,7 @@ class WorkerProcess
     /**
      * The time at which the cooldown period will be over.
      *
-     * @var \Cake\Chronos\Chronos
+     * @var \Carbon\CarbonImmutable
      */
     public $restartAgainAt;
 
@@ -159,14 +159,14 @@ class WorkerProcess
 
         if ($this->restartAgainAt) {
             $this->restartAgainAt = ! $this->process->isRunning()
-                            ? Chronos::now()->addMinute()
+                            ? CarbonImmutable::now()->addMinute()
                             : null;
 
             if (! $this->process->isRunning()) {
                 event(new UnableToLaunchProcess($this));
             }
         } else {
-            $this->restartAgainAt = Chronos::now()->addSecond();
+            $this->restartAgainAt = CarbonImmutable::now()->addSecond();
         }
     }
 
@@ -178,7 +178,7 @@ class WorkerProcess
     public function coolingDown()
     {
         return isset($this->restartAgainAt) &&
-               Chronos::now()->lt($this->restartAgainAt);
+               CarbonImmutable::now()->lt($this->restartAgainAt);
     }
 
     /**

--- a/tests/Feature/JobRetrievalTest.php
+++ b/tests/Feature/JobRetrievalTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
 use Laravel\Horizon\Contracts\JobRepository;
@@ -57,7 +57,7 @@ class JobRetrievalTest extends IntegrationTest
         $ids[] = Queue::push(new Jobs\BasicJob);
 
         $repository = resolve(JobRepository::class);
-        Chronos::setTestNow(Chronos::now()->addHours(3));
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addHours(3));
 
         $this->assertEquals(5, Redis::connection('horizon')->zcard('recent_jobs'));
 
@@ -68,7 +68,7 @@ class JobRetrievalTest extends IntegrationTest
         $repository->completed(new JobPayload(json_encode(['id' => $ids[0]])));
         $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($ids[0]));
 
-        Chronos::setTestNow();
+        CarbonImmutable::setTestNow();
     }
 
     public function test_paginating_large_job_results_gives_correct_amounts()

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Stopwatch;
@@ -116,13 +116,13 @@ class MetricsTest extends IntegrationTest
         $this->work();
 
         // Take initial snapshot and set initial timestamp...
-        Chronos::setTestNow($firstTimestamp = Chronos::now());
+        CarbonImmutable::setTestNow($firstTimestamp = CarbonImmutable::now());
         resolve(MetricsRepository::class)->snapshot();
 
         // Work another job and take another snapshot...
         Queue::push(new Jobs\BasicJob);
         $this->work();
-        Chronos::setTestNow(Chronos::now()->addSeconds(1));
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(1));
         resolve(MetricsRepository::class)->snapshot();
 
         $snapshots = resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class);
@@ -137,7 +137,7 @@ class MetricsTest extends IntegrationTest
             (object) [
                 'throughput' => 1,
                 'runtime' => 3,
-                'time' => Chronos::now()->getTimestamp(),
+                'time' => CarbonImmutable::now()->getTimestamp(),
             ],
         ], $snapshots);
 
@@ -154,7 +154,7 @@ class MetricsTest extends IntegrationTest
                 'throughput' => 1,
                 'runtime' => 3,
                 'wait' => 0,
-                'time' => Chronos::now()->getTimestamp(),
+                'time' => CarbonImmutable::now()->getTimestamp(),
             ],
         ], $snapshots);
     }
@@ -178,7 +178,7 @@ class MetricsTest extends IntegrationTest
         );
 
         // Adjust current time...
-        Chronos::setTestNow(Chronos::now()->addMinutes(2));
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addMinutes(2));
 
         $this->assertEquals(
             1, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
@@ -199,26 +199,26 @@ class MetricsTest extends IntegrationTest
         $stopwatch->shouldReceive('check')->andReturn(1);
         $this->app->instance(Stopwatch::class, $stopwatch);
 
-        Chronos::setTestNow(Chronos::now());
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
 
         // Run the jobs...
         for ($i = 0; $i < 30; $i++) {
             Queue::push(new Jobs\BasicJob);
             $this->work();
             resolve(MetricsRepository::class)->snapshot();
-            Chronos::setTestNow(Chronos::now()->addSeconds(1));
+            CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(1));
         }
 
         // Check the job snapshots...
         $snapshots = resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class);
         $this->assertCount(24, $snapshots);
-        $this->assertEquals(Chronos::now()->getTimestamp() - 1, $snapshots[23]->time);
+        $this->assertEquals(CarbonImmutable::now()->getTimestamp() - 1, $snapshots[23]->time);
 
         // Check the queue snapshots...
         $snapshots = resolve(MetricsRepository::class)->snapshotsForQueue('default');
         $this->assertCount(24, $snapshots);
-        $this->assertEquals(Chronos::now()->getTimestamp() - 1, $snapshots[23]->time);
+        $this->assertEquals(CarbonImmutable::now()->getTimestamp() - 1, $snapshots[23]->time);
 
-        Chronos::setTestNow();
+        CarbonImmutable::setTestNow();
     }
 }

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\Facades\Event;
 use Laravel\Horizon\Contracts\MetricsRepository;
@@ -32,7 +32,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $listener = new MonitorWaitTimes(resolve(MetricsRepository::class), $redis);
-        $listener->lastMonitoredAt = Chronos::now()->subDays(1);
+        $listener->lastMonitoredAt = CarbonImmutable::now()->subDays(1);
 
         $listener->handle(new SupervisorLooped(Mockery::mock(Supervisor::class)));
 

--- a/tests/Feature/QueueProcessingTest.php
+++ b/tests/Feature/QueueProcessingTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
@@ -80,7 +80,7 @@ class QueueProcessingTest extends IntegrationTest
 
     public function test_stale_reserved_jobs_are_marked_as_pending_after_migrating()
     {
-        $id = Queue::later(Chronos::now()->addSeconds(0), new Jobs\BasicJob);
+        $id = Queue::later(CarbonImmutable::now()->addSeconds(0), new Jobs\BasicJob);
 
         Redis::connection('horizon')->hset($id, 'status', 'reserved');
 

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Event;
@@ -125,7 +125,7 @@ class SupervisorTest extends IntegrationTest
         $supervisor->loop();
         usleep(250 * 1000);
 
-        $supervisor->processes()[0]->restartAgainAt = Chronos::now()->subMinutes(10);
+        $supervisor->processes()[0]->restartAgainAt = CarbonImmutable::now()->subMinutes(10);
 
         // Make sure that the worker attempts restart...
         $restarted = false;

--- a/tests/Feature/TrimMonitoredJobsTest.php
+++ b/tests/Feature/TrimMonitoredJobsTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
 use Laravel\Horizon\Listeners\TrimMonitoredJobs;
@@ -23,13 +23,13 @@ class TrimMonitoredJobsTest extends IntegrationTest
         // Should not be called first time since date is initialized...
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
 
-        Chronos::setTestNow(Chronos::now()->addMinutes(1600));
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addMinutes(1600));
 
         // Should only be called twice...
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
 
-        Chronos::setTestNow();
+        CarbonImmutable::setTestNow();
     }
 }

--- a/tests/Feature/TrimRecentJobsTest.php
+++ b/tests/Feature/TrimRecentJobsTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Events\MasterSupervisorLooped;
 use Laravel\Horizon\Listeners\TrimRecentJobs;
@@ -23,13 +23,13 @@ class TrimRecentJobsTest extends IntegrationTest
         // Should not be called first time since date is initialized...
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
 
-        Chronos::setTestNow(Chronos::now()->addMinutes(30));
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addMinutes(30));
 
         // Should only be called twice...
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
         $trim->handle(new MasterSupervisorLooped(Mockery::mock(MasterSupervisor::class)));
 
-        Chronos::setTestNow();
+        CarbonImmutable::setTestNow();
     }
 }

--- a/tests/Feature/WorkerProcessTest.php
+++ b/tests/Feature/WorkerProcessTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
-use Cake\Chronos\Chronos;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Laravel\Horizon\Events\UnableToLaunchProcess;
 use Laravel\Horizon\Events\WorkerProcessRestarting;
@@ -61,7 +61,7 @@ class WorkerProcessTest extends IntegrationTest
 
         // Travel to the future...
         sleep(1);
-        Chronos::setTestNow(Chronos::now()->addMinutes(3));
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addMinutes(3));
         $this->assertFalse($workerProcess->coolingDown());
 
         // Should try to restart now...
@@ -70,6 +70,6 @@ class WorkerProcessTest extends IntegrationTest
         Event::assertDispatched(WorkerProcessRestarting::class);
         $this->assertCount(2, Event::dispatched(WorkerProcessRestarting::class));
 
-        Chronos::setTestNow();
+        CarbonImmutable::setTestNow();
     }
 }


### PR DESCRIPTION
The original motivation to use Chronos over Carbon was for its immutability.  Now that Carbon v2 offers immutability, we should switch back to Carbon to keep package dependencies consistent across the Laravel Ecosystem.

`CarbonImmutable` is a drop in replacement for `Chronos`, as all method names are the same, and all the tests pass.