### PR TITLE
[5.x] Add missing force option to horizon:clear

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -19,6 +19,7 @@ class ClearCommand extends Command
      * @var string
      */
     protected $signature = 'horizon:clear
+                            {--force : Force the operation to run when in production}
                             {--queue= : The name of the queue to clear}';
 
     /**
@@ -65,7 +66,8 @@ class ClearCommand extends Command
     protected function getQueue($connection)
     {
         return $this->option('queue') ?: $this->laravel['config']->get(
-            "queue.connections.{$connection}.queue", 'default'
+            "queue.connections.{$connection}.queue",
+            'default'
         );
     }
 }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -19,8 +19,8 @@ class ClearCommand extends Command
      * @var string
      */
     protected $signature = 'horizon:clear
-                            {--force : Force the operation to run when in production}
-                            {--queue= : The name of the queue to clear}';
+                            {--queue= : The name of the queue to clear}
+                            {--force : Force the operation to run when in production}';
 
     /**
      * The console command description.


### PR DESCRIPTION
This PR adds the `force` option to the `horizon:clear` command to be able to clear queues without the confirmation prompt in production. The `ConfirmableTrait` is already pulled in the command.