### PR TITLE
[5.x] Support PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4]
+        php: [7.3, 7.4, 8.0]
         laravel: [^8.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
@@ -32,7 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, redis, zip
           coverage: none
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",


### PR DESCRIPTION
This PR adds support for PHP 8.

However, while testing I noticed that running the tests with PHP 8 and the predis/predis package, the tests fail whereas running the tests with the redis extension `ext-redis` are successful.

The failing tests are 

- `Laravel\Horizon\Tests\Feature\SupervisorTest::test_processes_can_be_paused_and_continued`
- `Laravel\Horizon\Tests\Feature\SupervisorTest::test_supervisor_can_start_worker_process_with_given_options`