### PR TITLE
Revert "[5.x] Add secs to y-axis ticks' for clarity"

### DIFF
--- a/resources/js/components/LineChart.vue
+++ b/resources/js/components/LineChart.vue
@@ -24,10 +24,7 @@
                         yAxes: [
                             {
                                 ticks: {
-                                    beginAtZero: true,
-                                    callback: function (value, index, values) {
-                                        return `${value} secs`;
-                                    },
+                                    beginAtZero: true
                                 },
                                 gridLines: {
                                     display: true


### PR DESCRIPTION
This needs to be refined first, currently every y-axis get's `secs` added to the ticks. 