### PR TITLE
[5.x] Update forget failed command to use job uuid instead of job id

### DIFF
--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -28,7 +28,11 @@ class ForgetFailedCommand extends Command
      */
     public function handle(JobRepository $repository)
     {
-        $repository->deleteFailed($this->argument('id'));
+        $failedJobPayload = $this->laravel['queue.failer']->find($this->argument('id'))->payload ?? null;
+        if (! is_null($failedJobPayload)) {
+            $jobId = json_decode($failedJobPayload, true)['uuid'] ?? $this->argument('id');
+            $repository->deleteFailed($jobId);
+        }
 
         if ($this->laravel['queue.failer']->forget($this->argument('id'))) {
             $this->info('Failed job deleted successfully!');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

fixes #1080

### Summary 
This PR fixes a bug on `ForgetFailedCommand` where it tries to remove a job from Horizon Redis using Job ID instead of Job UUID.

### Description
`ForgetFailedCommand`uses Job ID to be remove a particular job entry from Horizon's Redis. However, when storing a failed job unto Redis, Horizon always uses UUID instead of ID. 

This causes a bug whereby the job is successfully removed from the `failed_job` database table but not removed from Horizon (since there is no such key with `horizon:job-id`, the correct key is `horizon:job-uuid`)

To fix this, ForgetFailedCommand must be updated to remove the failed job from Redis using job UUID as key instead of job ID

### Steps To Reproduce

1) Create a job which always fail/throw exception
2) Trigger the job
3) Notice that a new entry is created in the `failed_jobs` table
4) Try "forgetting" that failed job by running `php artisan horizon:forget job-id` as explained in the docs
5) Job would be removed from failed_jobs database but running `HGETALL 'horizon:job-uuid'` against redis shows that the job still remain in Redis.