### PR TITLE
[5.x] Update syntax highlighting

### DIFF
--- a/resources/sass/syntaxhighlight.scss
+++ b/resources/sass/syntaxhighlight.scss
@@ -1,43 +1,27 @@
-.vjs__tree {
-    .vjs__tree__content {
-        border-left: 1px dotted rgba(204, 204, 204, 0.28) !important;
+.vjs-tree {
+    font-family: 'Monaco', 'Menlo', 'Consolas', 'Bitstream Vera Sans Mono', monospace !important;
+
+    &.is-root {
+        position: relative;
     }
-    .vjs__tree__node {
+    .vjs-tree__content {
+        padding-left: 1em;
+        &.has-line {
+            border-left: 1px dotted rgba(204, 204, 204, 0.28) !important;
+        }
+    }
+    .vjs-tree__brackets {
         cursor: pointer;
         &:hover {
             color: #20a0ff;
         }
     }
-    .vjs-checkbox {
-        position: absolute;
-        left: -30px;
-    }
-    .vjs__value__null {
+    .vjs-value__null,
+    .vjs-value__number,
+    .vjs-value__boolean {
         color: #a291f5 !important;
     }
-    .vjs__value__number,
-    .vjs__value__boolean {
-        color: #a291f5 !important;
-    }
-    .vjs__value__string {
+    .vjs-value__string {
         color: #dacb4d !important;
     }
-}
-
-.hljs-keyword,
-.hljs-selector-tag,
-.hljs-addition {
-    color: #8bd72f;
-}
-
-.hljs-string,
-.hljs-meta .hljs-meta-string,
-.hljs-doctag,
-.hljs-regexp {
-    color: #dacb4d;
-}
-
-.hljs-number,
-.hljs-literal {
-    color: #a291f5 !important;
 }


### PR DESCRIPTION
It seems that the `vue-json-pretty` library has been updated a while ago and the syntax highlighting broke.

This PR updates the styles according to https://github.com/leezng/vue-json-pretty/blob/v1.7.1/src/assets/less/tree.less and https://github.com/laravel/telescope/pull/721 

#### Before:
![vue-json-pretty-broken](https://user-images.githubusercontent.com/667144/113368865-6ed0ed80-9368-11eb-9388-9ab5f81c6ccb.png)

#### After
![vue-json-pretty-fixed](https://user-images.githubusercontent.com/667144/113368875-78f2ec00-9368-11eb-992d-8301f2786fb7.png)
