### PR TITLE
[5.x] Make autoscaling rate configurable

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -163,14 +163,7 @@ return [
     */
 
     'autoscaling' => [
-        /*
-         * The cooldown between autoscaling iterations in seconds.
-         */
         'cooldown' => 3,
-
-        /*
-         * The maximum number of processes to increase/decrease per iteration.
-         */
         'max_shift' => 1,
     ],
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -155,20 +155,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Autoscaling
-    |--------------------------------------------------------------------------
-    |
-    | Here you may define the autoscaling settings used by your application.
-    |
-    */
-
-    'autoscaling' => [
-        'cooldown' => 3,
-        'max_shift' => 1,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Queue Worker Configuration
     |--------------------------------------------------------------------------
     |
@@ -182,22 +168,24 @@ return [
         'supervisor-1' => [
             'connection' => 'redis',
             'queue' => ['default'],
-            'balance' => 'simple',
-            'processes' => 1,
+            'balance' => 'auto',
             'tries' => 1,
+            'maxProcesses' => 1,
         ],
     ],
 
     'environments' => [
         'production' => [
             'supervisor-1' => [
-                'processes' => 10,
+                'maxProcesses' => 10,
+                'balanceCooldown' => 1,
+                'autoScaleMaxShift' => 5,
             ],
         ],
 
         'local' => [
             'supervisor-1' => [
-                'processes' => 3,
+                'maxProcesses' => 3,
             ],
         ],
     ],

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -155,6 +155,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Autoscaling
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the autoscaling settings used by your application.
+    |
+    */
+
+    'autoscaling' => [
+        /*
+         * The cooldown between autoscaling iterations in seconds.
+         */
+        'cooldown' => 3,
+
+        /*
+         * The maximum number of processes to increase/decrease per iteration.
+         */
+        'max_shift' => 1,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Queue Worker Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -169,8 +169,8 @@ return [
             'connection' => 'redis',
             'queue' => ['default'],
             'balance' => 'auto',
-            'tries' => 1,
             'maxProcesses' => 1,
+            'tries' => 1,
         ],
     ],
 

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -146,7 +146,7 @@ class AutoScaler
     }
 
     /**
-     * The maximum number of processes to increase/decrease per iteration.
+     * The maximum number of processes to increase or decrease per one scaling.
      *
      * @return int
      */

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -131,27 +131,31 @@ class AutoScaler
         $desiredProcessCount = ceil($workers);
 
         if ($desiredProcessCount > $totalProcessCount) {
-            $maxUpShift = min($supervisor->options->maxProcesses - $supervisor->totalProcessCount(), $this->maxShift());
+            $maxUpShift = min(
+                $supervisor->options->maxProcesses - $supervisor->totalProcessCount(),
+                $supervisor->options->autoScaleMaxShift
+            );
 
             $pool->scale(
-                min($totalProcessCount + $maxUpShift, $supervisor->options->maxProcesses, $desiredProcessCount)
+                min(
+                    $totalProcessCount + $maxUpShift,
+                    $supervisor->options->maxProcesses,
+                    $desiredProcessCount
+                )
             );
         } elseif ($desiredProcessCount < $totalProcessCount) {
-            $maxDownShift = min($supervisor->totalProcessCount() - $supervisor->options->minProcesses, $this->maxShift());
+            $maxDownShift = min(
+                $supervisor->totalProcessCount() - $supervisor->options->minProcesses,
+                $supervisor->options->autoScaleMaxShift
+            );
 
             $pool->scale(
-                max($totalProcessCount - $maxDownShift, $supervisor->options->minProcesses, $desiredProcessCount)
+                max(
+                    $totalProcessCount - $maxDownShift,
+                    $supervisor->options->minProcesses,
+                    $desiredProcessCount
+                )
             );
         }
-    }
-
-    /**
-     * The maximum number of processes to increase or decrease per one scaling.
-     *
-     * @return int
-     */
-    public function maxShift(): int
-    {
-        return config('horizon.autoscaling.max_shift', 1);
     }
 }

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -131,12 +131,16 @@ class AutoScaler
         $desiredProcessCount = ceil($workers);
 
         if ($desiredProcessCount > $totalProcessCount) {
+            $maxUpShift = min($supervisor->options->maxProcesses - $supervisor->totalProcessCount(), $this->maxShift());
+
             $pool->scale(
-                min($totalProcessCount + $this->maxShift(), $supervisor->options->maxProcesses)
+                min($totalProcessCount + $maxUpShift, $supervisor->options->maxProcesses, $desiredProcessCount)
             );
         } elseif ($desiredProcessCount < $totalProcessCount) {
+            $maxDownShift = min($supervisor->totalProcessCount() - $supervisor->options->minProcesses, $this->maxShift());
+
             $pool->scale(
-                max($totalProcessCount - $this->maxShift(), $supervisor->options->minProcesses)
+                max($totalProcessCount - $maxDownShift, $supervisor->options->minProcesses, $desiredProcessCount)
             );
         }
     }

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -150,7 +150,7 @@ class AutoScaler
      *
      * @return int
      */
-    protected function maxShift(): int
+    public function maxShift(): int
     {
         return config('horizon.autoscaling.max_shift', 1);
     }

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -28,7 +28,9 @@ class SupervisorCommand extends Command
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+                            {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--balance-cooldown=3 : The number of seconds to wait in between auto-scaling attempts}
+                            {--auto-scale-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}';
 
     /**
      * The console command description.
@@ -112,7 +114,9 @@ class SupervisorCommand extends Command
             $this->option('sleep'),
             $this->option('tries'),
             $this->option('force'),
-            $this->option('nice')
+            $this->option('nice'),
+            $this->option('balance-cooldown'),
+            $this->option('auto-scale-max-shift')
         );
     }
 

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -68,7 +68,7 @@ class ProcessPool implements Countable
      */
     public function scale($processes)
     {
-        $processes = max(0, $processes);
+        $processes = max(0, (int) $processes);
 
         if ($processes === count($this->processes)) {
             return;

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -411,7 +411,7 @@ class Supervisor implements Pausable, Restartable, Terminable
      *
      * @return int
      */
-    protected function autoScaleCooldown(): int
+    public function autoScaleCooldown(): int
     {
         return config('horizon.autoscaling.cooldown', 3);
     }

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -325,9 +325,9 @@ class Supervisor implements Pausable, Restartable, Terminable
     protected function autoScale()
     {
         $this->lastAutoScaled = $this->lastAutoScaled ?:
-                    CarbonImmutable::now()->subSeconds($this->autoScaleCooldown() + 1);
+                    CarbonImmutable::now()->subSeconds($this->options->balanceCooldown + 1);
 
-        if (CarbonImmutable::now()->subSeconds($this->autoScaleCooldown())->gte($this->lastAutoScaled)) {
+        if (CarbonImmutable::now()->subSeconds($this->options->balanceCooldown)->gte($this->lastAutoScaled)) {
             $this->lastAutoScaled = CarbonImmutable::now();
 
             app(AutoScaler::class)->scale($this);
@@ -404,16 +404,6 @@ class Supervisor implements Pausable, Restartable, Terminable
     public function totalSystemProcessCount()
     {
         return app(SystemProcessCounter::class)->get($this->name);
-    }
-
-    /**
-     * The number of seconds to wait in between auto-scaling attempts.
-     *
-     * @return int
-     */
-    public function autoScaleCooldown(): int
-    {
-        return config('horizon.autoscaling.cooldown', 3);
     }
 
     /**

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -55,13 +55,6 @@ class Supervisor implements Pausable, Restartable, Terminable
     public $lastAutoScaled;
 
     /**
-     * The number of seconds to wait in between auto-scaling attempts.
-     *
-     * @var int
-     */
-    public $autoScaleCooldown = 3;
-
-    /**
      * The output handler.
      *
      * @var \Closure|null
@@ -332,9 +325,9 @@ class Supervisor implements Pausable, Restartable, Terminable
     protected function autoScale()
     {
         $this->lastAutoScaled = $this->lastAutoScaled ?:
-                    CarbonImmutable::now()->subSeconds($this->autoScaleCooldown + 1);
+                    CarbonImmutable::now()->subSeconds($this->autoScaleCooldown() + 1);
 
-        if (CarbonImmutable::now()->subSeconds($this->autoScaleCooldown)->gte($this->lastAutoScaled)) {
+        if (CarbonImmutable::now()->subSeconds($this->autoScaleCooldown())->gte($this->lastAutoScaled)) {
             $this->lastAutoScaled = CarbonImmutable::now();
 
             app(AutoScaler::class)->scale($this);
@@ -411,6 +404,16 @@ class Supervisor implements Pausable, Restartable, Terminable
     public function totalSystemProcessCount()
     {
         return app(SystemProcessCounter::class)->get($this->name);
+    }
+
+    /**
+     * The number of seconds to wait in between auto-scaling attempts.
+     *
+     * @return int
+     */
+    protected function autoScaleCooldown(): int
+    {
+        return config('horizon.autoscaling.cooldown', 3);
     }
 
     /**

--- a/src/SupervisorCommandString.php
+++ b/src/SupervisorCommandString.php
@@ -36,9 +36,10 @@ class SupervisorCommandString
      */
     public static function toOptionsString(SupervisorOptions $options)
     {
-        return sprintf('%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s',
+        return sprintf('%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s --balance-cooldown=%s --auto-scale-max-shift=%s',
             QueueCommandString::toOptionsString($options), $options->balance,
-            $options->maxProcesses, $options->minProcesses, $options->nice
+            $options->maxProcesses, $options->minProcesses, $options->nice,
+            $options->balanceCooldown, $options->autoScaleMaxShift
         );
     }
 

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -63,6 +63,20 @@ class SupervisorOptions extends WorkerOptions
     public $directory;
 
     /**
+     * The number of seconds to wait in between auto-scaling attempts.
+     *
+     * @var int
+     */
+    public $balanceCooldown = 3;
+
+    /**
+     * The maximum number of processes to increase or decrease per one scaling.
+     *
+     * @var int
+     */
+    public $autoScaleMaxShift = 1;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -78,10 +92,13 @@ class SupervisorOptions extends WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      * @param  int  $nice
+     * @param  int  $balanceCooldown
+     * @param  int  $autoScaleMaxShift
      */
     public function __construct($name, $connection, $queue = null, $balance = 'off',
                                 $delay = 0, $maxProcesses = 1, $minProcesses = 1, $memory = 128,
-                                $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $nice = 0)
+                                $timeout = 60, $sleep = 3, $maxTries = 0, $force = false, $nice = 0,
+                                $balanceCooldown = 3, $autoScaleMaxShift = 1)
     {
         $this->name = $name;
         $this->nice = $nice;
@@ -90,6 +107,8 @@ class SupervisorOptions extends WorkerOptions
         $this->maxProcesses = $maxProcesses;
         $this->minProcesses = $minProcesses;
         $this->queue = $queue ?: config('queue.connections.'.$connection.'.queue');
+        $this->balanceCooldown = $balanceCooldown;
+        $this->autoScaleMaxShift = $autoScaleMaxShift;
 
         parent::__construct($delay, $memory, $timeout, $sleep, $maxTries, $force);
     }
@@ -178,6 +197,8 @@ class SupervisorOptions extends WorkerOptions
             'name' => $this->name,
             'sleep' => $this->sleep,
             'timeout' => $this->timeout,
+            'balanceCooldown' => $this->balanceCooldown,
+            'autoScaleMaxShift' => $this->autoScaleMaxShift,
         ];
     }
 

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertEquals(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1 --nice=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --auto-scale-max-shift=1',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -182,20 +182,6 @@ class AutoScalerTest extends IntegrationTest
         return [$scaler, $supervisor];
     }
 
-    public function test_max_shift_returns_default_value_if_max_shift_is_not_specified_in_config()
-    {
-        config(['horizon.autoscaling' => null]);
-
-        $this->assertSame(1, app(AutoScaler::class)->maxShift());
-    }
-
-    public function test_max_shift_returns_value_from_config()
-    {
-        config(['horizon.autoscaling.max_shift' => 20]);
-
-        $this->assertSame(20, app(AutoScaler::class)->maxShift());
-    }
-
     public function test_scaler_considers_max_shift_and_attempts_to_get_closer_to_proper_balance_on_each_iteration()
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(150, [
@@ -203,7 +189,7 @@ class AutoScalerTest extends IntegrationTest
             'second' => ['current' => 75, 'size' => 300, 'runtime' => 75],
         ]);
 
-        config(['horizon.autoscaling.max_shift' => 10]);
+        $supervisor->options->autoScaleMaxShift = 10;
 
         $scaler->scale($supervisor);
 

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -35,7 +35,7 @@ class AutoScalerTest extends IntegrationTest
         $this->assertEquals(13, $supervisor->processPools['first']->totalProcessCount());
         $this->assertEquals(7, $supervisor->processPools['second']->totalProcessCount());
 
-        // Asset scaler stays at target values...
+        // Assert scaler stays at target values...
         $scaler->scale($supervisor);
 
         $this->assertEquals(13, $supervisor->processPools['first']->totalProcessCount());
@@ -180,5 +180,56 @@ class AutoScalerTest extends IntegrationTest
         });
 
         return [$scaler, $supervisor];
+    }
+
+    public function test_max_shift_returns_default_value_if_max_shift_is_not_specified_in_config()
+    {
+        config(['horizon.autoscaling' => null]);
+
+        $this->assertSame(1, app(AutoScaler::class)->maxShift());
+    }
+
+    public function test_max_shift_returns_value_from_config()
+    {
+        config(['horizon.autoscaling.max_shift' => 20]);
+
+        $this->assertSame(20, app(AutoScaler::class)->maxShift());
+    }
+
+    public function test_scaler_considers_max_shift_and_attempts_to_get_closer_to_proper_balance_on_each_iteration()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(150, [
+            'first' => ['current' => 75, 'size' => 600, 'runtime' => 75],
+            'second' => ['current' => 75, 'size' => 300, 'runtime' => 75],
+        ]);
+
+        config(['horizon.autoscaling.max_shift' => 10]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(85, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(65, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(95, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(55, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(100, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(50, $supervisor->processPools['second']->totalProcessCount());
+
+        // Assert scaler stays at target values...
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(100, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(50, $supervisor->processPools['second']->totalProcessCount());
+
+        // Assert scaler still stays at target values...
+        $scaler->scale($supervisor);
+
+        $this->assertEquals(100, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertEquals(50, $supervisor->processPools['second']->totalProcessCount());
     }
 }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -454,29 +454,29 @@ class SupervisorTest extends IntegrationTest
         // Start the supervisor...
         $supervisor->scale(1);
 
-        $baseTime = CarbonImmutable::create();
+        $time = CarbonImmutable::create();
 
         $this->assertNull($supervisor->lastAutoScaled);
 
         $supervisor->lastAutoScaled = null;
-        CarbonImmutable::setTestNow($baseTime);
+        CarbonImmutable::setTestNow($time);
         $supervisor->loop();
-        $this->assertTrue($supervisor->lastAutoScaled->eq($baseTime));
+        $this->assertTrue($supervisor->lastAutoScaled->eq($time));
 
-        $supervisor->lastAutoScaled = $baseTime;
-        CarbonImmutable::setTestNow($baseTime->addSeconds($supervisor->autoScaleCooldown() - 0.01));
+        $supervisor->lastAutoScaled = $time;
+        CarbonImmutable::setTestNow($time->addSeconds($supervisor->autoScaleCooldown() - 0.01));
         $supervisor->loop();
-        $this->assertTrue($supervisor->lastAutoScaled->eq($baseTime));
+        $this->assertTrue($supervisor->lastAutoScaled->eq($time));
 
-        $supervisor->lastAutoScaled = $baseTime;
-        CarbonImmutable::setTestNow($baseTime->addSeconds($supervisor->autoScaleCooldown()));
+        $supervisor->lastAutoScaled = $time;
+        CarbonImmutable::setTestNow($time->addSeconds($supervisor->autoScaleCooldown()));
         $supervisor->loop();
-        $this->assertTrue($supervisor->lastAutoScaled->eq($baseTime->addSeconds($supervisor->autoScaleCooldown())));
+        $this->assertTrue($supervisor->lastAutoScaled->eq($time->addSeconds($supervisor->autoScaleCooldown())));
 
-        $supervisor->lastAutoScaled = $baseTime;
-        CarbonImmutable::setTestNow($baseTime->addSeconds($supervisor->autoScaleCooldown() + 0.01));
+        $supervisor->lastAutoScaled = $time;
+        CarbonImmutable::setTestNow($time->addSeconds($supervisor->autoScaleCooldown() + 0.01));
         $supervisor->loop();
-        $this->assertTrue($supervisor->lastAutoScaled->eq($baseTime->addSeconds($supervisor->autoScaleCooldown())));
+        $this->assertTrue($supervisor->lastAutoScaled->eq($time->addSeconds($supervisor->autoScaleCooldown())));
     }
 
     public function test_supervisor_with_duplicate_name_cant_be_started()

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -421,35 +421,11 @@ class SupervisorTest extends IntegrationTest
         $supervisor->loop();
     }
 
-    public function test_auto_scale_cooldown_returns_value_from_config()
-    {
-        $options = $this->supervisorOptions();
-        $options->autoScale = true;
-        $this->supervisor = $supervisor = new Supervisor($options);
-
-        config(['horizon.autoscaling.cooldown' => 5]);
-
-        $this->assertSame(5, $supervisor->autoScaleCooldown());
-    }
-
-    public function test_auto_scale_cooldown_returns_default_value_if_cooldown_is_not_specified_in_the_config()
-    {
-        $options = $this->supervisorOptions();
-        $options->autoScale = true;
-        $this->supervisor = $supervisor = new Supervisor($options);
-
-        config(['horizon.autoscaling' => null]);
-
-        $this->assertSame(3, $supervisor->autoScaleCooldown());
-    }
-
     public function test_auto_scaler_is_not_called_on_loop_during_cooldown()
     {
         $options = $this->supervisorOptions();
         $options->autoScale = true;
         $this->supervisor = $supervisor = new Supervisor($options);
-
-        config(['horizon.autoscaling.cooldown' => 5]);
 
         // Start the supervisor...
         $supervisor->scale(1);
@@ -464,19 +440,19 @@ class SupervisorTest extends IntegrationTest
         $this->assertTrue($supervisor->lastAutoScaled->eq($time));
 
         $supervisor->lastAutoScaled = $time;
-        CarbonImmutable::setTestNow($time->addSeconds($supervisor->autoScaleCooldown() - 0.01));
+        CarbonImmutable::setTestNow($time->addSeconds($supervisor->options->balanceCooldown - 0.01));
         $supervisor->loop();
         $this->assertTrue($supervisor->lastAutoScaled->eq($time));
 
         $supervisor->lastAutoScaled = $time;
-        CarbonImmutable::setTestNow($time->addSeconds($supervisor->autoScaleCooldown()));
+        CarbonImmutable::setTestNow($time->addSeconds($supervisor->options->balanceCooldown));
         $supervisor->loop();
-        $this->assertTrue($supervisor->lastAutoScaled->eq($time->addSeconds($supervisor->autoScaleCooldown())));
+        $this->assertTrue($supervisor->lastAutoScaled->eq($time->addSeconds($supervisor->options->balanceCooldown)));
 
         $supervisor->lastAutoScaled = $time;
-        CarbonImmutable::setTestNow($time->addSeconds($supervisor->autoScaleCooldown() + 0.01));
+        CarbonImmutable::setTestNow($time->addSeconds($supervisor->options->balanceCooldown + 0.01));
         $supervisor->loop();
-        $this->assertTrue($supervisor->lastAutoScaled->eq($time->addSeconds($supervisor->autoScaleCooldown())));
+        $this->assertTrue($supervisor->lastAutoScaled->eq($time->addSeconds($supervisor->options->balanceCooldown)));
     }
 
     public function test_supervisor_with_duplicate_name_cant_be_started()


### PR DESCRIPTION
This PR makes autobalancing rate configurable for applications that use the `auto` queue balancing strategy.

## Problem

Imagine we have the following supervisor config:

```php
'supervisor-1' => [
    'connection' => 'redis',
    'queue' => ['high', 'low'],
    'balance' => 'auto',
    'minProcesses' => 5,
    'maxProcesses' => 150,
    'tries' => 1,
],
```

Let's say we dispatch 1,000 jobs to the `low` queue for something like an email campaign. Currently, autobalancing will only adjust the number of workers at a maximum rate of ±1 worker every 3 seconds. So, it will take a long time to increase the number of workers from 5 (`minProcesses`) to 150 (`maxProcesses`). There's no way to change this.

## Solution

With this PR we make the autobalancing rate configurable:

```php
/*
|--------------------------------------------------------------------------
| Autoscaling
|--------------------------------------------------------------------------
|
| Here you may define the autoscaling settings used by your application.
|
*/

'autoscaling' => [
    'cooldown' => 3,
    'max_shift' => 1,
],
```

`cooldown` - the number of seconds to wait in between auto-scaling attempts
`max_shift` - the maximum number of processes to increase or decrease per one scaling

## Breaking changes

This PR doesn't introduce any breaking changes since the default values (for `cooldown` and `max_shift`) are consistent with the current values. Even if someone upgrades without adding these config values, it will still use those defaults.

However, I decided that it might be better to point this PR to the `5.x` branch.

## Benefit

Let's perform a test by dispatching 750 jobs at once (each job sleeps for 5 seconds) without this change. We can see it takes [135 seconds](https://pastebin.com/raw/LJ9cHLbK) to process these jobs.

Let's set `'cooldown' => 1` and `'max_shift' => 50` and perform the same test one more time. 

This time, it took only [30 seconds](https://pastebin.com/raw/QZqkMC4C), because autoscaling happens much faster.

## Related issues

https://github.com/laravel/horizon/issues/658