### PR TITLE
[5.x] Set lastPushed when executing the delayed enqueue closure

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -41,9 +41,17 @@ class RedisQueue extends BaseQueue
      */
     public function push($job, $data = '', $queue = null)
     {
-        $this->lastPushed = $job;
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $queue,
+            null,
+            function ($payload, $queue) use ($job) {
+                $this->lastPushed = $job;
 
-        return parent::push($job, $data, $queue);
+                return $this->pushRaw($payload, $queue);
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
This fixes https://github.com/laravel/horizon/issues/950

`$this->lastPushed = $job;` will run when the closure is executed. Before this PR it was set before the closure is executed so multiple jobs could have been dispatched after it.