### PR TITLE
[5.x] Add horizon:forget command to delete a failed job

### DIFF
--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Horizon\Contracts\JobRepository;
+
+class ForgetFailedCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:forget {id : The ID of the failed job}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete a failed queue job';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle(JobRepository $repository)
+    {
+        $repository->deleteFailed($this->argument('id'));
+
+        if ($this->laravel['queue.failer']->forget($this->argument('id'))) {
+            $this->info('Failed job deleted successfully!');
+        } else {
+            $this->error('No failed job matches the given ID.');
+        }
+    }
+}

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -173,6 +173,7 @@ class HorizonServiceProvider extends ServiceProvider
             $this->commands([
                 Console\ClearCommand::class,
                 Console\ContinueCommand::class,
+                Console\ForgetFailedCommand::class,
                 Console\HorizonCommand::class,
                 Console\InstallCommand::class,
                 Console\ListCommand::class,


### PR DESCRIPTION
Currently, there's no way to delete a failed job from both Redis and the database. The `queue:forget` command in the framework simply deletes the job from the database but the Horizon dashboard still shows the job as failed.

This PR provides a clean way for users using Horizon to delete failed jobs.