### PR TITLE
[5.x] Add secs to y-axis ticks' for clarity

### DIFF
--- a/resources/js/components/LineChart.vue
+++ b/resources/js/components/LineChart.vue
@@ -24,7 +24,12 @@
                         yAxes: [
                             {
                                 ticks: {
-                                    beginAtZero: true
+                                    beginAtZero: true,
+                                     callback: (value, index, values) => {
+                                        return this.data.datasets[0].label === "Seconds"
+                                            ? `${value} secs`
+                                            : value;
+                                    },
                                 },
                                 gridLines: {
                                     display: true


### PR DESCRIPTION
Since the line chart's y-axis shows ticks without units, this could help clarify that it's in seconds.

This only affects charts with the y-axis being `Seconds`, `Throughput` charts will remain the same.

<img width="958" alt="Bildschirmfoto 2020-10-01 um 15 38 46" src="https://user-images.githubusercontent.com/9453522/94816683-7127ae80-03fc-11eb-9a9f-5a542679a78d.png">
