### PR TITLE
Reduce bundle size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@
 *.md diff=markdown
 *.php diff=php
 
+public/*.css binary
+public/*.js binary
+
 /.github export-ignore
 /tests export-ignore
 .gitattributes export-ignore

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -36,5 +36,10 @@ mix.options({
                 '@': path.resolve(__dirname, 'resources/js/'),
             },
         },
-        plugins: [new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)],
+        plugins: [
+            new webpack.IgnorePlugin({
+                resourceRegExp: /^\.\/locale$/,
+                contextRegExp: /moment$/,
+            }),
+        ],
     });


### PR DESCRIPTION
This PR reduces the bundle size by updating an outdated webpack configuration.
The webpack.IgnorePlugin has changed its syntax since it was added in 2017.

So now the bundle is reduced from 1160kb to 922kb!

See: https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales

I've submitted the same fix in https://github.com/laravel/telescope/pull/1142