### PR TITLE
[5.x] Add ability to see if a failed job is retried and/or a retry

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -137,6 +137,22 @@
 
 
             /**
+             * Determine if the given job was retried.
+             */
+            wasRetried(job) {
+                return job.retried_by && job.retried_by.length;
+            },
+
+
+            /**
+             * Determine if the given job is a retry.
+             */
+            isRetry(job) {
+                return job.payload.retry_of;
+            },
+
+
+            /**
              * Refresh the jobs every period of time.
              */
             refreshJobsPeriodically() {
@@ -222,11 +238,24 @@
                         <router-link :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.id }}">
                             {{ jobBaseName(job.name) }}
                         </router-link>
+
+                        <small class="badge badge-secondary badge-sm"
+                               v-tooltip:top="`Total retries: ${job.retried_by.length}`"
+                               v-if="wasRetried(job)">
+                            Retried
+                        </small>
+
                         <br>
 
                         <small class="text-muted">
                             Queue: {{job.queue}}
                             | Attempts: {{ job.payload.attempts }}
+                            <span v-if="isRetry(job)">
+                            | Retry of
+                            <router-link :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.payload.retry_of }}">
+                                {{ job.payload.retry_of.split('-')[0] }}
+                            </router-link>
+                            </span>
                             <span v-if="job.payload.tags && job.payload.tags.length" class="text-break">
                             | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.join(', ') : '' }}
                             </span>

--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -161,7 +161,7 @@
                 <div class="row mb-2" v-if="job.payload.retry_of">
                     <div class="col-md-2"><strong>Retry of ID</strong></div>
                     <div class="col">
-                        <a :href="Horizon.basePath + '/failed/'+job.payload.retry_of">
+                        <a :href="Horizon.basePath + '/failed/' + job.payload.retry_of">
                             {{ job.payload.retry_of }}
                         </a>
                     </div>

--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -161,9 +161,9 @@
                 <div class="row mb-2" v-if="job.payload.retry_of">
                     <div class="col-md-2"><strong>Retry of ID</strong></div>
                     <div class="col">
-                        <router-link :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.payload.retry_of }}">
+                        <a :href="Horizon.basePath + '/failed/'+job.payload.retry_of">
                             {{ job.payload.retry_of }}
-                        </router-link>
+                        </a>
                     </div>
                 </div>
                 <div class="row mb-2">

--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -151,6 +151,22 @@
                     <div class="col">{{job.queue}}</div>
                 </div>
                 <div class="row mb-2">
+                    <div class="col-md-2"><strong>Attempts</strong></div>
+                    <div class="col">{{job.payload.attempts}}</div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-md-2"><strong>Retries</strong></div>
+                    <div class="col">{{job.retried_by.length}}</div>
+                </div>
+                <div class="row mb-2" v-if="job.payload.retry_of">
+                    <div class="col-md-2"><strong>Retry of ID</strong></div>
+                    <div class="col">
+                        <router-link :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.payload.retry_of }}">
+                            {{ job.payload.retry_of }}
+                        </router-link>
+                    </div>
+                </div>
+                <div class="row mb-2">
                     <div class="col-md-2"><strong>Tags</strong></div>
                     <div class="col">{{ job.payload.tags && job.payload.tags.length ? job.payload.tags.join(', ') : '' }}</div>
                 </div>


### PR DESCRIPTION
In the current situation, a job that has previously failed and has a successful retry can be identified by the fact that it doesn't show the retry indicator/button on the right side.

If retrying a failed job results in the retry also failing, you'll end up with two failed jobs that can both be retried again: the original failed job, and the failed retry.
Right now it's hard to keep track of what jobs have been retried and/or are (failed) retries, since they all look the same. This PR tries to solve that.

On the index page:
- Failed jobs that have been retried show a "Retried" badge
- Failed jobs that are retries show the (truncated) ID of the retried job that links to the detail page of that job

![Horizon_-_Failed_Jobs_Index](https://user-images.githubusercontent.com/1008127/93664074-7dab1f00-fa6c-11ea-9f7b-ff684df9cf88.png)


On the detail page:
- The number of retries are shown
- If the failed job is a retry, the job ID of the retried job is shown (if the job is not a retry, this will not be shown)
- The Attempts count was missing here, so I added that for good measure

![Horizon_-_Failed_Jobs_Details](https://user-images.githubusercontent.com/1008127/93663846-e7c2c480-fa6a-11ea-8ce6-9180e59b7b82.png)

