### PR TITLE
show attempts count for completed jobs

### DIFF
--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -15,7 +15,9 @@
 
             <small class="text-muted">
                 Queue: {{job.queue}}
-
+                <span v-if="$route.params.type=='completed'" class="text-break">
+                    | Attempts: {{ job.payload.attempts }}
+                </span>
                 <span v-if="job.payload.tags.length" class="text-break">
                     | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.slice(0,3).join(', ') : '' }}<span v-if="job.payload.tags.length > 3"> ({{ job.payload.tags.length - 3 }} more)</span>
                 </span>


### PR DESCRIPTION
Attemps count is displayed on failed jobs list. But when a job finally succeed after retry, it could also be great to get information about retries.