### PR TITLE
Show number of reserved + waiting jobs in dashboard

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -32,6 +32,28 @@ class RedisQueue extends BaseQueue
     }
 
     /**
+     * Get the number of queue jobs that are processing.
+     *
+     * @param string|null $queue
+     * @return int
+     */
+    public function reservedNow($queue = null)
+    {
+        return $this->getConnection()->zcard($this->getQueue($queue).':reserved');
+    }
+
+    /**
+     * Get the number of queue jobs that are ready to process or processing.
+     *
+     * @param string|null $queue
+     * @return int
+     */
+    public function lengthNow($queue = null)
+    {
+        return $this->readyNow($queue) + $this->reservedNow($queue);
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  object|string  $job

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -73,9 +73,9 @@ class RedisWorkloadRepository implements WorkloadRepository
                 $totalProcesses = $processes[$queue] ?? 0;
 
                 $length = ! Str::contains($queue, ',')
-                    ? collect([$queueName => $this->queue->connection($connection)->readyNow($queueName)])
+                    ? collect([$queueName => $this->queue->connection($connection)->lengthNow($queueName)])
                     : collect(explode(',', $queueName))->mapWithKeys(function ($queueName) use ($connection) {
-                        return [$queueName => $this->queue->connection($connection)->readyNow($queueName)];
+                        return [$queueName => $this->queue->connection($connection)->lengthNow($queueName)];
                     });
 
                 $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses, &$wait) {


### PR DESCRIPTION
In a stable system, the number of waiting jobs for each queue should be 0 most of the time, while the number of jobs being processed may be greater than 0.
Laravel dashboard currently shows the number of waiting jobs per queue in jobs column which is most on the  time zero. Therefore, it doesn't give us feeling on how crowded each queue is. It also shows the number of workers for each queue, in processes column.
This PR, changes the value showed in "Jobs" column to be `number_of_waiting_jobs + number_of_processing_jobs`. The sum gives more valuable information, and still we can easily know how many jobs are waiting.

Unless someone is using `RedisWorkloadRepository` elsewhere, I don't regard it as a breaking change. Let me know if you want me to send it for 6.x.

![image](https://user-images.githubusercontent.com/7089140/123970329-463faa80-d9ce-11eb-8467-2f6a607bf5b0.png)
Before this change, all numbers was constantly 0 all the times. Now I know more, and guess 35 workers is a little bit too many.