### PR TITLE
Trigger MasterSupervisorDeployed event

### DIFF
--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\HorizonCommandQueue;
+use Laravel\Horizon\Events\MasterSupervisorDeployed;
 use Laravel\Horizon\MasterSupervisorCommands\AddSupervisor;
 
 class ProvisioningPlan
@@ -96,6 +97,8 @@ class ProvisioningPlan
         foreach ($supervisors as $supervisor => $options) {
             $this->add($options);
         }
+
+        event(new MasterSupervisorDeployed($this->master));
     }
 
     /**


### PR DESCRIPTION
I wanted to listen for an event whenever Horizon is (re)started. I found the `MasterSupervisorDeployed` event exists but is never triggered.

I'm assuming this was the right place to trigger the event?