### PR TITLE
use callAfterResolving to register QueueManager

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -187,7 +187,7 @@ class HorizonServiceProvider extends ServiceProvider
      */
     protected function registerQueueConnectors()
     {
-        $this->app->resolving(QueueManager::class, function ($manager) {
+        $this->callAfterResolving(QueueManager::class, function ($manager) {
             $manager->addConnector('redis', function () {
                 return new RedisConnector($this->app['redis']);
             });


### PR DESCRIPTION
Due to the nature of how our app/monolith is registering service providers (we disabled autodiscovery), the resolving listener would never trigger because of another error tracking dependency.

While serving the app via the console, `HorizonServiceProvider` is always registered. But when serving over HTTP, it is only registered lazily via some domain\context inference in a global middleware. At that point however, the error tracking package has already resolved the `QueueManager` instance causing the app to crash when trying to visit the Horizon dashboard.

Using `callAfterResolving` would fix our issue and not break anything for any other user, as it just adds an extra if-check under the hood.

Thank you!