### PR TITLE
Add some PHP 8.1 fixes

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -170,7 +170,7 @@ class JobPayload implements ArrayAccess
      * @param  string  $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->decoded);
     }
@@ -181,6 +181,7 @@ class JobPayload implements ArrayAccess
      * @param  string  $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->decoded[$offset];
@@ -193,7 +194,7 @@ class JobPayload implements ArrayAccess
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->decoded[$offset] = $value;
     }
@@ -204,7 +205,7 @@ class JobPayload implements ArrayAccess
      * @param  string  $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->decoded[$offset]);
     }

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -323,7 +323,7 @@ class ProcessPool implements Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->processes);
     }


### PR DESCRIPTION
Since these classes are very unlikely to be overridden as Horizon isn't that extensible, I've opted to add return types directly. Only for the `mixed` type (needs minimum version of PHP 8.0) I've opted to add the `ReturnTypeWillChange` attribute instead.

Fixes #1099
