### PR TITLE
[5.x] Considering queue config parameter 'after_commit'

### DIFF
--- a/src/Connectors/RedisConnector.php
+++ b/src/Connectors/RedisConnector.php
@@ -20,7 +20,8 @@ class RedisConnector extends BaseConnector
             $this->redis, $config['queue'],
             Arr::get($config, 'connection', $this->connection),
             Arr::get($config, 'retry_after', 60),
-            Arr::get($config, 'block_for', null)
+            Arr::get($config, 'block_for', null),
+            Arr::get($config, 'after_commit', null)
         );
     }
 }


### PR DESCRIPTION
The newly released 'after_commit' option in queue config from laravel framework is currently not considered when using horizon. So even if setting this option to true, jobs are still immediately dispatched even if they are within a transaction.

This PR considers the config parameter and passes it along to the RedisQueue.