### PR TITLE
Improve assertions

### DIFF
--- a/tests/Controller/MonitoringControllerTest.php
+++ b/tests/Controller/MonitoringControllerTest.php
@@ -51,8 +51,8 @@ class MonitoringControllerTest extends AbstractControllerTest
         $results = $response->original['jobs'];
 
         $this->assertCount(25, $results);
-        $this->assertEquals(49, $results[0]->id);
-        $this->assertEquals(25, $results[24]->id);
+        $this->assertSame('49', $results[0]->id);
+        $this->assertSame('25', $results[24]->id);
 
         // Paginate second set...
         $response = $this->actingAs(new Fakes\User)
@@ -61,10 +61,10 @@ class MonitoringControllerTest extends AbstractControllerTest
         $results = $response->original['jobs'];
 
         $this->assertCount(25, $results);
-        $this->assertEquals(24, $results[0]->id);
-        $this->assertEquals(0, $results[24]->id);
-        $this->assertEquals(25, $results[0]->index);
-        $this->assertEquals(49, $results[24]->index);
+        $this->assertSame('24', $results[0]->id);
+        $this->assertSame('0', $results[24]->id);
+        $this->assertSame('25', $results[0]->index);
+        $this->assertSame(49, $results[24]->index);
     }
 
     public function test_can_paginate_where_jobs_dont_exist()

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -27,7 +27,7 @@ class AddSupervisorTest extends IntegrationTest
 
         $this->assertCount(1, $master->supervisors);
 
-        $this->assertEquals(
+        $this->assertSame(
             'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --balance=off --max-processes=1 --min-processes=1 --nice=0',
             $master->supervisors->first()->process->getCommandLine()
         );

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -22,24 +22,24 @@ class AutoScalerTest extends IntegrationTest
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(11, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(9, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(11, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(9, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(12, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(8, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(12, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(8, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(13, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(7, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(13, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(7, $supervisor->processPools['second']->totalProcessCount());
 
         // Asset scaler stays at target values...
         $scaler->scale($supervisor);
 
-        $this->assertEquals(13, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(7, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(13, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(7, $supervisor->processPools['second']->totalProcessCount());
     }
 
     public function test_balance_stays_even_when_queue_is_empty()
@@ -51,23 +51,23 @@ class AutoScalerTest extends IntegrationTest
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(4, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(4, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(4, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(4, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(3, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(3, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(3, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(2, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(2, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(1, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
     }
 
     public function test_balancer_assigns_more_processes_on_busy_queue()
@@ -80,27 +80,27 @@ class AutoScalerTest extends IntegrationTest
         $scaler->scale($supervisor);
         $scaler->scale($supervisor);
 
-        $this->assertEquals(3, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
         $scaler->scale($supervisor);
 
-        $this->assertEquals(5, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(5, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
         $scaler->scale($supervisor);
 
-        $this->assertEquals(7, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(7, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
         $scaler->scale($supervisor);
         $scaler->scale($supervisor);
 
-        $this->assertEquals(9, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(1, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(9, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
     }
 
     public function test_balancing_a_single_queue_assigns_it_the_min_workers_with_empty_queue()
@@ -110,7 +110,7 @@ class AutoScalerTest extends IntegrationTest
         ]);
 
         $scaler->scale($supervisor);
-        $this->assertEquals(1, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['first']->totalProcessCount());
     }
 
     public function test_scaler_will_not_scale_past_max_process_threshold_under_high_load()
@@ -122,8 +122,8 @@ class AutoScalerTest extends IntegrationTest
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(10, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(10, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(10, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(10, $supervisor->processPools['second']->totalProcessCount());
     }
 
     public function test_scaler_will_not_scale_below_minimum_worker_threshold()
@@ -139,13 +139,13 @@ class AutoScalerTest extends IntegrationTest
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(3, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(2, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['second']->totalProcessCount());
 
         $scaler->scale($supervisor);
 
-        $this->assertEquals(3, $supervisor->processPools['first']->totalProcessCount());
-        $this->assertEquals(2, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['second']->totalProcessCount());
     }
 
     protected function with_scaling_scenario($maxProcesses, array $pools, array $extraOptions = [])

--- a/tests/Feature/FailedJobTest.php
+++ b/tests/Feature/FailedJobTest.php
@@ -14,7 +14,7 @@ class FailedJobTest extends IntegrationTest
     {
         $id = Queue::push(new Jobs\FailingJob);
         $this->work();
-        $this->assertEquals(1, $this->failedJobs());
+        $this->assertSame(1, $this->failedJobs());
         $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($id));
 
         $job = resolve(JobRepository::class)->getJobs([$id])[0];
@@ -22,8 +22,8 @@ class FailedJobTest extends IntegrationTest
         $this->assertTrue(isset($job->exception));
         $this->assertTrue(isset($job->failed_at));
         $this->assertSame('failed', $job->status);
-        $this->assertTrue(is_numeric($job->failed_at));
-        $this->assertEquals(Jobs\FailingJob::class, $job->name);
+        $this->assertIsNumeric($job->failed_at);
+        $this->assertSame(Jobs\FailingJob::class, $job->name);
     }
 
     public function test_tags_for_failed_jobs_are_stored_in_redis()

--- a/tests/Feature/JobRetrievalTest.php
+++ b/tests/Feature/JobRetrievalTest.php
@@ -28,18 +28,18 @@ class JobRetrievalTest extends IntegrationTest
         // Test getting all jobs...
         $this->assertCount(5, $recent);
         $this->assertEquals($ids[4], $recent->first()->id);
-        $this->assertEquals(Jobs\BasicJob::class, $recent->first()->name);
-        $this->assertEquals(0, $recent->first()->index);
+        $this->assertSame(Jobs\BasicJob::class, $recent->first()->name);
+        $this->assertSame(0, $recent->first()->index);
         $this->assertEquals($ids[0], $recent->last()->id);
-        $this->assertEquals(4, $recent->last()->index);
+        $this->assertSame(4, $recent->last()->index);
 
         // Test pagination...
         $recent = $repository->getRecent(1);
         $this->assertCount(3, $recent);
         $this->assertEquals($ids[2], $recent->first()->id);
-        $this->assertEquals(2, $recent->first()->index);
+        $this->assertSame(2, $recent->first()->index);
         $this->assertEquals($ids[0], $recent->last()->id);
-        $this->assertEquals(4, $recent->last()->index);
+        $this->assertSame(4, $recent->last()->index);
 
         // Test no results...
         $recent = $repository->getRecent(4);
@@ -59,10 +59,10 @@ class JobRetrievalTest extends IntegrationTest
         $repository = resolve(JobRepository::class);
         Chronos::setTestNow(Chronos::now()->addHours(3));
 
-        $this->assertEquals(5, Redis::connection('horizon')->zcard('recent_jobs'));
+        $this->assertSame(5, Redis::connection('horizon')->zcard('recent_jobs'));
 
         $repository->trimRecentJobs();
-        $this->assertEquals(0, Redis::connection('horizon')->zcard('recent_jobs'));
+        $this->assertSame(0, Redis::connection('horizon')->zcard('recent_jobs'));
 
         // Assert job record has a TTL...
         $repository->completed(new JobPayload(json_encode(['id' => $ids[0]])));

--- a/tests/Feature/MasterSupervisorTest.php
+++ b/tests/Feature/MasterSupervisorTest.php
@@ -93,7 +93,7 @@ class MasterSupervisorTest extends IntegrationTest
         $command = (object) json_decode($commands[0], true);
 
         $this->assertCount(0, $master->supervisors);
-        $this->assertEquals(AddSupervisor::class, $command->command);
+        $this->assertSame(AddSupervisor::class, $command->command);
         $this->assertSame('default', $command->options['queue']);
     }
 
@@ -148,7 +148,7 @@ class MasterSupervisorTest extends IntegrationTest
 
         $command = resolve(Commands\FakeMasterCommand::class);
 
-        $this->assertEquals(1, $command->processCount);
+        $this->assertSame(1, $command->processCount);
         $this->assertEquals($master, $command->master);
         $this->assertEquals(['foo' => 'bar'], $command->options);
     }

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -19,7 +19,7 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $this->assertEquals(2, resolve(MetricsRepository::class)->throughput());
+        $this->assertSame(2, resolve(MetricsRepository::class)->throughput());
     }
 
     public function test_throughput_is_stored_per_job_class()
@@ -34,9 +34,9 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $this->assertEquals(4, resolve(MetricsRepository::class)->throughput());
-        $this->assertEquals(3, resolve(MetricsRepository::class)->throughputForJob(Jobs\BasicJob::class));
-        $this->assertEquals(1, resolve(MetricsRepository::class)->throughputForJob(Jobs\ConditionallyFailingJob::class));
+        $this->assertSame(4, resolve(MetricsRepository::class)->throughput());
+        $this->assertSame(3, resolve(MetricsRepository::class)->throughputForJob(Jobs\BasicJob::class));
+        $this->assertSame(1, resolve(MetricsRepository::class)->throughputForJob(Jobs\ConditionallyFailingJob::class));
     }
 
     public function test_throughput_is_stored_per_queue()
@@ -51,8 +51,8 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $this->assertEquals(4, resolve(MetricsRepository::class)->throughput());
-        $this->assertEquals(4, resolve(MetricsRepository::class)->throughputForQueue('default'));
+        $this->assertSame(4, resolve(MetricsRepository::class)->throughput());
+        $this->assertSame(4, resolve(MetricsRepository::class)->throughputForQueue('default'));
     }
 
     public function test_average_runtime_is_stored_per_job_class_in_milliseconds()
@@ -68,7 +68,7 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $this->assertEquals(1.5, resolve(MetricsRepository::class)->runtimeForJob(Jobs\BasicJob::class));
+        $this->assertSame(1.5, resolve(MetricsRepository::class)->runtimeForJob(Jobs\BasicJob::class));
     }
 
     public function test_average_runtime_is_stored_per_queue_in_milliseconds()
@@ -84,7 +84,7 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $this->assertEquals(1.5, resolve(MetricsRepository::class)->runtimeForQueue('default'));
+        $this->assertSame(1.5, resolve(MetricsRepository::class)->runtimeForQueue('default'));
     }
 
     public function test_list_of_all_jobs_with_metric_information_is_maintained()
@@ -97,8 +97,8 @@ class MetricsTest extends IntegrationTest
 
         $jobs = resolve(MetricsRepository::class)->measuredJobs();
         $this->assertCount(2, $jobs);
-        $this->assertTrue(in_array(Jobs\ConditionallyFailingJob::class, $jobs));
-        $this->assertTrue(in_array(Jobs\BasicJob::class, $jobs));
+        $this->assertContains(Jobs\ConditionallyFailingJob::class, $jobs);
+        $this->assertContains(Jobs\BasicJob::class, $jobs);
     }
 
     public function test_snapshot_of_metrics_performance_can_be_stored()
@@ -173,22 +173,22 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $this->assertEquals(
-            2, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
+        $this->assertSame(
+            2.0, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
         );
 
         // Adjust current time...
         Chronos::setTestNow(Chronos::now()->addMinutes(2));
 
-        $this->assertEquals(
-            1, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
+        $this->assertSame(
+            1.0, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
         );
 
         // take snapshot and ensure count is reset...
         resolve(MetricsRepository::class)->snapshot();
 
-        $this->assertEquals(
-            0, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
+        $this->assertSame(
+            0.0, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
         );
     }
 
@@ -212,12 +212,12 @@ class MetricsTest extends IntegrationTest
         // Check the job snapshots...
         $snapshots = resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class);
         $this->assertCount(24, $snapshots);
-        $this->assertEquals(Chronos::now()->getTimestamp() - 1, $snapshots[23]->time);
+        $this->assertSame(Chronos::now()->getTimestamp() - 1, $snapshots[23]->time);
 
         // Check the queue snapshots...
         $snapshots = resolve(MetricsRepository::class)->snapshotsForQueue('default');
         $this->assertCount(24, $snapshots);
-        $this->assertEquals(Chronos::now()->getTimestamp() - 1, $snapshots[23]->time);
+        $this->assertSame(Chronos::now()->getTimestamp() - 1, $snapshots[23]->time);
 
         Chronos::setTestNow();
     }

--- a/tests/Feature/MonitoringTest.php
+++ b/tests/Feature/MonitoringTest.php
@@ -20,8 +20,8 @@ class MonitoringTest extends IntegrationTest
 
         dispatch(new MonitorTag('second'));
         $monitored = $repository->monitoring();
-        $this->assertTrue(in_array('first', $monitored));
-        $this->assertTrue(in_array('second', $monitored));
+        $this->assertContains('first', $monitored);
+        $this->assertContains('second', $monitored);
         $this->assertCount(2, $monitored);
     }
 
@@ -52,7 +52,7 @@ class MonitoringTest extends IntegrationTest
         dispatch(new MonitorTag('first'));
         $id = Queue::push(new Jobs\BasicJob);
         $this->work();
-        $this->assertEquals(1, $this->monitoredJobs('first'));
+        $this->assertSame(1, $this->monitoredJobs('first'));
         $this->assertGreaterThan(0, Redis::connection('horizon')->ttl($id));
     }
 
@@ -62,7 +62,7 @@ class MonitoringTest extends IntegrationTest
         Queue::push(new Jobs\BasicJob);
         $this->work();
         dispatch(new StopMonitoringTag('first'));
-        $this->assertEquals(0, $this->monitoredJobs('first'));
+        $this->assertSame(0, $this->monitoredJobs('first'));
     }
 
     public function test_all_completed_jobs_are_removed_from_database_when_their_tag_is_no_longer_monitored()
@@ -76,6 +76,6 @@ class MonitoringTest extends IntegrationTest
         $this->work();
 
         dispatch(new StopMonitoringTag('first'));
-        $this->assertEquals(0, $this->monitoredJobs('first'));
+        $this->assertSame(0, $this->monitoredJobs('first'));
     }
 }

--- a/tests/Feature/ProvisioningPlanTest.php
+++ b/tests/Feature/ProvisioningPlanTest.php
@@ -31,9 +31,9 @@ class ProvisioningPlanTest extends IntegrationTest
 
         $this->assertCount(1, $commands);
         $command = (object) json_decode($commands[0], true);
-        $this->assertEquals(AddSupervisor::class, $command->command);
+        $this->assertSame(AddSupervisor::class, $command->command);
         $this->assertSame('first', $command->options['queue']);
-        $this->assertEquals(20, $command->options['maxProcesses']);
+        $this->assertSame(20, $command->options['maxProcesses']);
     }
 
     public function test_supervisors_are_added_by_wildcard()
@@ -57,9 +57,9 @@ class ProvisioningPlanTest extends IntegrationTest
 
         $this->assertCount(1, $commands);
         $command = (object) json_decode($commands[0], true);
-        $this->assertEquals(AddSupervisor::class, $command->command);
+        $this->assertSame(AddSupervisor::class, $command->command);
         $this->assertSame('first', $command->options['queue']);
-        $this->assertEquals(20, $command->options['maxProcesses']);
+        $this->assertSame(20, $command->options['maxProcesses']);
     }
 
     public function test_plan_is_converted_into_array_of_supervisor_options()
@@ -90,12 +90,12 @@ class ProvisioningPlanTest extends IntegrationTest
 
         $results = (new ProvisioningPlan(MasterSupervisor::name(), $plan))->toSupervisorOptions();
 
-        $this->assertEquals(MasterSupervisor::name().':supervisor-1', $results['production']['supervisor-1']->name);
+        $this->assertSame(MasterSupervisor::name().':supervisor-1', $results['production']['supervisor-1']->name);
         $this->assertSame('redis', $results['production']['supervisor-1']->connection);
         $this->assertSame('default', $results['production']['supervisor-1']->queue);
         $this->assertTrue($results['production']['supervisor-1']->balance);
         $this->assertTrue($results['production']['supervisor-1']->autoScale);
 
-        $this->assertEquals(20, $results['local']['supervisor-2']->maxProcesses);
+        $this->assertSame(20, $results['local']['supervisor-2']->maxProcesses);
     }
 }

--- a/tests/Feature/QueueProcessingTest.php
+++ b/tests/Feature/QueueProcessingTest.php
@@ -23,21 +23,21 @@ class QueueProcessingTest extends IntegrationTest
     {
         Queue::push(new Jobs\BasicJob);
         $this->work();
-        $this->assertEquals(0, $this->monitoredJobs('first'));
-        $this->assertEquals(0, $this->monitoredJobs('second'));
+        $this->assertSame(0, $this->monitoredJobs('first'));
+        $this->assertSame(0, $this->monitoredJobs('second'));
     }
 
     public function test_pending_jobs_are_stored_in_pending_job_database()
     {
         $id = Queue::push(new Jobs\BasicJob);
-        $this->assertEquals(1, $this->recentJobs());
+        $this->assertSame(1, $this->recentJobs());
         $this->assertSame('pending', Redis::connection('horizon')->hget($id, 'status'));
     }
 
     public function test_pending_delayed_jobs_are_stored_in_pending_job_database()
     {
         $id = Queue::later(1, new Jobs\BasicJob);
-        $this->assertEquals(1, $this->recentJobs());
+        $this->assertSame(1, $this->recentJobs());
         $this->assertSame('pending', Redis::connection('horizon')->hget($id, 'status'));
     }
 

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -17,7 +17,7 @@ class RedisJobRepositoryTest extends IntegrationTest
 
         $repository->failed(new Exception('Failed Job'), 'redis', 'default', $payload);
 
-        $this->assertEquals(1, $repository->findFailed(1)->id);
+        $this->assertSame('1', $repository->findFailed(1)->id);
     }
 
     public function test_it_will_not_find_a_failed_job_if_the_job_has_not_failed()

--- a/tests/Feature/RedisPrefixTest.php
+++ b/tests/Feature/RedisPrefixTest.php
@@ -14,6 +14,6 @@ class RedisPrefixTest extends IntegrationTest
 
         Horizon::use('default');
 
-        $this->assertEquals('custom:', config('database.redis.horizon.options.prefix'));
+        $this->assertSame('custom:', config('database.redis.horizon.options.prefix'));
     }
 }

--- a/tests/Feature/RetryJobTest.php
+++ b/tests/Feature/RetryJobTest.php
@@ -34,7 +34,7 @@ class RetryJobTest extends IntegrationTest
         $_SERVER['horizon.fail'] = true;
         $id = Queue::push(new Jobs\ConditionallyFailingJob);
         $this->work();
-        $this->assertEquals(1, $this->failedJobs());
+        $this->assertSame(1, $this->failedJobs());
 
         // Monitor the tag so the job is stored in the completed table...
         dispatch(new MonitorTag('first'));
@@ -50,8 +50,8 @@ class RetryJobTest extends IntegrationTest
         // Work the now-passing job...
         $this->work();
 
-        $this->assertEquals(1, $this->failedJobs());
-        $this->assertEquals(1, $this->monitoredJobs('first'));
+        $this->assertSame(1, $this->failedJobs());
+        $this->assertSame(1, $this->monitoredJobs('first'));
 
         // Test that retry job ID reference is stored on original failed job...
         $retried = Redis::connection('horizon')->hget($id, 'retried_by');

--- a/tests/Feature/SupervisorCommandTest.php
+++ b/tests/Feature/SupervisorCommandTest.php
@@ -34,7 +34,7 @@ class SupervisorCommandTest extends IntegrationTest
         $this->app->instance(SupervisorFactory::class, $factory = new FakeSupervisorFactory);
         $this->artisan('horizon:supervisor', ['name' => 'foo', 'connection' => 'redis', '--nice' => 10]);
 
-        $this->assertEquals(10, $this->myNiceness());
+        $this->assertSame(10, $this->myNiceness());
     }
 
     private function myNiceness()

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -52,7 +52,7 @@ class SupervisorTest extends IntegrationTest
     public function test_supervisor_can_start_worker_process_with_given_options()
     {
         Queue::push(new Jobs\BasicJob);
-        $this->assertEquals(1, $this->recentJobs());
+        $this->assertSame(1, $this->recentJobs());
 
         $this->supervisor = $supervisor = new Supervisor($this->supervisorOptions());
 
@@ -66,7 +66,7 @@ class SupervisorTest extends IntegrationTest
         $this->assertCount(1, $supervisor->processes());
 
         $host = MasterSupervisor::name();
-        $this->assertEquals(
+        $this->assertSame(
             'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
@@ -84,12 +84,12 @@ class SupervisorTest extends IntegrationTest
 
         $host = MasterSupervisor::name();
 
-        $this->assertEquals(
+        $this->assertSame(
             'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="first" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[0]->getCommandLine()
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'exec '.$this->phpBinary.' worker.php redis --delay=0 --memory=128 --queue="second" --sleep=3 --timeout=60 --tries=0 --supervisor='.$host.':name',
             $supervisor->processes()[1]->getCommandLine()
         );
@@ -98,7 +98,7 @@ class SupervisorTest extends IntegrationTest
     public function test_recent_jobs_are_correctly_maintained()
     {
         $id = Queue::push(new Jobs\BasicJob);
-        $this->assertEquals(1, $this->recentJobs());
+        $this->assertSame(1, $this->recentJobs());
 
         $this->supervisor = $supervisor = new Supervisor($options = $this->supervisorOptions());
 
@@ -106,7 +106,7 @@ class SupervisorTest extends IntegrationTest
         $supervisor->loop();
 
         $this->wait(function () {
-            $this->assertEquals(1, $this->recentJobs());
+            $this->assertSame(1, $this->recentJobs());
         });
 
         $this->wait(function () use ($id) {
@@ -163,8 +163,8 @@ class SupervisorTest extends IntegrationTest
 
         $record = resolve(SupervisorRepository::class)->find($supervisor->name);
         $this->assertSame('running', $record->status);
-        $this->assertEquals(2, collect($record->processes)->sum());
-        $this->assertEquals(2, $record->processes['redis:default,another']);
+        $this->assertSame(2, collect($record->processes)->sum());
+        $this->assertSame(2, $record->processes['redis:default,another']);
         $this->assertTrue(isset($record->pid));
         $this->assertSame('redis', $record->options['connection']);
 
@@ -253,7 +253,7 @@ class SupervisorTest extends IntegrationTest
         Queue::push(new Jobs\BasicJob);
         usleep(1100 * 1000);
 
-        $this->assertEquals(1, $this->recentJobs());
+        $this->assertSame(1, $this->recentJobs());
 
         $supervisor->continue();
         $this->assertTrue($supervisor->processPools[0]->working);
@@ -312,7 +312,7 @@ class SupervisorTest extends IntegrationTest
         $supervisor->scale(0);
         usleep(500 * 1000);
 
-        $this->assertEquals(0, $supervisor->pruneAndGetTotalProcesses());
+        $this->assertSame(0, $supervisor->pruneAndGetTotalProcesses());
     }
 
     public function test_terminating_processes_that_are_stuck_are_hard_stopped()
@@ -370,7 +370,7 @@ class SupervisorTest extends IntegrationTest
 
         $command = resolve(Commands\FakeCommand::class);
 
-        $this->assertEquals(1, $command->processCount);
+        $this->assertSame(1, $command->processCount);
         $this->assertEquals($supervisor, $command->supervisor);
         $this->assertEquals(['foo' => 'bar'], $command->options);
     }
@@ -392,12 +392,12 @@ class SupervisorTest extends IntegrationTest
 
         $supervisor->loop();
 
-        $this->assertEquals(2, $supervisor->totalProcessCount());
+        $this->assertSame(2, $supervisor->totalProcessCount());
 
         Queue::push(new Jobs\BasicJob);
         usleep(500 * 1000);
 
-        $this->assertEquals(1, $this->recentJobs());
+        $this->assertSame(1, $this->recentJobs());
     }
 
     public function test_auto_scaler_is_called_on_loop_when_auto_scaling()
@@ -442,7 +442,7 @@ class SupervisorTest extends IntegrationTest
         $supervisor->loop();
 
         $this->wait(function () use ($supervisor) {
-            $this->assertEquals(3, $supervisor->totalSystemProcessCount());
+            $this->assertSame(3, $supervisor->totalSystemProcessCount());
         });
     }
 
@@ -454,21 +454,21 @@ class SupervisorTest extends IntegrationTest
         $supervisor->scale(3);
 
         $this->wait(function () use ($supervisor) {
-            $this->assertEquals(0, $supervisor->totalSystemProcessCount());
+            $this->assertSame(0, $supervisor->totalSystemProcessCount());
         });
 
         $supervisor->working = false;
         $supervisor->loop();
 
         $this->wait(function () use ($supervisor) {
-            $this->assertEquals(0, $supervisor->totalSystemProcessCount());
+            $this->assertSame(0, $supervisor->totalSystemProcessCount());
         });
 
         $supervisor->working = true;
         $supervisor->loop();
 
         $this->wait(function () use ($supervisor) {
-            $this->assertEquals(3, $supervisor->totalSystemProcessCount());
+            $this->assertSame(3, $supervisor->totalSystemProcessCount());
         });
     }
 

--- a/tests/Feature/TagRepositoryTest.php
+++ b/tests/Feature/TagRepositoryTest.php
@@ -18,13 +18,13 @@ class TagRepositoryTest extends IntegrationTest
         $results = $repo->paginate('tag', 0, 25);
 
         $this->assertCount(25, $results);
-        $this->assertEquals(49, $results[0]);
-        $this->assertEquals(25, $results[24]);
+        $this->assertSame('49', $results[0]);
+        $this->assertSame('25', $results[24]);
 
         $results = $repo->paginate('tag', last(array_keys($results)) + 1, 25);
 
         $this->assertCount(25, $results);
-        $this->assertEquals(24, $results[25]);
-        $this->assertEquals(0, $results[49]);
+        $this->assertSame('24', $results[25]);
+        $this->assertSame('0', $results[49]);
     }
 }

--- a/tests/Feature/WaitTimeCalculatorTest.php
+++ b/tests/Feature/WaitTimeCalculatorTest.php
@@ -101,8 +101,8 @@ class WaitTimeCalculatorTest extends IntegrationTest
             $calculator->calculate('redis:test-queue-2')
         );
 
-        $this->assertEquals(
-            40,
+        $this->assertSame(
+            40.0,
             $calculator->calculateFor('redis:test-queue-2')
         );
     }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` to make assert equals checking strict.
- Using the `assertIsNumeric` to assert result type is `numeric`.
- Using the `assertContains` to assert expected key contains result array.