### PR TITLE
Update 'New Tag' placeholder to reflect location of models in Framework 8.x

### DIFF
--- a/resources/js/screens/monitoring/index.vue
+++ b/resources/js/screens/monitoring/index.vue
@@ -157,7 +157,7 @@
                     <div class="modal-header">Monitor New Tag</div>
 
                     <div class="modal-body">
-                        <input type="text" class="form-control" placeholder="App\User:6352"
+                        <input type="text" class="form-control" placeholder="App\Models\User:6352"
                                v-on:keyup.enter="monitorNewTag"
                                v-model="newTag"
                                id="newTagInput">


### PR DESCRIPTION
This very small PR updates the "New Tag" placeholder to reflect the new location for models in 8.x of the Laravel Framework.