### PR TITLE
[5.x] Show workload also per queue when balancing is disabled

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -278,14 +278,27 @@
                 </thead>
 
                 <tbody>
-                <tr v-for="queue in workload">
-                    <td>
-                        <span>{{ queue.name.replace(/,/g, ', ') }}</span>
-                    </td>
-                    <td>{{ queue.processes ? queue.processes.toLocaleString() : 0 }}</td>
-                    <td>{{ queue.length ? queue.length.toLocaleString() : 0 }}</td>
-                    <td class="text-right">{{ humanTime(queue.wait) }}</td>
-                </tr>
+                <template v-for="queue in workload">
+                    <tr>
+                        <td :class="{'font-weight-bold': queue.split_queues}">
+                            <span>{{ queue.name.replace(/,/g, ', ') }}</span>
+                        </td>
+                        <td :class="{'font-weight-bold': queue.split_queues}">{{ queue.processes ? queue.processes.toLocaleString() : 0 }}</td>
+                        <td :class="{'font-weight-bold': queue.split_queues}">{{ queue.length ? queue.length.toLocaleString() : 0 }}</td>
+                        <td :class="{'font-weight-bold': queue.split_queues}" class="text-right">{{ humanTime(queue.wait) }}</td>
+                    </tr>
+                    <tr v-for="split_queue in queue.split_queues">
+                        <td>
+                            <svg class="icon info-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                <path d="M12.95 10.707l.707-.707L8 4.343 6.586 5.757 10.828 10l-4.242 4.243L8 15.657l4.95-4.95z"/>
+                            </svg>
+                            <span>{{ split_queue.name.replace(/,/g, ', ') }}</span>
+                        </td>
+                        <td>-</td>
+                        <td>{{ split_queue.length ? split_queue.length.toLocaleString() : 0 }}</td>
+                        <td class="text-right">{{ humanTime(split_queue.wait) }}</td>
+                    </tr>
+                </template>
                 </tbody>
             </table>
         </div>

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -172,6 +172,10 @@ button:hover {
     }
 }
 
+.info-icon {
+    fill: $control-action-icon-color;
+}
+
 .paginator {
     .btn {
         text-decoration: none;

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -72,7 +72,7 @@ class RedisWorkloadRepository implements WorkloadRepository
                 $totalProcesses = $processes[$queue] ?? 0;
 
                 $length = ! Str::contains($queue, ',')
-                    ? collect($this->queue->connection($connection)->readyNow($queueName))
+                    ? collect([$queueName => $this->queue->connection($connection)->readyNow($queueName)])
                     : collect(explode(',', $queueName))->mapWithKeys(function ($queueName) use ($connection) {
                         return [$queueName => $this->queue->connection($connection)->readyNow($queueName)];
                     });

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -69,18 +69,28 @@ class RedisWorkloadRepository implements WorkloadRepository
         return collect($this->waitTime->calculate())
             ->map(function ($waitTime, $queue) use ($processes) {
                 [$connection, $queueName] = explode(':', $queue, 2);
+                $totalProcesses = $processes[$queue] ?? 0;
 
                 $length = ! Str::contains($queue, ',')
-                    ? $this->queue->connection($connection)->readyNow($queueName)
-                    : collect(explode(',', $queueName))->sum(function ($queueName) use ($connection) {
-                        return $this->queue->connection($connection)->readyNow($queueName);
+                    ? collect($this->queue->connection($connection)->readyNow($queueName))
+                    : collect(explode(',', $queueName))->mapWithKeys(function ($queueName) use ($connection) {
+                        return [$queueName => $this->queue->connection($connection)->readyNow($queueName)];
                     });
+
+                $splitQueues = Str::contains($queue, ',') ? $length->map(function($length, $queueName) use ($connection, $totalProcesses) {
+                    return [
+                        'name' => $queueName,
+                        'length' => $length,
+                        'wait' => $this->waitTime->calculateTimeToClear($connection, $queueName, $totalProcesses),
+                    ];
+                }) : null;
 
                 return [
                     'name' => $queueName,
-                    'length' => $length,
+                    'length' => $length->sum(),
                     'wait' => $waitTime,
-                    'processes' => $processes[$queue] ?? 0,
+                    'processes' => $totalProcesses,
+                    'split_queues' => $splitQueues,
                 ];
             })->values()->toArray();
     }

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -77,7 +77,7 @@ class RedisWorkloadRepository implements WorkloadRepository
                         return [$queueName => $this->queue->connection($connection)->readyNow($queueName)];
                     });
 
-                $splitQueues = Str::contains($queue, ',') ? $length->map(function($length, $queueName) use ($connection, $totalProcesses) {
+                $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses) {
                     return [
                         'name' => $queueName,
                         'length' => $length,

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -77,11 +77,11 @@ class RedisWorkloadRepository implements WorkloadRepository
                         return [$queueName => $this->queue->connection($connection)->readyNow($queueName)];
                     });
 
-                $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses) {
+                $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses, &$wait) {
                     return [
                         'name' => $queueName,
                         'length' => $length,
-                        'wait' => $this->waitTime->calculateTimeToClear($connection, $queueName, $totalProcesses),
+                        'wait' => $wait += $this->waitTime->calculateTimeToClear($connection, $queueName, $totalProcesses),
                     ];
                 }) : null;
 

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -80,7 +80,7 @@ class WaitTimeCalculator
     }
 
     /**
-     * Calculate the time to clear for the given in queue in seconds distributed over the given amount of processes.
+     * Calculate the time to clear for the given queue in seconds distributed over the given amount of processes.
      *
      * @param  string  $connection
      * @param  string  $queue
@@ -123,7 +123,7 @@ class WaitTimeCalculator
      * @param  string  $queue
      * @return float
      */
-    public function timeToClearFor($connection, $queue)
+    protected function timeToClearFor($connection, $queue)
     {
         $size = $this->queue->connection($connection)->readyNow($queue);
 

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -75,16 +75,29 @@ class WaitTimeCalculator
 
             [$connection, $queueName] = explode(':', $queue, 2);
 
-            $timeToClear = ! Str::contains($queueName, ',')
-                ? $this->timeToClearFor($connection, $queueName)
-                : collect(explode(',', $queueName))->sum(function ($queueName) use ($connection) {
-                    return $this->timeToClearFor($connection, $queueName);
-                });
-
-            return $totalProcesses === 0
-                    ? [$queue => round($timeToClear / 1000)]
-                    : [$queue => round(($timeToClear / $totalProcesses) / 1000)];
+            return [$queue => $this->calculateTimeToClear($connection, $queueName, $totalProcesses)];
         })->sort()->reverse()->all();
+    }
+
+    /**
+     * Calculate the time to clear for the given in queue in seconds distributed over the given amount of processes.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  int  $totalProcesses
+     * @return int
+     */
+    public function calculateTimeToClear($connection, $queue, $totalProcesses)
+    {
+        $timeToClear = ! Str::contains($queue, ',')
+            ? $this->timeToClearFor($connection, $queue)
+            : collect(explode(',', $queue))->sum(function ($queueName) use ($connection) {
+                return $this->timeToClearFor($connection, $queueName);
+            });
+
+        return $totalProcesses === 0
+            ? round($timeToClear / 1000)
+            : round(($timeToClear / $totalProcesses) / 1000);
     }
 
     /**
@@ -110,7 +123,7 @@ class WaitTimeCalculator
      * @param  string  $queue
      * @return float
      */
-    protected function timeToClearFor($connection, $queue)
+    public function timeToClearFor($connection, $queue)
     {
         $size = $this->queue->connection($connection)->readyNow($queue);
 


### PR DESCRIPTION
When handling multiple queues from a single supervisor with balancing disabled it will only show the total amount of jobs and wait time for that supervisor. When using this configuration to split your queues in priority (for example high,default,low) it's not possible to see the details per queue. When the workload spikes you have no idea which queue is causing it. For example, when the 'low' queue would make your workload spike it's no problem probably, as any new jobs coming in on the 'high' or 'default' queue would still be processed quickly.

To get better insight in the workload per queue when `'balance' => false` this PR adds details about each individual queue of a supervisor.

This only affects those setups where balancing is disabled. For all other balancing strategies the UI is unchanged. 

![image](https://user-images.githubusercontent.com/7716654/107535012-a7eaae00-6bc0-11eb-9183-d3bc2ae6bd30.png)
