### PR TITLE
[5.x] Add ability to delete a failed job

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -121,6 +121,19 @@
 
 
             /**
+             * Remove the given failed job.
+             */
+            remove(id) {
+                this.$http.delete(Horizon.basePath + '/api/jobs/failed/' + id)
+                    .then((response) => {
+                        this.jobs = _.reject(this.jobs, job => job.id == id)
+                    }).catch(error => {
+                        //
+                    });
+            },
+
+
+            /**
              * Determine if the given job is currently retrying.
              */
             isRetrying(id) {
@@ -220,7 +233,7 @@
                     <th>Job</th>
                     <th>Runtime</th>
                     <th>Failed At</th>
-                    <th class="text-right">Retry</th>
+                    <th class="text-right">Actions</th>
                 </tr>
                 </thead>
 
@@ -271,9 +284,14 @@
                     </td>
 
                     <td class="text-right table-fit">
-                        <a href="#" @click.prevent="retry(job.id)" v-if="!hasCompleted(job)">
+                        <a href="#" @click.prevent="retry(job.id)" v-if="!hasCompleted(job)" title="Retry job">
                             <svg class="fill-primary" viewBox="0 0 20 20" style="width: 1.5rem; height: 1.5rem;" :class="{spin: isRetrying(job.id)}">
                                 <path d="M10 3v2a5 5 0 0 0-3.54 8.54l-1.41 1.41A7 7 0 0 1 10 3zm4.95 2.05A7 7 0 0 1 10 17v-2a5 5 0 0 0 3.54-8.54l1.41-1.41zM10 20l-4-4 4-4v8zm0-12V0l4 4-4 4z"/>
+                            </svg>
+                        </a>
+                        <a href="#" @click.prevent="remove(job.id)" title="Remove job">
+                            <svg class="fill-danger" viewBox="0 0 20 20" style="width: 1.2rem; height: 1.2rem;">
+                                <path d="M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"/>
                             </svg>
                         </a>
                     </td>

--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -87,6 +87,19 @@
 
 
             /**
+             * Remove the given failed job.
+             */
+            remove(id) {
+                this.$http.delete(Horizon.basePath + '/api/jobs/failed/' + id)
+                    .then((response) => {
+                        this.$router.push({name: 'failed-jobs'})
+                    }).catch(error => {
+                        //
+                    });
+            },
+
+
+            /**
              * Convert exception to a more readable format.
              */
             prettyPrintException(exception) {
@@ -126,9 +139,15 @@
                 <h5 v-if="!ready">Job Preview</h5>
                 <h5 v-if="ready">{{job.name}}</h5>
 
-                <button class="btn btn-outline-primary" v-on:click.prevent="retry(job.id)">
+                <button class="btn btn-outline-primary ml-auto mr-2" v-on:click.prevent="retry(job.id)" title="Retry job">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-primary" :class="{spin: retrying}">
                         <path d="M10 3v2a5 5 0 0 0-3.54 8.54l-1.41 1.41A7 7 0 0 1 10 3zm4.95 2.05A7 7 0 0 1 10 17v-2a5 5 0 0 0 3.54-8.54l1.41-1.41zM10 20l-4-4 4-4v8zm0-12V0l4 4-4 4z"/>
+                    </svg>
+                </button>
+
+                <button class="btn btn-outline-danger" v-on:click.prevent="remove(job.id)" title="Remove job">
+                    <svg class="icon fill-danger" viewBox="0 0 20 20">
+                        <path d="M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"/>
                     </svg>
                 </button>
             </div>

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -145,7 +145,8 @@ svg.icon {
 }
 
 button:hover {
-    .fill-primary {
+    .fill-primary,
+    .fill-danger {
         fill: #fff;
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::prefix('api')->group(function () {
     Route::get('/jobs/completed', 'CompletedJobsController@index')->name('horizon.completed-jobs.index');
     Route::get('/jobs/failed', 'FailedJobsController@index')->name('horizon.failed-jobs.index');
     Route::get('/jobs/failed/{id}', 'FailedJobsController@show')->name('horizon.failed-jobs.show');
+    Route::delete('/jobs/failed/{id}', 'FailedJobsController@delete')->name('horizon.failed-jobs.delete');
     Route::post('/jobs/retry/{id}', 'RetryController@store')->name('horizon.retry-jobs.show');
     Route::get('/jobs/{id}', 'JobsController@show')->name('horizon.jobs.show');
 });

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -106,6 +106,19 @@ class FailedJobsController extends Controller
     }
 
     /**
+     * Delete a failed job instance.
+     *
+     * @param string $id
+     * @return mixed
+     */
+    public function delete($id)
+    {
+        return $this->jobs->deleteFailed($id) == 0
+            ? response(null, 404)
+            : response()->noContent();
+    }
+
+    /**
      * Decode the given job.
      *
      * @param  object  $job

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -684,9 +684,9 @@ class RedisJobRepository implements JobRepository
      */
     public function deleteFailed($id)
     {
-        $this->connection()->zrem('failed_jobs', $id);
-
-        $this->connection()->del($id);
+        return $this->connection()->zrem('failed_jobs', $id) != 1
+            ? 0
+            : $this->connection()->del($id);
     }
 
     /**

--- a/tests/Controller/FailedJobsControllerTest.php
+++ b/tests/Controller/FailedJobsControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Controller;
+
+use Laravel\Horizon\Contracts\JobRepository;
+use Mockery;
+
+class FailedJobsControllerTest extends AbstractControllerTest
+{
+    public function test_failed_job_can_be_deleted()
+    {
+        $jobs = Mockery::mock(JobRepository::class);
+        $jobs->shouldReceive('deleteFailed')->with('1')->andReturn(1);
+        $this->app->instance(JobRepository::class, $jobs);
+
+        $response = $this->actingAs(new Fakes\User)
+            ->delete('/horizon/api/jobs/failed/1');
+
+        $response->assertNoContent();
+    }
+
+    public function test_deleting_unknown_job_returns_not_found_status()
+    {
+        $jobs = Mockery::mock(JobRepository::class);
+        $jobs->shouldReceive('deleteFailed')->with('1')->andReturn(0);
+        $this->app->instance(JobRepository::class, $jobs);
+
+        $response = $this->actingAs(new Fakes\User)
+            ->delete('/horizon/api/jobs/failed/1');
+
+        $response->assertNotFound();
+    }
+}


### PR DESCRIPTION
This PR expands upon #891 by further improving managing failed jobs.

It would be nice to be able to delete failed jobs no longer needing attention, which makes it easier to find the ones that do. I've renamed the Retry column on the Index page to Actions, and added a button to delete the job. The same button is added on the detail page as well.

I also fixed the `deleteFailed` method on the RedisJobRepository; it now actually checks if the job is failed before deleting it. Tests are added.

![Horizon_-_Failed_Jobs](https://user-images.githubusercontent.com/1008127/93931402-081aa980-fd1f-11ea-9625-0ea5f816e01e.png)

![Screenshot_22-09-2020_21_45](https://user-images.githubusercontent.com/1008127/93931419-0d77f400-fd1f-11ea-9aa6-ce9f398d990e.png)
