### PR TITLE
[5.x] Add ability to clear queues from dashboard

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -301,7 +301,7 @@
                     <th>Queue</th>
                     <th>Processes</th>
                     <th>Jobs</th>
-                    <th>Clear</th>
+                    <th v-if="Horizon.supportsClear">Clear</th>
                     <th class="text-right">Wait</th>
                 </tr>
                 </thead>
@@ -313,7 +313,7 @@
                     </td>
                     <td>{{ queue.processes ? queue.processes.toLocaleString() : 0 }}</td>
                     <td>{{ queue.length ? queue.length.toLocaleString() : 0 }}</td>
-                    <td>
+                    <td v-if="Horizon.supportsClear">
                         <button class="btn btn-outline-danger" title="Clear queued jobs" :disabled="purge.queue === queue.name" @click="confirmClearQueue(queue)">
 
                             <svg class="icon fill-danger" viewBox="0 0 20 20">

--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -11,6 +11,11 @@
          */
         data() {
             return {
+                purge: {
+                    queue: null,
+                    message: null,
+                    confirm: false,
+                },
                 stats: {},
                 workers: [],
                 workload: [],
@@ -148,7 +153,31 @@
              */
             determinePeriod(minutes) {
                 return moment.duration(moment().diff(moment().subtract(minutes, "minutes"))).humanize().replace(/^An?/i, '');
-            }
+            },
+
+
+            /**
+              * Displays confirmation to clear queued jobs from given queue
+              */
+             confirmClearQueue(queue) {
+                 this.purge.queue = queue.name;
+                 this.purge.message = `Are you sure you want to clear the '${queue.name}' queue?`;
+                 this.purge.confirm = true;
+
+                 this.$nextTick(() => {
+                     this.$refs.purgeModal.open();
+                 });
+             },
+
+
+             /**
+              * Clears queued jobs from given queue
+              */
+             clearQueue() {
+                 this.$http.post(`/${Horizon.path}/api/clearQueue`, { queue: this.purge.queue }).then(response => {
+                     this.purge.queue = null;
+                 });
+             }
         }
     }
 </script>
@@ -272,6 +301,7 @@
                     <th>Queue</th>
                     <th>Processes</th>
                     <th>Jobs</th>
+                    <th>Clear</th>
                     <th class="text-right">Wait</th>
                 </tr>
                 </thead>
@@ -283,6 +313,15 @@
                     </td>
                     <td>{{ queue.processes ? queue.processes.toLocaleString() : 0 }}</td>
                     <td>{{ queue.length ? queue.length.toLocaleString() : 0 }}</td>
+                    <td>
+                        <button class="btn btn-outline-danger" title="Clear queued jobs" :disabled="purge.queue === queue.name" @click="confirmClearQueue(queue)">
+
+                            <svg class="icon fill-danger" viewBox="0 0 20 20">
+                                <path d="M19 24h-14c-1.104 0-2-.896-2-2v-17h-1v-2h6v-1.5c0-.827.673-1.5 1.5-1.5h5c.825 0 1.5.671 1.5 1.5v1.5h6v2h-1v17c0 1.104-.896 2-2 2zm0-19h-14v16.5c0 .276.224.5.5.5h13c.276 0 .5-.224.5-.5v-16.5zm-9 4c0-.552-.448-1-1-1s-1 .448-1 1v9c0 .552.448 1 1 1s1-.448 1-1v-9zm6 0c0-.552-.448-1-1-1s-1 .448-1 1v9c0 .552.448 1 1 1s1-.448 1-1v-9zm-2-7h-4v1h4v-1z"/>
+                            </svg>
+
+                        </button>
+                    </td>
                     <td class="text-right">{{ humanTime(queue.wait) }}</td>
                 </tr>
                 </tbody>
@@ -318,6 +357,6 @@
             </table>
         </div>
 
-
+        <alert ref="purgeModal" :message="purge.message" type="confirmation" v-if="purge.confirm" :confirmation-proceed="clearQueue"></alert>
     </div>
 </template>

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -145,6 +145,7 @@ svg.icon {
 }
 
 button:hover {
+    .fill-danger,
     .fill-primary {
         fill: #fff;
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('api')->group(function () {
     // Dashboard Routes...
     Route::get('/stats', 'DashboardStatsController@index')->name('horizon.stats.index');
+    Route::post('/clearQueue', 'QueueClearController')->name('horizon.queue-clear.store');
 
     // Workload Routes...
     Route::get('/workload', 'WorkloadController@index')->name('horizon.workload.index');

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon;
 use Closure;
 use Exception;
 use Illuminate\Support\Facades\File;
+use Laravel\Horizon\RedisQueue;
 use RuntimeException;
 
 class Horizon
@@ -128,6 +129,7 @@ class Horizon
     {
         return [
             'path' => config('horizon.path'),
+            'supportsClear' => method_exists(RedisQueue::class, 'clear'),
         ];
     }
 

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -5,7 +5,6 @@ namespace Laravel\Horizon;
 use Closure;
 use Exception;
 use Illuminate\Support\Facades\File;
-use Laravel\Horizon\RedisQueue;
 use RuntimeException;
 
 class Horizon

--- a/src/Http/Controllers/QueueClearController.php
+++ b/src/Http/Controllers/QueueClearController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Horizon\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Arr;
+use Laravel\Horizon\Repositories\RedisJobRepository;
+
+class QueueClearController extends Controller
+{
+    /**
+     * Clear the specified queue.
+     *
+     * @param  \Laravel\Horizon\Repositories\RedisJobRepository  $jobRepository
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function __invoke(RedisJobRepository $jobRepository, QueueManager $manager, Request $request)
+    {
+        $jobRepository->purge($queue = $request->input('queue'));
+        
+        $connection = Arr::first(config('horizon.defaults'))['connection'] ?? 'redis';
+        $manager->connection($connection)->clear($queue);
+    }
+}

--- a/src/Http/Controllers/QueueClearController.php
+++ b/src/Http/Controllers/QueueClearController.php
@@ -20,7 +20,7 @@ class QueueClearController extends Controller
     public function __invoke(RedisJobRepository $jobRepository, QueueManager $manager, Request $request)
     {
         $jobRepository->purge($queue = $request->input('queue'));
-        
+
         $connection = Arr::first(config('horizon.defaults'))['connection'] ?? 'redis';
         $manager->connection($connection)->clear($queue);
     }

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -689,13 +689,13 @@ class RedisJobRepository implements JobRepository
     }
 
     /**
-      * Delete pending and reserved jobs for a queue.
-      *
-      * @param  string  $queue
-      * @return void
-      */
-     public function purge($queue)
-     {
+     * Delete pending and reserved jobs for a queue.
+     *
+     * @param  string  $queue
+     * @return void
+     */
+    public function purge($queue)
+    {
         $ids = collect(range(0, ceil($this->nextJobId() / 50)))->transform(function ($_, $index) use ($queue) {
             return $this->getRecent($index === 0 ? null : $index * 50)->filter(function ($recent) use ($queue) {
                 return in_array($recent->status, ['pending', 'reserved']) && $recent->queue === $queue;
@@ -707,7 +707,7 @@ class RedisJobRepository implements JobRepository
             $pipe->zrem('pending_jobs', $ids);
             $pipe->del($ids);
         });
-     }
+    }
 
     /**
      * Get the Redis connection instance.

--- a/tests/Controller/QueueClearControllerTest.php
+++ b/tests/Controller/QueueClearControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Controller;
+
+use Laravel\Horizon\RedisQueue;
+use Laravel\Horizon\Repositories\RedisJobRepository;
+use Mockery;
+
+class QueueClearControllerTest extends AbstractControllerTest
+{
+    public function test_it_removes_all_job_from_specific_queue()
+    {
+        Mockery::mock(RedisJobRepository::class)
+            ->shouldReceive('purge')
+            ->withArgs(['email-processing']);
+
+        Mockery::mock(RedisQueue::class)
+            ->shouldReceive('clear')
+            ->withArgs(['email-processing']);
+        
+        $this->actingAs(new Fakes\User)
+            ->post('/horizon/api/clearQueue', ['queue' => 'email-processing']);
+    }
+}

--- a/tests/Controller/QueueClearControllerTest.php
+++ b/tests/Controller/QueueClearControllerTest.php
@@ -17,7 +17,7 @@ class QueueClearControllerTest extends AbstractControllerTest
         Mockery::mock(RedisQueue::class)
             ->shouldReceive('clear')
             ->withArgs(['email-processing']);
-        
+
         $this->actingAs(new Fakes\User)
             ->post('/horizon/api/clearQueue', ['queue' => 'email-processing']);
     }

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -56,4 +56,28 @@ class RedisJobRepositoryTest extends IntegrationTest
             throw $e;
         }
     }
+
+    public function test_it_removes_recent_jobs_when_queue_is_purged()
+    {
+        $repository = $this->app->make(JobRepository::class);
+
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 1, 'displayName' => 'first'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 2, 'displayName' => 'second'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 3, 'displayName' => 'third'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 4, 'displayName' => 'fourth'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 5, 'displayName' => 'fifth'])));
+
+        $repository->completed(new JobPayload(json_encode(['id' => 1, 'displayName' => 'first'])));
+        $repository->completed(new JobPayload(json_encode(['id' => 2, 'displayName' => 'second'])));
+
+        $repository->purge('email-processing');
+
+        $this->assertEquals(2, $repository->countRecent());
+        $this->assertEquals(0, $repository->countPending());
+        $this->assertEquals(2, $repository->countCompleted());
+
+        $recent = collect($repository->getRecent());
+        $this->assertNotNull($recent->firstWhere('id', 1));
+        $this->assertNotNull($recent->firstWhere('id', 2));
+    }
 }


### PR DESCRIPTION
![queues](https://user-images.githubusercontent.com/16099046/93455671-49afec80-f8fa-11ea-9208-dd96b1e2b730.png)
<img width="1191" alt="confirm" src="https://user-images.githubusercontent.com/16099046/93455709-52082780-f8fa-11ea-895c-0ba1cd3efca7.png">

This PR adds the ability to clear queues (delete all jobs from specific queues) from the Horizon dashboard.
Resubmission of https://github.com/laravel/horizon/pull/742 with fixes to sorted sets and also uses the in-built queue clear of the Laravel framework based on https://github.com/laravel/framework/pull/34330. Fixes #328. 

**Important Notice**
Clearing of queues will not work on Laravel versions below 8.4 (unreleased). So I'm not sure if we want to send to master or 5x? The `illuminate\queue` repository isn't updated with the recent changes either, so we can't bump up that version yet. Also, I haven't compiled assets with this PR. Let me know if you'd like me to update with compilation of assets as well.