### PR TITLE
[5.x] Fix delayed until on pending jobs screen

### DIFF
--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -58,8 +58,11 @@
             },
 
             delayed() {
-                if (this.unserialized && this.unserialized.delay) {
+                if (this.unserialized && this.unserialized.delay && this.unserialized.delay.date) {
                     return moment.tz(this.unserialized.delay.date, this.unserialized.delay.timezone)
+                        .fromNow(true);
+                } else if (this.unserialized && this.unserialized.delay) {
+                    return this.formatDate(this.job.payload.pushedAt).add(this.unserialized.delay, 'seconds')
                         .fromNow(true);
                 }
 

--- a/resources/js/screens/recentJobs/job.vue
+++ b/resources/js/screens/recentJobs/job.vue
@@ -120,8 +120,12 @@
                     //
                 }
 
-                if (unserialized && unserialized.delay) {
+                if (unserialized && unserialized.delay && unserialized.delay.date) {
                     return moment.tz(unserialized.delay.date, unserialized.delay.timezone)
+                        .local()
+                        .format('YYYY-MM-DD HH:mm:ss');
+                } else if (unserialized && unserialized.delay) {
+                    return this.formatDate(this.job.payload.pushedAt).add(unserialized.delay, 'seconds')
                         .local()
                         .format('YYYY-MM-DD HH:mm:ss');
                 }


### PR DESCRIPTION
Fixes https://github.com/laravel/horizon/issues/906

I've confirmed this is a bug in 5.x as well. The issue is that [PendingDispatch::delay](https://github.com/laravel/framework/blob/86fc8fb07f05d8a8d5f88f452d7beada732909da/src/Illuminate/Foundation/Bus/PendingDispatch.php#L89) accepts an `int` or `DateTime`. The current Horizon code assumes that it's always a date. This PR fixes that. I've checked it on my PC.

Steps to reproduce:
1. Execute `TestJob::dispatch(...)->delay(60*60*24);`
2. Go to the pending jobs screen. On the index screen, it shows "delayed for a few seconds" (as tooltip) and on the job detail screen, it shows Delayed Until as the current time.