### PR TITLE
[5.x] Add Horizon command to clear queue

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Arr;
+use Laravel\Horizon\RedisQueue;
+use Laravel\Horizon\Repositories\RedisJobRepository;
+
+class ClearCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:clear
+                            {--queue= : The name of the queue to clear}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete all of the jobs from the specified queue';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int|null
+     */
+    public function handle(RedisJobRepository $jobRepository, QueueManager $manager)
+    {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        if (!method_exists(RedisQueue::class, 'clear')) {
+            $this->line('<error>Clearing queues is not supported on this version of Laravel</error>');
+            
+            return 1;
+        }
+
+        $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
+
+        $jobRepository->purge($queue = $this->getQueue($connection));
+        
+        $count = $manager->connection($connection)->clear($queue);
+        $this->line('<info>Cleared '.$count.' jobs from the ['.$queue.'] queue</info> ');
+
+        return 0;
+    }
+
+    /**
+     * Get the queue name to clear.
+     *
+     * @param  string  $connection
+     * @return string
+     */
+    protected function getQueue($connection)
+    {
+        return $this->option('queue') ?: $this->laravel['config']->get(
+            "queue.connections.{$connection}.queue", 'default'
+        );
+    }
+}

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -39,16 +39,16 @@ class ClearCommand extends Command
             return 1;
         }
 
-        if (!method_exists(RedisQueue::class, 'clear')) {
+        if (! method_exists(RedisQueue::class, 'clear')) {
             $this->line('<error>Clearing queues is not supported on this version of Laravel</error>');
-            
+
             return 1;
         }
 
         $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
 
         $jobRepository->purge($queue = $this->getQueue($connection));
-        
+
         $count = $manager->connection($connection)->clear($queue);
         $this->line('<info>Cleared '.$count.' jobs from the ['.$queue.'] queue</info> ');
 

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -171,6 +171,7 @@ class HorizonServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                Console\ClearCommand::class,
                 Console\ContinueCommand::class,
                 Console\HorizonCommand::class,
                 Console\InstallCommand::class,

--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -34,4 +34,46 @@ class LuaScripts
             redis.call('hmset', KEYS[1], 'throughput', throughput, 'runtime', runtime)
 LUA;
     }
+
+    /**
+     * Get the Lua script for purging recent and pending jobs off of the queue.
+     *
+     * KEYS[1] - The name of the recent jobs sorted set
+     * KEYS[2] - The name of the pending jobs sorted set
+     * ARGV[1] - The prefix of the Horizon keys
+     * ARGV[2] - The name of the queue to purge
+     *
+     * @return string
+     */
+    public static function purge()
+    {
+        return <<<'LUA'
+            
+            local count = 0
+            local cursor = 0
+            
+            repeat
+                -- Iterate over the recent jobs sorted set
+                local scanner = redis.call('zscan', KEYS[1], cursor)
+                cursor = scanner[1]
+
+                for i = 1, #scanner[2], 2 do
+                    local jobid = scanner[2][i]
+                    local hashkey = ARGV[1] .. jobid
+                    local job = redis.call('hmget', hashkey, 'status', 'queue')
+
+                    -- Delete the pending/reserved jobs, that match the queue
+                    -- name, from the sorted sets as well as the job hash
+                    if((job[1] == 'reserved' or job[1] == 'pending') and job[2] == ARGV[2]) then
+                        redis.call('zrem', KEYS[1], jobid)
+                        redis.call('zrem', KEYS[2], jobid)
+                        redis.call('del', hashkey)
+                        count = count + 1
+                    end           
+                end
+            until cursor == '0'
+
+            return count
+LUA;
+    }
 }

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\JobPayload;
+use Laravel\Horizon\LuaScripts;
 
 class RedisJobRepository implements JobRepository
 {
@@ -686,6 +687,19 @@ class RedisJobRepository implements JobRepository
         $this->connection()->zrem('failed_jobs', $id);
 
         $this->connection()->del($id);
+    }
+
+    /**
+     * Delete pending and reserved jobs for a queue.
+     *
+     * @param  string  $queue
+     * @return int
+     */
+    public function purge($queue)
+    {
+        return $this->connection()->eval(LuaScripts::purge(), 2,
+            'recent_jobs', 'pending_jobs', config('horizon.prefix'), $queue
+        );
     }
 
     /**

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -56,4 +56,28 @@ class RedisJobRepositoryTest extends IntegrationTest
             throw $e;
         }
     }
+
+    public function test_it_removes_recent_jobs_when_queue_is_purged()
+    {
+        $repository = $this->app->make(JobRepository::class);
+
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 1, 'displayName' => 'first'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 2, 'displayName' => 'second'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 3, 'displayName' => 'third'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 4, 'displayName' => 'fourth'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 5, 'displayName' => 'fifth'])));
+
+        $repository->completed(new JobPayload(json_encode(['id' => 1, 'displayName' => 'first'])));
+        $repository->completed(new JobPayload(json_encode(['id' => 2, 'displayName' => 'second'])));
+
+        $this->assertEquals(3, $repository->purge('email-processing'));
+        $this->assertEquals(2, $repository->countRecent());
+        $this->assertEquals(0, $repository->countPending());
+        $this->assertEquals(2, $repository->countCompleted());
+
+        $recent = collect($repository->getRecent());
+        $this->assertNotNull($recent->firstWhere('id', 1));
+        $this->assertNotNull($recent->firstWhere('id', 2));
+        $this->assertCount(2, $repository->getJobs([1, 2, 3, 4, 5]));
+    }
 }


### PR DESCRIPTION
Resubmission of https://github.com/laravel/horizon/pull/890

Adds a Horizon command to clear queues. The way this is different from the Framework's `queue:clear` command is that it also deletes the jobs from the `recent_jobs` and `pending_jobs` sorted sets and Horizon job hash. 

Instead of looping through recent jobs in PHP, I've added a Lua script to do this in a more efficient manner. This is backwards-compatible as it checks if the `RedisQueue` class has the `clear` method, so it will show a user-friendly error message for Laravel versions prior to 8.4.
