### PR TITLE
Add maintenance notice on dashboard

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -106,6 +106,11 @@
                         The published Horizon assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan horizon:publish</code>
                     </div>
                 @endif
+                @if ($isDownForMaintenance)
+                    <div class="alert alert-warning">
+                        You are currently down for maintenance. Queued jobs might not be handled during this period.
+                    </div>
+                @endif
 
                 <router-view></router-view>
             </div>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -106,9 +106,10 @@
                         The published Horizon assets are not up-to-date with the installed version. To update, run:<br/><code>php artisan horizon:publish</code>
                     </div>
                 @endif
+
                 @if ($isDownForMaintenance)
                     <div class="alert alert-warning">
-                        You are currently down for maintenance. Queued jobs might not be handled during this period.
+                        This application is in "maintenance mode". Queued jobs may not be processed unless your worker is using the "force" flag.
                     </div>
                 @endif
 

--- a/src/Http/Controllers/HomeController.php
+++ b/src/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Http\Controllers;
 
+use Illuminate\Support\Facades\App;
 use Laravel\Horizon\Horizon;
 
 class HomeController extends Controller
@@ -17,6 +18,7 @@ class HomeController extends Controller
             'cssFile' => Horizon::$useDarkTheme ? 'app-dark.css' : 'app.css',
             'horizonScriptVariables' => Horizon::scriptVariables(),
             'assetsAreCurrent' => Horizon::assetsAreCurrent(),
+            'isDownForMaintenance' => App::isDownForMaintenance(),
         ]);
     }
 }


### PR DESCRIPTION
With the improved maintenance mode in Laravel 8, you can easily view the Horizon dashboard when in maintenance mode and using the bypass functionality.

While in maintenance mode the queued jobs aren't processed.

This added notice gives a hint to the developer why jobs aren't being run.