### PR TITLE
Prevent pool to receive more than available processes on scaling

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -139,7 +139,7 @@ class AutoScaler
             $pool->scale(
                 min(
                     $totalProcessCount + $maxUpShift,
-                    $supervisor->options->maxProcesses,
+                    $supervisor->options->maxProcesses - (($supervisor->processPools->count() - 1) * $supervisor->options->minProcesses),
                     $desiredProcessCount
                 )
             );


### PR DESCRIPTION
As described in https://github.com/laravel/horizon/issues/897 a queue might currently scale down to 0 processes even though a minimum amount of processes per queue is configured. 
I observed the behavior especially when one queue needs to process a lot of jobs over a longer period of time (`system_function` in the screenshot). In that case it sometimes receives all processes from other busy queues (`low` in the screenshot) which leads to the other busy queue (`low`) receiving 0 processes as all others are already busy even though the `minProcesses` in the config is set to 3.
![image](https://user-images.githubusercontent.com/19409640/142010167-22e65eb1-5941-476e-a7bc-e88dcd5d6c60.png)

To prevent this issue this pull request ensures that a queue will not receive more than the available processes when scaling up by considering the configured `minProcesses` and the amount of configured queues using the following formula: 
`[maxProcesses] - (([amount of queues] - 1) * [minProcesses])`

This ensures that every queue has the configured amount of `minProcesses` available.