### PR TITLE
[4.x] Autoscaling can now be configured to scale the way you want it to

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -153,6 +153,20 @@ return [
 
     'memory_limit' => 64,
 
+    /**
+    |--------------------------------------------------------------------------
+    | Queue Worker Scale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the queue worker scale settings used by your application
+    | in all environments. These setting will let you limit the number of processes scaled at a time
+    | and speed factor on how many processes will start at a time (Percentage of the total number jobs).
+     */
+    'scale' => [
+        'limit' => 1,
+        'factor' => 20,
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Queue Worker Configuration


### PR DESCRIPTION
For medium / large queues the auto scaling feature creates new processes too slow imho.
It works good if you don't need to have your queue worked through as fast as possible.
But if you are processing something a user waits on the frontend it may take awhile.
You may want to disable auto-scaling or use min-processes to always use minimum 100 processes.

But thats a bit resource heavy on some systems thats why i made this pull request. :)

The Autoscaling may now be configured the way the user wishes.

Say you got 1000 Jobs in your queue and you got 20 processes running.
Depending on your configuration you could say: create as many processes as possible but never more than 50 at a time.

Or you could say: i want to start 25% (250) of the processes each iteration but also never more than 100 at a time.

Also the configuration defaults to: never start more than 1 at a time. 
If your upgrading: the default will always be in place so it's fully backward compatible and you don't need to change a thing in your code.

Also i wrote tests to confirm the 'percentage' and 'limit per iteration' are working. 