### PR TITLE
[5.x] Improve wording of error message

### DIFF
--- a/src/Console/ContinueSupervisorCommand.php
+++ b/src/Console/ContinueSupervisorCommand.php
@@ -46,7 +46,7 @@ class ContinueSupervisorCommand extends Command
         $this->info("Sending CONT Signal To Process: {$processId}");
 
         if (! posix_kill($processId, SIGCONT)) {
-            $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+            $this->error("Failed to send CONT signal to process: {$processId} (".posix_strerror(posix_get_last_error()).')');
         }
     }
 }

--- a/src/Console/PauseSupervisorCommand.php
+++ b/src/Console/PauseSupervisorCommand.php
@@ -46,7 +46,7 @@ class PauseSupervisorCommand extends Command
         $this->info("Sending USR2 Signal To Process: {$processId}");
 
         if (! posix_kill($processId, SIGUSR2)) {
-            $this->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+            $this->error("Failed to send USR2 signal to process: {$processId} (".posix_strerror(posix_get_last_error()).')');
         }
     }
 }


### PR DESCRIPTION
See discussion outcome in https://github.com/laravel/horizon/pull/914#issuecomment-717254110

This also better aligns with the `info` message right above in both places. I neither cases are we "killing" the process, we're just sending a signal.