### PR TITLE
[5.x] Add commands to pause and continue supervisors

### DIFF
--- a/src/Console/ContinueSupervisorCommand.php
+++ b/src/Console/ContinueSupervisorCommand.php
@@ -34,7 +34,7 @@ class ContinueSupervisorCommand extends Command
     {
         $processId = optional(collect($supervisors->all())->first(function ($supervisor) {
             return Str::startsWith($supervisor->name, MasterSupervisor::basename())
-                    && Str::endsWith($supervisor->name, ':'.$this->argument('name'));
+                    && Str::endsWith($supervisor->name, $this->argument('name'));
         }))->pid;
 
         if (is_null($processId)) {

--- a/src/Console/ContinueSupervisorCommand.php
+++ b/src/Console/ContinueSupervisorCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Horizon\Contracts\SupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
+
+class ContinueSupervisorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:continue-supervisor
+                            {name : The name of the supervisor to resume}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Instruct the supervisor to continue processing jobs';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
+     * @return void
+     */
+    public function handle(SupervisorRepository $supervisors)
+    {
+        $processId = optional(collect($supervisors->all())->first(function ($supervisor) {
+            return Str::startsWith($supervisor->name, MasterSupervisor::basename())
+                    && Str::endsWith($supervisor->name, ':'.$this->argument('name'));
+        }))->pid;
+
+        if (is_null($processId)) {
+            $this->error('Failed to find a supervisor with this name');
+
+            return 1;
+        }
+
+        $this->info("Sending CONT Signal To Process: {$processId}");
+
+        if (! posix_kill($processId, SIGCONT)) {
+            $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+        }
+    }
+}

--- a/src/Console/PauseSupervisorCommand.php
+++ b/src/Console/PauseSupervisorCommand.php
@@ -34,7 +34,7 @@ class PauseSupervisorCommand extends Command
     {
         $processId = optional(collect($supervisors->all())->first(function ($supervisor) {
             return Str::startsWith($supervisor->name, MasterSupervisor::basename())
-                    && Str::endsWith($supervisor->name, ':'.$this->argument('name'));
+                    && Str::endsWith($supervisor->name, $this->argument('name'));
         }))->pid;
 
         if (is_null($processId)) {

--- a/src/Console/PauseSupervisorCommand.php
+++ b/src/Console/PauseSupervisorCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Horizon\Contracts\SupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
+
+class PauseSupervisorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:pause-supervisor
+                            {name : The name of the supervisor to pause}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Pause a supervisor';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
+     * @return void
+     */
+    public function handle(SupervisorRepository $supervisors)
+    {
+        $processId = optional(collect($supervisors->all())->first(function ($supervisor) {
+            return Str::startsWith($supervisor->name, MasterSupervisor::basename())
+                    && Str::endsWith($supervisor->name, ':'.$this->argument('name'));
+        }))->pid;
+
+        if (is_null($processId)) {
+            $this->error('Failed to find a supervisor with this name');
+
+            return 1;
+        }
+
+        $this->info("Sending USR2 Signal To Process: {$processId}");
+
+        if (! posix_kill($processId, SIGUSR2)) {
+            $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+        }
+    }
+}

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -173,11 +173,13 @@ class HorizonServiceProvider extends ServiceProvider
             $this->commands([
                 Console\ClearCommand::class,
                 Console\ContinueCommand::class,
+                Console\ContinueSupervisorCommand::class,
                 Console\ForgetFailedCommand::class,
                 Console\HorizonCommand::class,
                 Console\InstallCommand::class,
                 Console\ListCommand::class,
                 Console\PauseCommand::class,
+                Console\PauseSupervisorCommand::class,
                 Console\PublishCommand::class,
                 Console\PurgeCommand::class,
                 Console\StatusCommand::class,


### PR DESCRIPTION
Currently, it is possible to pause and continue the master supervisor. But there is no command readily available to pause and continue specific supervisors. This could be a common use case in production. 

For instance, say we want to pause a supervisor that runs a dedicated queue for unstable APIs. If the API is currently unavailable, pausing that specific supervisor really helps so that the jobs are queued up and can be continued (without exhausting their `tries`) once the API is up and running.

<img width="951" alt="Screenshot 2020-10-23 at 3 48 15 PM" src="https://user-images.githubusercontent.com/16099046/96992256-3f12f380-1547-11eb-96e7-4a4aa21248a2.png">

EDIT: I've added separate commands instead of modifying existing `PauseCommand` and `ContinueCommand` (used for master supervisor) so that there's no breaking change and this PR can be included for 5x.
