### PR TITLE
Check if `failedJob.reserved_at` is set before making time calculation

### DIFF
--- a/resources/js/screens/batches/preview.vue
+++ b/resources/js/screens/batches/preview.vue
@@ -184,7 +184,7 @@
                     </td>
 
                     <td class="table-fit">
-                        <span>{{ failedJob.failed_at ? String((failedJob.failed_at - failedJob.reserved_at).toFixed(2))+'s' : '-' }}</span>
+                        <span>{{ failedJob.failed_at && failedJob.reserved_at ? String((failedJob.failed_at - failedJob.reserved_at).toFixed(2))+'s' : '-' }}</span>
                     </td>
 
                     <td class="text-right table-fit">


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a check if the `failedJob.reserved_at` is set, since the calculated runtime is wrong if this is not set (see image below). Unsure if `failedJob.reserved_at` should always be set and a bug is causing this not to happen though.

![Screenshot 2021-09-08 at 10 09 45](https://user-images.githubusercontent.com/30228807/132471961-e76fdfcc-58c2-4830-bed7-910440ea483d.png)
