### PR TITLE
[5.x] Implement default environment

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -165,23 +165,25 @@ return [
     */
 
     'environments' => [
-        'production' => [
+        'default' => [
             'supervisor-1' => [
                 'connection' => 'redis',
                 'queue' => ['default'],
                 'balance' => 'simple',
-                'processes' => 10,
+                'processes' => 1,
                 'tries' => 1,
+            ],
+        ],
+
+        'production' => [
+            'supervisor-1' => [
+                'processes' => 10,
             ],
         ],
 
         'local' => [
             'supervisor-1' => [
-                'connection' => 'redis',
-                'queue' => ['default'],
-                'balance' => 'simple',
                 'processes' => 3,
-                'tries' => 1,
             ],
         ],
     ],

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -164,17 +164,17 @@ return [
     |
     */
 
-    'environments' => [
-        'default' => [
-            'supervisor-1' => [
-                'connection' => 'redis',
-                'queue' => ['default'],
-                'balance' => 'simple',
-                'processes' => 1,
-                'tries' => 1,
-            ],
+    'defaults' => [
+        'supervisor-1' => [
+            'connection' => 'redis',
+            'queue' => ['default'],
+            'balance' => 'simple',
+            'processes' => 1,
+            'tries' => 1,
         ],
+    ],
 
+    'environments' => [
         'production' => [
             'supervisor-1' => [
                 'processes' => 10,

--- a/src/Console/TimeoutCommand.php
+++ b/src/Console/TimeoutCommand.php
@@ -3,6 +3,8 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\ProvisioningPlan;
 
 class TimeoutCommand extends Command
 {
@@ -34,8 +36,8 @@ class TimeoutCommand extends Command
      */
     public function handle()
     {
-        $this->line(collect(
-            config('horizon.environments.'.$this->argument('environment'), [])
-        )->max('timeout') ?? 60);
+        $plan = ProvisioningPlan::get(MasterSupervisor::name())->plan;
+
+        $this->line(collect($plan[$this->argument('environment')] ?? [])->max('timeout') ?? 60);
     }
 }

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -36,11 +36,12 @@ class ProvisioningPlan
      *
      * @param  string  $master
      * @param  array  $plan
+     * @param  array  $defaults
      * @return void
      */
-    public function __construct($master, array $plan)
+    public function __construct($master, array $plan, array $defaults = [])
     {
-        $this->plan = $this->applyDefaultOptions($plan);
+        $this->plan = $this->applyDefaultOptions($plan, $defaults);
         $this->master = $master;
 
         $this->parsed = $this->toSupervisorOptions();
@@ -54,21 +55,20 @@ class ProvisioningPlan
      */
     public static function get($master)
     {
-        return new static($master, config('horizon.environments'));
+        return new static($master, config('horizon.environments'), config('horizon.defaults', []));
     }
 
     /**
      * Apply the default supervisor options to each environment.
      *
      * @param  array  $plan
+     * @param  array  $defaults
      * @return array
      */
-    protected function applyDefaultOptions(array $plan)
+    protected function applyDefaultOptions(array $plan, array $defaults = [])
     {
-        $default = $plan['default'] ?? [];
-
-        return collect($plan)->forget('default')->map(function ($plan) use ($default) {
-            return array_replace_recursive($default, $plan);
+        return collect($plan)->map(function ($plan) use ($defaults) {
+            return array_replace_recursive($defaults, $plan);
         })->all();
     }
 

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -40,7 +40,7 @@ class ProvisioningPlan
      */
     public function __construct($master, array $plan)
     {
-        $this->plan = $plan;
+        $this->plan = $this->applyDefaultOptions($plan);
         $this->master = $master;
 
         $this->parsed = $this->toSupervisorOptions();
@@ -55,6 +55,21 @@ class ProvisioningPlan
     public static function get($master)
     {
         return new static($master, config('horizon.environments'));
+    }
+
+    /**
+     * Apply the default supervisor options to each environment.
+     *
+     * @param  array  $plan
+     * @return array
+     */
+    protected function applyDefaultOptions(array $plan)
+    {
+        $default = $plan['default'] ?? [];
+
+        return collect($plan)->forget('default')->map(function ($plan) use ($default) {
+            return array_replace_recursive($default, $plan);
+        })->all();
     }
 
     /**


### PR DESCRIPTION
This PR implements a default environment for Horizon. Any other environment will re-use this default environment's settings which can be overridden. Supported environments still need to be defined but this helps with the maintenance burden of having to maintain duplicate settings for multiple environments.

I've updated the config file which immediately shows how this can be useful.

Sent to master because it's obviously breaking for anyone who was relying on the current formatting of the config.

Closes https://github.com/laravel/horizon/issues/438