### PR TITLE
[4.x] Ability to see which masters are paused and only show paused if everything is paused

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -293,6 +293,14 @@
         <div class="card mt-4" v-for="worker in workers" :key="worker.name">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h5>{{ worker.name }}</h5>
+
+                <svg v-if="worker.status == 'running'" class="fill-success" viewBox="0 0 20 20" style="width: 1.5rem; height: 1.5rem;">
+                    <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM6.7 9.29L9 11.6l4.3-4.3 1.4 1.42L9 14.4l-3.7-3.7 1.4-1.42z"></path>
+                </svg>
+
+                <svg v-if="worker.status == 'paused'" class="fill-warning" viewBox="0 0 20 20" style="width: 1.5rem; height: 1.5rem;">
+                    <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM7 6h2v8H7V6zm4 0h2v8h-2V6z"/>
+                </svg>
             </div>
 
             <table class="table table-hover table-sm mb-0">

--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -210,6 +210,7 @@
                                 </svg>
 
                                 <h4 class="mb-0 ml-2">{{ {running: 'Active', paused: 'Paused', inactive:'Inactive'}[stats.status] }}</h4>
+                                <small v-if="stats.status == 'running' && stats.pausedMasters > 0" class="mb-0 ml-2">({{ stats.pausedMasters }} paused)</small>
                             </div>
                         </div>
                     </div>

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -74,7 +74,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
         $masters = Mockery::mock(MasterSupervisorRepository::class);
         $masters->shouldReceive('all')->andReturn([
             (object) [
-                'status' => 'running',
+                'status' => 'paused',
             ],
             (object) [
                 'status' => 'paused',
@@ -87,6 +87,27 @@ class DashboardStatsControllerTest extends AbstractControllerTest
 
         $response->assertJson([
             'status' => 'paused',
+        ]);
+    }
+
+    public function test_paused_status_isnt_reflected_if_not_all_master_supervisors_are_paused()
+    {
+        $masters = Mockery::mock(MasterSupervisorRepository::class);
+        $masters->shouldReceive('all')->andReturn([
+            (object) [
+                'status' => 'running',
+            ],
+            (object) [
+                'status' => 'paused',
+            ],
+        ]);
+        $this->app->instance(MasterSupervisorRepository::class, $masters);
+
+        $response = $this->actingAs(new Fakes\User)
+            ->get('/horizon/api/stats');
+
+        $response->assertJson([
+            'status' => 'running',
         ]);
     }
 }


### PR DESCRIPTION
This pull request does two things:

- Show on a every "master" if it's paused or running
- If horizon is active but at least 1 master is running and 1 is paused, you see this in the dashboard.

A couple of images to show what has been changed.

![status_workers](https://user-images.githubusercontent.com/62723/99738245-556e8980-2aca-11eb-8853-212c65a4f9eb.jpg)
![inactive-not-changed](https://user-images.githubusercontent.com/62723/99738249-56072000-2aca-11eb-8ccf-1bf869bc52cb.jpg)
![active_unchanged](https://user-images.githubusercontent.com/62723/99738250-569fb680-2aca-11eb-9002-49d2b9431125.jpg)
![paused_unchanged](https://user-images.githubusercontent.com/62723/99738252-569fb680-2aca-11eb-88f8-543fabe9e93b.jpg)
![active_changed](https://user-images.githubusercontent.com/62723/99738254-57384d00-2aca-11eb-9885-70d04e2ce257.jpg)

_Little question: I wasn't sure if I should update the javascript files by running `npm run production`. If necessary, I can make changes._

Closes https://github.com/laravel/horizon/issues/927