### PR TITLE
[develop] Support worker max-time and max-jobs

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -18,9 +18,10 @@ class SupervisorCommand extends Command
                             {name : The name of supervisor}
                             {connection : The name of the connection to work}
                             {--balance= : The balancing strategy the supervisor should apply}
-                            {--balance= : The balancing strategy the supervisor should apply}
                             {--delay=0 : The number of seconds to delay failed jobs (Deprecated)}
                             {--backoff=0 : The number of seconds to wait before retrying a job that encountered an uncaught exception}
+                            {--max-jobs=0 : The number of jobs to process before stopping a child process}
+                            {--max-time=0 : The maximum number of seconds a child process should run}
                             {--force : Force the worker to run even in maintenance mode}
                             {--max-processes=1 : The maximum number of total workers to start}
                             {--min-processes=1 : The minimum number of workers to assign per queue}
@@ -113,6 +114,8 @@ class SupervisorCommand extends Command
             $this->option('workers-name'),
             $this->option('balance'),
             $backoff,
+            $this->option('max-time'),
+            $this->option('max-jobs'),
             $this->option('max-processes'),
             $this->option('min-processes'),
             $this->option('memory'),

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -16,6 +16,8 @@ class WorkCommand extends BaseWorkCommand
                             {--name=default : The name of the worker}
                             {--delay=0 : The number of seconds to delay failed jobs (Deprecated)}
                             {--backoff=0 : The number of seconds to wait before retrying a job that encountered an uncaught exception}
+                            {--max-jobs=0 : The number of jobs to process before stopping}
+                            {--max-time=0 : The maximum number of seconds the worker should run}
                             {--daemon : Run the worker in daemon mode (Deprecated)}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}

--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -46,9 +46,9 @@ class QueueCommandString
      */
     public static function toOptionsString(SupervisorOptions $options, $paused = false)
     {
-        $string = sprintf('--backoff=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
-            $options->backoff, $options->memory, $options->queue,
-            $options->sleep, $options->timeout, $options->maxTries
+        $string = sprintf('--backoff=%s --max-time=%s --max-jobs=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
+            $options->backoff, $options->maxTime, $options->maxJobs, $options->memory,
+            $options->queue, $options->sleep, $options->timeout, $options->maxTries
         );
 
         if ($options->force) {

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -75,6 +75,20 @@ class SupervisorOptions
     public $backoff;
 
     /**
+     * The maximum number of jobs to run.
+     *
+     * @var int
+     */
+    public $maxJobs;
+
+    /**
+     * The maximum number of seconds a worker may live.
+     *
+     * @var int
+     */
+    public $maxTime;
+
+    /**
      * The maximum amount of RAM the worker may consume.
      *
      * @var int
@@ -118,6 +132,8 @@ class SupervisorOptions
      * @param  string  $workersName
      * @param  string  $balance
      * @param  int  $backoff
+     * @param  int  $maxTime
+     * @param  int  $maxJobs
      * @param  int  $maxProcesses
      * @param  int  $minProcesses
      * @param  int  $memory
@@ -133,6 +149,8 @@ class SupervisorOptions
                                 $workersName = 'default',
                                 $balance = 'off',
                                 $backoff = 0,
+                                $maxTime = 0,
+                                $maxJobs = 0,
                                 $maxProcesses = 1,
                                 $minProcesses = 1,
                                 $memory = 128,
@@ -148,6 +166,8 @@ class SupervisorOptions
         $this->workersName = $workersName;
         $this->balance = $balance;
         $this->backoff = $backoff;
+        $this->maxTime = $maxTime;
+        $this->maxJobs = $maxJobs;
         $this->maxProcesses = $maxProcesses;
         $this->minProcesses = $minProcesses;
         $this->memory = $memory;
@@ -237,6 +257,8 @@ class SupervisorOptions
             'maxProcesses' => $this->maxProcesses,
             'minProcesses' => $this->minProcesses,
             'maxTries' => $this->maxTries,
+            'maxTime' => $this->maxTime,
+            'maxJobs' => $this->maxJobs,
             'memory' => $this->memory,
             'nice' => $this->nice,
             'name' => $this->name,

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertEquals(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --backoff=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -67,7 +67,7 @@ class SupervisorTest extends IntegrationTest
 
         $host = MasterSupervisor::name();
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
             $supervisor->processes()[0]->getCommandLine()
         );
     }
@@ -85,12 +85,12 @@ class SupervisorTest extends IntegrationTest
         $host = MasterSupervisor::name();
 
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --memory=128 --queue="first" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="first" --sleep=3 --timeout=60 --tries=0',
             $supervisor->processes()[0]->getCommandLine()
         );
 
         $this->assertEquals(
-            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --memory=128 --queue="second" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="second" --sleep=3 --timeout=60 --tries=0',
             $supervisor->processes()[1]->getCommandLine()
         );
     }


### PR DESCRIPTION
This PR adds support for max_time and max_jobs:

```
'supervisor-1' => [
    'connection' => 'redis',
    'queue' => ['deployments', 'notifications'],
    'balance' => 'auto',
    'min_processes' => 1,
    'max_processes' => 10,
    'max_time' => 10000,
    'max_jobs' => 10000,
    'tries' => 1,
],
```