### PR TITLE
[5.x] Fix misleading memory limit config

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -145,9 +145,9 @@ return [
     | Memory Limit (MB)
     |--------------------------------------------------------------------------
     |
-    | This value describes the maximum amount of memory the Horizon worker
-    | may consume before it is terminated and restarted. You should set
-    | this value according to the resources available to your server.
+    | This value describes the maximum amount of memory the Horizon master
+    | supervisor may consume before it is terminated and restarted. For
+    | configuring this limit on the workers, refer the next section.
     |
     */
 
@@ -172,6 +172,7 @@ return [
             'maxProcesses' => 1,
             'tries' => 1,
             'nice' => 0,
+            'memory' => 128,
         ],
     ],
 


### PR DESCRIPTION
The `memory_limit` Horizon configuration is misleading. It reads that it's the max memory for the queue workers, when instead, it is the memory limit for the master supervisor (default 64 MB). The memory limit for the workers percolates down from the supervisor memory limit (default 128 MB).

This PR fixes the wording and also makes it clear that the supervisor memory option is the one for the queue workers. This is a non-breaking change, as the config defaults are the same (64 MB for master supervisor and 128 MB for supervisors + queue workers).

Edit: On digging further, I realised this issue has been lingering from quite some time now: https://github.com/laravel/horizon/issues/712