### PR TITLE
[5.x] Make sure you are able to override the full job payload

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -130,7 +130,7 @@ class RedisQueue extends BaseQueue
             'data' => $data,
             'tags' => $payload['tags'],
             'type' => $payload['type'],
-            'pushedAt' => $payload['pushedAt']
+            'pushedAt' => $payload['pushedAt'],
         ]);
     }
 
@@ -153,7 +153,7 @@ class RedisQueue extends BaseQueue
             ],
             'tags' => $jobPayload->tags(),
             'type' => $jobPayload['type'],
-            'pushedAt' => $jobPayload['pushedAt']
+            'pushedAt' => $jobPayload['pushedAt'],
         ]);
 
         return array_merge($payload, [

--- a/tests/Feature/QueueProcessingTest.php
+++ b/tests/Feature/QueueProcessingTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Redis;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Events\JobReserved;
 use Laravel\Horizon\Events\JobsMigrated;
+use Laravel\Horizon\Tests\Feature\Jobs\BasicJob;
 use Laravel\Horizon\Tests\IntegrationTest;
 
 class QueueProcessingTest extends IntegrationTest
@@ -92,5 +93,21 @@ class QueueProcessingTest extends IntegrationTest
         $this->work();
 
         $this->assertSame('pending', $status);
+    }
+
+    public function test_overriding_job_payload_using_createPayloadUsing_method_on_the_queue_returns_the_full_payload()
+    {
+        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
+            $this->assertArrayHasKey('tags', $payload);
+            $this->assertArrayHasKey('type', $payload);
+            $this->assertArrayHasKey('pushedAt', $payload);
+            //$this->assertArrayHasKey('retry_of', $payload);
+
+            return $payload;
+        });
+
+        Queue::push(new Jobs\BasicJob);
+
+        Queue::push(BasicJob::class);
     }
 }


### PR DESCRIPTION
### Motivation
Currectly when you use `Queue::createPayloadUsing` and you try to override or merge existing tags the existing tags was not part of the job payload.

### The Issue
The issue/bug is simple it's because the JobPayload class gets instanticated after any hooks has had a chance to run.

More specifically the methods that generate the job payload e.g `createObjectPayload` and `createStringPayload` also calls any payload hooks. 

But the methods `later` and `pushRaw` both overrides the the payload right before the attempt to push the given job to the queue. But at this point the hooks have already ran. 

### Solution
The proposed solution to this problem is to override `createObjectPayload` and `createStringPayload` respectively and add the missing keys to the payload array there.

This should give the developer the missing context in the hook. 

### Future changes
I had no clever way of reducing the code repitition sense calling `createObjectPayload` and `createStringPayload` on the parent would trigger the hooks to many times. All i wanted is to grap the "raw" payload before any hooks have ran. So maybe we could add a `createObjectPayloadRaw` and `createStringPayloadRaw` that can take overrides on the parent?

### Sources/ Possible closing issues
Closes: https://github.com/laravel/framework/pull/29643, https://github.com/laravel/framework/issues/29665

> We pass you the existing payload, right? Can't you just merge them there?

_Originally posted by @taylorotwell in https://github.com/laravel/framework/pull/29643#issuecomment-522739489_

