### PR TITLE
[5.0] Check if parent is still running

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -34,7 +34,8 @@ class SupervisorCommand extends Command
                             {--tries=0 : Number of times to attempt a job before logging it failed}
                             {--balance-cooldown=3 : The number of seconds to wait in between auto-scaling attempts}
                             {--balance-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}
-                            {--workers-name=default : The name that should be assigned to the workers}';
+                            {--workers-name=default : The name that should be assigned to the workers}
+                            {--parent-id=0 : The parent process id}';
 
     /**
      * The console command description.
@@ -127,7 +128,8 @@ class SupervisorCommand extends Command
             $this->option('force'),
             $this->option('nice'),
             $this->option('balance-cooldown'),
-            $this->option('balance-max-shift')
+            $this->option('balance-max-shift'),
+            $this->option('parent-id')
         );
     }
 

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -35,7 +35,7 @@ class SupervisorCommand extends Command
                             {--balance-cooldown=3 : The number of seconds to wait in between auto-scaling attempts}
                             {--balance-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}
                             {--workers-name=default : The name that should be assigned to the workers}
-                            {--parent-id=0 : The parent process id}';
+                            {--parent-id=0 : The parent process ID}';
 
     /**
      * The console command description.

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -176,6 +176,8 @@ class ProvisioningPlan
             return [Str::camel($key) => $value];
         })->all();
 
+        $options['parentId'] = getmypid();
+
         return SupervisorOptions::fromArray(
             Arr::add($options, 'name', $this->master.":{$supervisor}")
         );

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -281,6 +281,8 @@ class Supervisor implements Pausable, Restartable, Terminable
     public function loop()
     {
         try {
+            $this->ensureParentIsRunning();
+
             $this->processPendingSignals();
 
             $this->processPendingCommands();
@@ -302,6 +304,18 @@ class Supervisor implements Pausable, Restartable, Terminable
             event(new SupervisorLooped($this));
         } catch (Throwable $e) {
             app(ExceptionHandler::class)->report($e);
+        }
+    }
+
+    /**
+     * Ensure the parent process is still running.
+     *
+     * @return void
+     */
+    protected function ensureParentIsRunning()
+    {
+        if ($this->options->parentId > 1 && posix_getppid() <= 1) {
+            $this->terminate();
         }
     }
 

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -54,6 +54,13 @@ class SupervisorOptions
     public $minProcesses = 1;
 
     /**
+     * The parent process identifier.
+     *
+     * @var int
+     */
+    public $parentId = 0;
+
+    /**
      * The process priority.
      *
      * @var int
@@ -158,6 +165,7 @@ class SupervisorOptions
      * @param  int  $nice
      * @param  int  $balanceCooldown
      * @param  int  $balanceMaxShift
+     * @param  int  $parentId
      */
     public function __construct($name,
                                 $connection,
@@ -176,7 +184,8 @@ class SupervisorOptions
                                 $force = false,
                                 $nice = 0,
                                 $balanceCooldown = 3,
-                                $balanceMaxShift = 1)
+                                $balanceMaxShift = 1,
+                                $parentId = 0)
     {
         $this->name = $name;
         $this->connection = $connection;
@@ -196,6 +205,7 @@ class SupervisorOptions
         $this->nice = $nice;
         $this->balanceCooldown = $balanceCooldown;
         $this->balanceMaxShift = $balanceMaxShift;
+        $this->parentId = 0;
     }
 
     /**


### PR DESCRIPTION
Currently if horizon process gets terminated by SIGKILL, supervisor processes must be killed by kill command, or they will be provisioning workers for ever. There is no artisan command to terminate orphan supervisors, so it is a little bit of trouble.

If you want to see if you have orphan supervisors in your production, you can use the following command:
```bash
ps  xao pid,ppid,etime,time,comm,args|grep -P "^\\s+(PID|\\d+\\s+[01]\s.*horizon:)"
```

This PR lets the orphan supervisors check for their parent process id at the beginning of their loop, so they can terminate in case their parent, `php artisan horizon`, is no longer running.
