### PR TITLE
[5.x] Ability to see which masters are paused and only show paused if everything is paused

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -293,6 +293,14 @@
         <div class="card mt-4" v-for="worker in workers" :key="worker.name">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h5>{{ worker.name }}</h5>
+
+                <svg v-if="worker.status == 'running'" class="fill-success" viewBox="0 0 20 20" style="width: 1.5rem; height: 1.5rem;">
+                    <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM6.7 9.29L9 11.6l4.3-4.3 1.4 1.42L9 14.4l-3.7-3.7 1.4-1.42z"></path>
+                </svg>
+
+                <svg v-if="worker.status == 'paused'" class="fill-warning" viewBox="0 0 20 20" style="width: 1.5rem; height: 1.5rem;">
+                    <path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM7 6h2v8H7V6zm4 0h2v8h-2V6z"/>
+                </svg>
             </div>
 
             <table class="table table-hover table-sm mb-0">

--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -210,6 +210,7 @@
                                 </svg>
 
                                 <h4 class="mb-0 ml-2">{{ {running: 'Active', paused: 'Paused', inactive:'Inactive'}[stats.status] }}</h4>
+                                <small v-if="stats.status == 'running' && stats.pausedMasters > 0" class="mb-0 ml-2">({{ stats.pausedMasters }} paused)</small>
                             </div>
                         </div>
                     </div>

--- a/tests/Controller/DashboardStatsControllerTest.php
+++ b/tests/Controller/DashboardStatsControllerTest.php
@@ -74,7 +74,7 @@ class DashboardStatsControllerTest extends AbstractControllerTest
         $masters = Mockery::mock(MasterSupervisorRepository::class);
         $masters->shouldReceive('all')->andReturn([
             (object) [
-                'status' => 'running',
+                'status' => 'paused',
             ],
             (object) [
                 'status' => 'paused',
@@ -87,6 +87,27 @@ class DashboardStatsControllerTest extends AbstractControllerTest
 
         $response->assertJson([
             'status' => 'paused',
+        ]);
+    }
+
+    public function test_paused_status_isnt_reflected_if_not_all_master_supervisors_are_paused()
+    {
+        $masters = Mockery::mock(MasterSupervisorRepository::class);
+        $masters->shouldReceive('all')->andReturn([
+            (object) [
+                'status' => 'running',
+            ],
+            (object) [
+                'status' => 'paused',
+            ],
+        ]);
+        $this->app->instance(MasterSupervisorRepository::class, $masters);
+
+        $response = $this->actingAs(new Fakes\User)
+            ->get('/horizon/api/stats');
+
+        $response->assertJson([
+            'status' => 'running',
         ]);
     }
 }


### PR DESCRIPTION
This pull request does two things:

- Show on a every "master" if it's paused or running
- Not showing as "paused" if not all master supervisors are paused but show how many are pushed instead.

A couple of images to show what has been changed and what has been kept the same.

![status_workers](https://user-images.githubusercontent.com/62723/99816053-77f4b700-2b4b-11eb-9b9b-dda61022600a.jpg)
![inactive-not-changed](https://user-images.githubusercontent.com/62723/99816057-788d4d80-2b4b-11eb-85d4-88411f9192a5.jpg)
![active_unchanged](https://user-images.githubusercontent.com/62723/99816059-7925e400-2b4b-11eb-9a98-34befef451dc.jpg)
![paused_unchanged](https://user-images.githubusercontent.com/62723/99816061-7925e400-2b4b-11eb-9503-f0be0458b233.jpg)
![active_changed](https://user-images.githubusercontent.com/62723/99816067-79be7a80-2b4b-11eb-8b76-bde297c7e8a9.jpg)

_Little sidenote: I wasn't sure if I should update the javascript files by running npm run production. If necessary, I can make changes._

Closes #927