### PR TITLE
Alphabetically sort jobs/queues for metrics

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -40,7 +40,7 @@ class RedisMetricsRepository implements MetricsRepository
 
         return collect($classes)->map(function ($class) {
             return preg_match('/job:(.*)$/', $class, $matches) ? $matches[1] : $class;
-        })->all();
+        })->sort()->values()->all();
     }
 
     /**
@@ -54,7 +54,7 @@ class RedisMetricsRepository implements MetricsRepository
 
         return collect($queues)->map(function ($class) {
             return preg_match('/queue:(.*)$/', $class, $matches) ? $matches[1] : $class;
-        })->all();
+        })->sort()->values()->all();
     }
 
     /**


### PR DESCRIPTION
Minor change, but this will alphabetically sort the job classes and queue names before returning them to the Horizon front-end. I'm not sure what the default ordering is - possibly something internal to Redis, or the order the jobs are seen by Horizon. However, when you have a large number of jobs it can be hard to find what you're looking for. I think it makes sense to sort alphabetically so at least there is a predictable order.

For context - here's the first 4 jobs shown in my app without this ordering change and it's all over the shop.

![image](https://user-images.githubusercontent.com/1100408/136151330-5330fd4e-4aba-4d41-9cb8-7a75a7b9c2bd.png)
