### PR TITLE
New horizon:check command as health check for containers

### DIFF
--- a/src/Console/CheckCommand.php
+++ b/src/Console/CheckCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:check';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Ensure Horizon is running on the current machine';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masterSupervisorRepository
+     * @return int
+     */
+    public function handle(MasterSupervisorRepository $masterSupervisorRepository)
+    {
+        // If no master supervisor is running, we exit with an error.
+        if (! static::isMasterSupervisorRunningOnMachine($masterSupervisorRepository)) {
+            $this->error('No master supervisor is running on this machine at the moment.');
+
+            return 1;
+        }
+
+        // If everything is running as expected, we return with success.
+        $this->line('At least one master supervisor is running on this machine as expected.', null, OutputInterface::VERBOSITY_VERBOSE);
+
+        return 0;
+    }
+
+    /**
+     * Determine if a master supervisor is running on the current machine.
+     *
+     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masterSupervisorRepository
+     * @return bool
+     */
+    protected static function isMasterSupervisorRunningOnMachine(MasterSupervisorRepository $masterSupervisorRepository)
+    {
+        if (blank($masters = $masterSupervisorRepository->all())) {
+            return false;
+        }
+
+        return collect($masters)->contains(function (object $master) {
+            return Str::startsWith($master->name, MasterSupervisor::basename());
+        });
+    }
+}

--- a/tests/Unit/CheckCommandTest.php
+++ b/tests/Unit/CheckCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Illuminate\Console\OutputStyle;
+use Laravel\Horizon\Console\CheckCommand;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\Tests\UnitTest;
+use Mockery;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CheckCommandTest extends UnitTest
+{
+    public function test_check_command_returns_exit_code_1_as_error_if_no_master_supervisors_registered()
+    {
+        $masterSupervisorRepository = Mockery::mock(MasterSupervisorRepository::class);
+        $masterSupervisorRepository->shouldReceive('all')->once()->andReturn([]);
+
+        $this->assertSame(1, self::createCheckCommand()->handle($masterSupervisorRepository));
+    }
+
+    public function test_check_command_returns_exit_code_1_as_error_if_no_master_supervisor_of_the_current_machine_is_registered()
+    {
+        $expectedPrefix = MasterSupervisor::basename();
+        $wrongPrefix = "x-$expectedPrefix";
+
+        $masterSupervisorRepository = Mockery::mock(MasterSupervisorRepository::class);
+        $masterSupervisorRepository->shouldReceive('all')->once()->andReturn([
+            (object) ['name' => $wrongPrefix],
+        ]);
+
+        $this->assertSame(1, self::createCheckCommand()->handle($masterSupervisorRepository));
+    }
+
+    public function test_check_command_returns_exit_code_0_as_success_if_one_master_supervisor_of_the_current_machine_is_registered()
+    {
+        $expectedPrefix = MasterSupervisor::basename();
+
+        $masterSupervisorRepository = Mockery::mock(MasterSupervisorRepository::class);
+        $masterSupervisorRepository->shouldReceive('all')->once()->andReturn([
+            (object) ['name' => "$expectedPrefix-0001"],
+        ]);
+
+        $this->assertSame(0, self::createCheckCommand()->handle($masterSupervisorRepository));
+    }
+
+    public function test_check_command_returns_exit_code_0_as_success_if_multiple_master_supervisors_of_the_current_machine_is_registered()
+    {
+        $expectedPrefix = MasterSupervisor::basename();
+
+        $masterSupervisorRepository = Mockery::mock(MasterSupervisorRepository::class);
+        $masterSupervisorRepository->shouldReceive('all')->once()->andReturn([
+            (object) ['name' => "$expectedPrefix-0001"],
+            (object) ['name' => "$expectedPrefix-0002"],
+        ]);
+
+        $this->assertSame(0, self::createCheckCommand()->handle($masterSupervisorRepository));
+    }
+
+    private static function createCheckCommand()
+    {
+        $checkCommand = new CheckCommand();
+        $checkCommand->setOutput(new OutputStyle(new StringInput(''), new NullOutput()));
+
+        return $checkCommand;
+    }
+}


### PR DESCRIPTION
In #468, it was already discussed that checking for liveness of Horizon in replicated and containerized environments is tricky. The solution has been a new command, `horizon:status`, which verifies all registered master supervisors are running.

There are multiple problems with `horizon:status` which make it impractical as health check for environments like Docker Swarm or Kubernetes though:
1. Each container checks the status of all master supervisors (i.e. all containers). This is unsuitable in a containerized environment, where the health check (or liveness probe) is performed per container to ensure its health.

2. `horizon:status` checks the master supervisors for the `paused` status, which is a user-initiated status. In other words, it is not an error when master supervisors are paused and it should therefore not lead to a restart of such a container.

3. Using `horizon:status` in multiple containers may actually lead to wrong results. Even though one container may actually be unhealthy and therefore not report its state to the registry anymore ([by updating Redis with its current details](https://github.com/laravel/horizon/blob/d0a7fd91f26e95b1b941b33af36a736b70a29505/src/Repositories/RedisMasterSupervisorRepository.php#L91-L117)); yet the check may yield success because other containers are healthy. As a consequence, the degraded container will never be restarted.

---

Due to aforementioned reasons, this PR introduces a new `horizon:check` command. The new command also queries the master supervisor repository, but other than `horizon:status` it verifies that at least one master supervisor of the current machine has reported its status recently.

**Implementation details:** The `horizon:check` command uses [`MasterSupervisor::basename()`](https://github.com/laravel/horizon/blob/d0a7fd91f26e95b1b941b33af36a736b70a29505/src/MasterSupervisor.php#L92-L102) to retrieve the common prefix of master supervisor names. This works great with the default config where the hostname is used, but it may break if a custom name resolves has been registered with [`MasterSupervisor::determineNameUsing($factory)`](https://github.com/laravel/horizon/blob/d0a7fd91f26e95b1b941b33af36a736b70a29505/src/MasterSupervisor.php#L104-L113) which does not generate names unique per host.

---

This may actually not be the best solution to this problem. A local check would be preferable, e.g. checking some state file or pinging the process via socket. It would be quite hard to add such a check without breaking changes though. This new command interferes with no existing code and is therefore safe to add.