### PR TITLE
[5.x] Add "horizon:clear-all" command

### DIFF
--- a/src/Console/ClearAllCommand.php
+++ b/src/Console/ClearAllCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\ProvisioningPlan;
+use Laravel\Horizon\RedisQueue;
+use Laravel\Horizon\Repositories\RedisJobRepository;
+
+class ClearAllCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:clear-all
+                            {supervisor?* : The name(s) of the supervisors whose queues to clear [default: all]}
+                            {--environment= : The environment name}
+                            {--force : Force the operation to run when in production}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete all jobs from queues configured for the specified supervisor(s)';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int|null
+     */
+    public function handle(RedisJobRepository $jobRepository, QueueManager $manager)
+    {
+        if (!$this->confirmToProceed()) {
+            return 1;
+        }
+
+        if (!method_exists(RedisQueue::class, 'clear')) {
+            $this->line('<error>Clearing queues is not supported on this version of Laravel</error>');
+
+            return 1;
+        }
+
+        $queues = $this->getQueues(
+            $this->option('environment') ?? config('horizon.env') ?? config('app.env'),
+            $this->argument('supervisor')
+        );
+
+        $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
+        $count = 0;
+        foreach ($queues as $queue) {
+            $jobRepository->purge($queue);
+            $count += ($manager->connection($connection)->clear($queue));
+        }
+
+        $this->line('<info>Cleared ' . $count . ' jobs</info>');
+
+        return 0;
+    }
+
+    /**
+     * Get all the queues for the given environment and supervisors.
+     *
+     * @param  string $environment
+     * @param  array $supervisors
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getQueues($environment, $supervisors)
+    {
+        return collect(ProvisioningPlan::get(MasterSupervisor::name())->toSupervisorOptions())
+            ->first(function ($_, $name) use ($environment) {
+                return Str::is($name, $environment);
+            })
+            ->only($supervisors ?: null)
+            ->pluck('queue')
+            ->map(function ($queues) {
+                return explode(',', $queues);
+            })
+            ->flatten()
+            ->unique();
+    }
+}

--- a/src/Console/ClearAllCommand.php
+++ b/src/Console/ClearAllCommand.php
@@ -40,11 +40,11 @@ class ClearAllCommand extends Command
      */
     public function handle(RedisJobRepository $jobRepository, QueueManager $manager)
     {
-        if (!$this->confirmToProceed()) {
+        if (! $this->confirmToProceed()) {
             return 1;
         }
 
-        if (!method_exists(RedisQueue::class, 'clear')) {
+        if (! method_exists(RedisQueue::class, 'clear')) {
             $this->line('<error>Clearing queues is not supported on this version of Laravel</error>');
 
             return 1;
@@ -62,7 +62,7 @@ class ClearAllCommand extends Command
             $count += ($manager->connection($connection)->clear($queue));
         }
 
-        $this->line('<info>Cleared ' . $count . ' jobs</info>');
+        $this->line('<info>Cleared '.$count.' jobs</info>');
 
         return 0;
     }

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -109,6 +109,7 @@ class HorizonServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                Console\ClearAllCommand::class,
                 Console\ClearCommand::class,
                 Console\ContinueCommand::class,
                 Console\ContinueSupervisorCommand::class,

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -109,8 +109,8 @@ class HorizonServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                Console\ClearAllCommand::class,
                 Console\ClearCommand::class,
+                Console\ClearAllCommand::class,
                 Console\ContinueCommand::class,
                 Console\ContinueSupervisorCommand::class,
                 Console\ForgetFailedCommand::class,


### PR DESCRIPTION
This PR proposes the addition of a convenience command "horizon:clear-all".

It deletes jobs from all the queues configured for the given supervisor(s).

If no supervisor is specified, it clears all queues for all supervisors enabled in the present environment.

This is particularly useful when working with many queues or many supervisors.

```
Description:
  Delete all jobs from queues configured for the specified supervisor(s)

Usage:
  horizon:clear-all [options] [--] [<supervisor>...]

Arguments:
  supervisor                       The name(s) of the supervisors whose queues to clear [default: all]

Options:
      --environment[=ENVIRONMENT]  The environment name
      --force                      Force the operation to run when in production
```

**Review (1):** I wasn't sure if `clear-all` was appropriate as name, as it doesn't technically clear _all_ queues, but only those managed by horizon supervisors in the present environment. I originally thought `horizon:clear-supervisor-queues` might perhaps be more precise, although it's kind of long.

Let me know if tests are necessary, and I will look into adding those. 