### PR TITLE
Add Supervisor Rest Option

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -30,6 +30,7 @@ class SupervisorCommand extends Command
                             {--paused : Start the supervisor in a paused state}
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}
                             {--balance-cooldown=3 : The number of seconds to wait in between auto-scaling attempts}
@@ -124,6 +125,7 @@ class SupervisorCommand extends Command
             $this->option('memory'),
             $this->option('timeout'),
             $this->option('sleep'),
+            $this->option('rest'),
             $this->option('tries'),
             $this->option('force'),
             $this->option('nice'),

--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -49,9 +49,9 @@ class QueueCommandString
      */
     public static function toOptionsString(SupervisorOptions $options, $paused = false)
     {
-        $string = sprintf('--backoff=%s --max-time=%s --max-jobs=%s --memory=%s --queue="%s" --sleep=%s --timeout=%s --tries=%s',
+        $string = sprintf('--backoff=%s --max-time=%s --max-jobs=%s --memory=%s --queue="%s" --sleep=%s --rest=%s --timeout=%s --tries=%s',
             $options->backoff, $options->maxTime, $options->maxJobs, $options->memory,
-            $options->queue, $options->sleep, $options->timeout, $options->maxTries
+            $options->queue, $options->sleep, $options->rest, $options->timeout, $options->maxTries
         );
 
         if ($options->force) {

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -131,6 +131,13 @@ class SupervisorOptions
     public $sleep;
 
     /**
+     * The number of seconds to rest between jobs.
+     *
+     * @var int
+     */
+    public $rest;
+
+    /**
      * The maximum amount of times a job may be attempted.
      *
      * @var int
@@ -160,6 +167,7 @@ class SupervisorOptions
      * @param  int  $memory
      * @param  int  $timeout
      * @param  int  $sleep
+     * @param  int  $rest
      * @param  int  $maxTries
      * @param  bool  $force
      * @param  int  $nice
@@ -180,6 +188,7 @@ class SupervisorOptions
                                 $memory = 128,
                                 $timeout = 60,
                                 $sleep = 3,
+                                $rest = 0,
                                 $maxTries = 0,
                                 $force = false,
                                 $nice = 0,
@@ -200,6 +209,7 @@ class SupervisorOptions
         $this->memory = $memory;
         $this->timeout = $timeout;
         $this->sleep = $sleep;
+        $this->rest = $rest;
         $this->maxTries = $maxTries;
         $this->force = $force;
         $this->nice = $nice;
@@ -294,6 +304,7 @@ class SupervisorOptions
             'name' => $this->name,
             'workersName' => $this->workersName,
             'sleep' => $this->sleep,
+            'rest' => $this->rest,
             'timeout' => $this->timeout,
             'balanceCooldown' => $this->balanceCooldown,
             'balanceMaxShift' => $this->balanceMaxShift,

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertSame(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --rest=0 --timeout=60 --tries=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -67,7 +67,7 @@ class SupervisorTest extends IntegrationTest
 
         $host = MasterSupervisor::name();
         $this->assertSame(
-            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --rest=0 --timeout=60 --tries=0',
             $supervisor->processes()[0]->getCommandLine()
         );
     }
@@ -85,12 +85,12 @@ class SupervisorTest extends IntegrationTest
         $host = MasterSupervisor::name();
 
         $this->assertSame(
-            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="first" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="first" --sleep=3 --rest=0 --timeout=60 --tries=0',
             $supervisor->processes()[0]->getCommandLine()
         );
 
         $this->assertSame(
-            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="second" --sleep=3 --timeout=60 --tries=0',
+            'exec '.$this->phpBinary.' worker.php redis --name=default --supervisor='.$host.':name --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="second" --sleep=3 --rest=0 --timeout=60 --tries=0',
             $supervisor->processes()[1]->getCommandLine()
         );
     }


### PR DESCRIPTION
This PR allows users to specify a custom value for the `rest` option when configuring a Supervisor in `config/horizon.php`, much like they can do with the `sleep`, `timeout` and `tries` options.