### PR TITLE
[5.x] Providing directory to Symfony process

### DIFF
--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -194,7 +194,8 @@ class SupervisorOptions
                                 $balanceCooldown = 3,
                                 $balanceMaxShift = 1,
                                 $parentId = 0,
-                                $rest = 0)
+                                $rest = 0,
+                                $directory = null)
     {
         $this->name = $name;
         $this->connection = $connection;
@@ -216,6 +217,7 @@ class SupervisorOptions
         $this->balanceMaxShift = $balanceMaxShift;
         $this->parentId = $parentId;
         $this->rest = $rest;
+        $this->directory = $directory;
     }
 
     /**
@@ -309,6 +311,7 @@ class SupervisorOptions
             'balanceMaxShift' => $this->balanceMaxShift,
             'parentId' => $this->parentId,
             'rest' => $this->rest,
+            'directory' => $this->directory,
         ];
     }
 

--- a/tests/Feature/SupervisorOptionsTest.php
+++ b/tests/Feature/SupervisorOptionsTest.php
@@ -12,4 +12,44 @@ class SupervisorOptionsTest extends IntegrationTest
         $options = new SupervisorOptions('name', 'redis');
         $this->assertSame('default', $options->queue);
     }
+
+    public function test_directory_is_used_when_given()
+    {
+        $options = new SupervisorOptions(
+            'name',
+            'redis',
+            null,
+            'default',
+            'off',
+            0,
+            0,
+            0,
+            1,
+            1,
+            128,
+            60,
+            3,
+            0,
+            false,
+            0,
+            3,
+            1,
+            0,
+            0,
+            '/tmp'
+        );
+        $this->assertSame('/tmp', $options->directory);
+
+        $options = SupervisorOptions::fromArray([
+            'name' => 'name',
+            'connection' => 'redis',
+            'directory' => '/tmp',
+        ]);
+        $this->assertSame('/tmp', $options->directory);
+
+        $this->assertArrayHasKey('directory', $options->toArray());
+        $this->assertSame('/tmp', $options->toArray()['directory']);
+
+        $this->assertStringContainsString('"directory":"\/tmp"', $options->toJson());
+    }
 }


### PR DESCRIPTION
I found that the directory specified in config in `horizon.environments.{environment}.directory` wasn't provided to the Symfony process. It tries to:
```
Process::fromShellCommandline($command, $options->directory ?? base_path())
```
but `directory` is null on that `$options` object. I found it was due to `\Laravel\Horizon\SupervisorOptions::toArray()` not including the `$directory` attribute. Once I added that in, it seems to obey the directory value. It doesn't add it to the `\Laravel\Horizon\SupervisorOptions::toSupervisorCommand()` or `\Laravel\Horizon\SupervisorOptions::toWorkerCommand()` strings, which should maintain compatibility with the `illuminate/queue` package.

This allows developers to specify which directory `artisan queue:work` should be run from. The primary reason (and my reason) is to take advantage of symlinks on a server, where `base_path()` resolves symlinks to real paths.