### PR TITLE
[5.x] Fix checking parent id

### DIFF
--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -27,7 +27,7 @@ class QueueCommandString
      */
     public static function toSupervisorOptionsString(SupervisorOptions $options)
     {
-        return sprintf('--workers-name=%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s --balance-cooldown=%s --balance-max-shift=%s %s',
+        return sprintf('--workers-name=%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s --balance-cooldown=%s --balance-max-shift=%s --parent-id=%s %s',
             $options->workersName,
             $options->balance,
             $options->maxProcesses,
@@ -35,6 +35,7 @@ class QueueCommandString
             $options->nice,
             $options->balanceCooldown,
             $options->balanceMaxShift,
+            $options->parentId,
             static::toOptionsString($options)
         );
     }

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -205,7 +205,7 @@ class SupervisorOptions
         $this->nice = $nice;
         $this->balanceCooldown = $balanceCooldown;
         $this->balanceMaxShift = $balanceMaxShift;
-        $this->parentId = 0;
+        $this->parentId = $parentId;
     }
 
     /**
@@ -297,6 +297,7 @@ class SupervisorOptions
             'timeout' => $this->timeout,
             'balanceCooldown' => $this->balanceCooldown,
             'balanceMaxShift' => $this->balanceMaxShift,
+            'parentId' => $this->parentId,
         ];
     }
 

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertSame(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }


### PR DESCRIPTION
I think my previous PR https://github.com/laravel/horizon/pull/881 for checking parent ID was incomplete. I don't quite remember how that happened. I tested this PR in a fresh Laravel application by running horizon and killing it with 9 signal. It works fine in my tests.

@driesvints could you take a look please?