### PR TITLE
Update page title when switching between `Pending` and `Completed` views

### DIFF
--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -131,6 +131,9 @@
                 this.hasNewEntries = false;
             },
 
+            /**
+             * Update the page title.
+             */
             updatePageTitle() {
                 document.title = this.$route.params.type == 'pending'
                         ? 'Horizon - Pending Jobs'


### PR DESCRIPTION
When switching between `Pending` and `Completed` views, the page title does not get updated to correspond to the currently selected view, as the page title only gets set when the component is initially mounted.

This change watches `$route` and updates the page title on route change too 👍 