### PR TITLE
[5.x] Metrics snapshot config proposal and fix for race condition

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -113,8 +113,9 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you can configure how many snapshots should be kept to display in
-    | the metrics graph. This will get used in combination with Horizon's
-    | `horizon:snapshot` schedule to define how long to retain metrics.
+    | the metrics graph and how often they can be stored.
+    | This will get used in combination with Horizon's `horizon:snapshot`
+    | schedule to define how long to retain metrics.
     |
     */
 
@@ -123,6 +124,7 @@ return [
             'job' => 24,
             'queue' => 24,
         ],
+        'snapshot_lock' => 300,
     ],
 
     /*

--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -31,7 +31,7 @@ class SnapshotCommand extends Command
      */
     public function handle(Lock $lock, MetricsRepository $metrics)
     {
-        if ($lock->get('metrics:snapshot', 300)) {
+        if ($lock->get('metrics:snapshot', config('horizon.metrics.snapshot_lock', 300))) {
             $metrics->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');

--- a/src/Console/SnapshotCommand.php
+++ b/src/Console/SnapshotCommand.php
@@ -31,7 +31,7 @@ class SnapshotCommand extends Command
      */
     public function handle(Lock $lock, MetricsRepository $metrics)
     {
-        if ($lock->get('metrics:snapshot', config('horizon.metrics.snapshot_lock', 300))) {
+        if ($lock->get('metrics:snapshot', config('horizon.metrics.snapshot_lock', 300) - 30)) {
             $metrics->snapshot();
 
             $this->info('Metrics snapshot stored successfully.');


### PR DESCRIPTION
- New option in the config so you will be able to save snapshots on smaller timestamps then 5 minutes.
- Fix for a race condition when you have slow or fast servers and lock in redis isn't yes released because the lock was now the same length as the time the scheduler is been called. (bug noticed by @Dries-Vandenneucker and reported by myself in https://github.com/laravel/horizon/issues/935)