### PR TITLE
Update PHPDoc variable type

### DIFF
--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -91,7 +91,7 @@ class SupervisorOptions
     /**
      * The number of seconds to wait before retrying a job that encountered an uncaught exception.
      *
-     * @var string
+     * @var int
      */
     public $backoff;
 


### PR DESCRIPTION
I think this is just a typo, since in the constructor further down it's type hinted as int.