### PR TITLE
Add a new artisan command to test horizon notifications setup

### DIFF
--- a/src/Console/TestNotificationsCommand.php
+++ b/src/Console/TestNotificationsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Horizon\Horizon;
+use Laravel\Horizon\Notifications\Test;
+use Illuminate\Support\Facades\Notification;
+
+class TestNotificationsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:test-notifications';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send a test notifications to all methods that have been setup in horizon provider';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Notification::route('slack', Horizon::$slackWebhookUrl)
+            ->route('nexmo', Horizon::$smsNumber)
+            ->route('mail', Horizon::$email)
+            ->notify(
+                new Test()
+            );
+    }
+}

--- a/src/Console/TestNotificationsCommand.php
+++ b/src/Console/TestNotificationsCommand.php
@@ -3,9 +3,9 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
 use Laravel\Horizon\Horizon;
 use Laravel\Horizon\Notifications\Test;
-use Illuminate\Support\Facades\Notification;
 
 class TestNotificationsCommand extends Command
 {

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -126,6 +126,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\TerminateCommand::class,
                 Console\TimeoutCommand::class,
                 Console\WorkCommand::class,
+                Console\TestNotificationsCommand::class,
             ]);
         }
 

--- a/src/Notifications/Test.php
+++ b/src/Notifications/Test.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Laravel\Horizon\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\NexmoMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Laravel\Horizon\Horizon;
+
+class Test extends Notification
+{
+    use Queueable;
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return array_filter([
+            Horizon::$slackWebhookUrl ? 'slack' : null,
+            Horizon::$smsNumber ? 'nexmo' : null,
+            Horizon::$email ? 'mail' : null,
+        ]);
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->error()
+            ->subject(config('app.name').': Horizon test notification')
+            ->greeting('This is a horizon test.')
+            ->line('This is a test notification sent with php artisan horizon:test-notification command.');
+    }
+
+    /**
+     * Get the Slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+                    ->from('Laravel Horizon')
+                    ->to(Horizon::$slackChannel)
+                    ->image('https://laravel.com/assets/img/horizon-48px.png')
+                    ->error()
+                    ->content('This is a horizon test.')
+                    ->attachment(function ($attachment) {
+                        $attachment->title('Test')
+                                   ->content(sprintf(
+                                        '[%s] This is a test notification sent with php artisan horizon:test-notification command.',
+                                       config('app.name')
+                                   ));
+                    });
+    }
+
+    /**
+     * Get the Nexmo / SMS representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\NexmoMessage
+     */
+    public function toNexmo($notifiable)
+    {
+        return (new NexmoMessage)->content(sprintf(
+            '[%s] This is a test notification sent with php artisan horizon:test-notification command.',
+            config('app.name')
+        ));
+    }
+}

--- a/src/Notifications/Test.php
+++ b/src/Notifications/Test.php
@@ -40,7 +40,7 @@ class Test extends Notification
             ->error()
             ->subject(config('app.name').': Horizon test notification')
             ->greeting('This is a horizon test.')
-            ->line('This is a test notification sent with php artisan horizon:test-notification command.');
+            ->line('This is a test notification sent with php artisan horizon:test-notifications command.');
     }
 
     /**
@@ -60,7 +60,7 @@ class Test extends Notification
                     ->attachment(function ($attachment) {
                         $attachment->title('Test')
                                    ->content(sprintf(
-                                        '[%s] This is a test notification sent with php artisan horizon:test-notification command.',
+                                        '[%s] This is a test notification sent with php artisan horizon:test-notifications command.',
                                        config('app.name')
                                    ));
                     });
@@ -75,7 +75,7 @@ class Test extends Notification
     public function toNexmo($notifiable)
     {
         return (new NexmoMessage)->content(sprintf(
-            '[%s] This is a test notification sent with php artisan horizon:test-notification command.',
+            '[%s] This is a test notification sent with php artisan horizon:test-notifications command.',
             config('app.name')
         ));
     }


### PR DESCRIPTION
After setting up notifications in horizon service provider (https://laravel.com/docs/8.x/horizon#notifications), I have no way to check that everything is wired properly, so I made this basic artisan to send a test notification through all channels.

PS: I got inspired by https://docs.sentry.io/platforms/php/guides/laravel/#verify-with-artisan