### PR TITLE
unhide horizon command

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -24,13 +24,6 @@ class HorizonCommand extends Command
     protected $description = 'Start a master supervisor in the foreground';
 
     /**
-     * Indicates whether the command should be shown in the Artisan command list.
-     *
-     * @var bool
-     */
-    protected $hidden = true;
-
-    /**
      * Execute the console command.
      *
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters


### PR DESCRIPTION
`php artisan horizon` is the main horizon command that users must run. So it shouldn't be hidden.