### PR TITLE
[5.x] Add secs to y-axis ticks' for clarity

### DIFF
--- a/resources/js/components/LineChart.vue
+++ b/resources/js/components/LineChart.vue
@@ -24,7 +24,10 @@
                         yAxes: [
                             {
                                 ticks: {
-                                    beginAtZero: true
+                                    beginAtZero: true,
+                                    callback: function (value, index, values) {
+                                        return `${value} secs`;
+                                    },
                                 },
                                 gridLines: {
                                     display: true


### PR DESCRIPTION
Since the line chart's y-axis shows ticks without units, this could help clarify that it's in seconds.