### PR TITLE
[6.x] Do not override all options provided by connection

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -103,7 +103,9 @@ class Horizon
         }
 
         config(['database.redis.horizon' => array_merge($config, [
-            'options' => ['prefix' => config('horizon.prefix') ?: 'horizon:'],
+            'options' => array_merge($config['options'] ?? [], [
+                'prefix' => config('horizon.prefix') ?: 'horizon:',
+            ]),
         ])]);
     }
 


### PR DESCRIPTION
By default when horizon redis connection is created in config it flushes all of extra options. By doing this we are not able to use redis sentinel configuration via predis driver. This PR merges default options with ones that are needed for horizon.

https://github.com/laravel/horizon/pull/959