### PR TITLE
Merge tags from payload

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -123,14 +123,10 @@ class JobPayload implements ArrayAccess
      */
     protected function determineTags($job)
     {
-        switch (true) {
-            case is_string($job):
-                return [];
-            case array_key_exists('tags', $this->decoded):
-                return $this->decoded['tags'];
-            default:
-                return Tags::for($job);
-        }
+        return array_merge(
+            $this->decoded['tags'] ?? [],
+            is_string($job) ? [] : Tags::for($job)
+        );
     }
 
     /**

--- a/tests/Unit/RedisPayloadTest.php
+++ b/tests/Unit/RedisPayloadTest.php
@@ -31,7 +31,7 @@ class RedisPayloadTest extends UnitTest
         $JobPayload->prepare(new BroadcastEvent(new StdClass));
         $this->assertSame('broadcast', $JobPayload->decoded['type']);
 
-        $JobPayload->prepare(new CallQueuedListener('Class', 'method', [new StdClass]));
+        $JobPayload->prepare(new CallQueuedListener('stdClass', 'method', [new StdClass]));
         $this->assertSame('event', $JobPayload->decoded['type']);
 
         $JobPayload->prepare(new SendQueuedMailable(Mockery::mock(Mailable::class)));
@@ -119,6 +119,17 @@ class RedisPayloadTest extends UnitTest
         $JobPayload->prepare($job);
 
         $this->assertEquals([FakeModel::class.':21'], $JobPayload->decoded['tags']);
+    }
+
+    public function test_tags_are_added_to_existing()
+    {
+        $JobPayload = new JobPayload(json_encode(['id' => 1, 'tags' => ['mytag']]));
+
+        $job = new CallQueuedListener(FakeListenerWithProperties::class, 'handle', [new FakeEventWithModel(42)]);
+
+        $JobPayload->prepare($job);
+
+        $this->assertEquals(['mytag', FakeModel::class.':42'], $JobPayload->decoded['tags']);
     }
 
     public function test_listener_and_event_tags_can_merge_auto_tag_events()


### PR DESCRIPTION
This PR allows merging existing tags from the raw payload to the payload created by Horizon. Current behaviour in Horizon 4.x is to use the existing raw tags an override Horizon's.