### PR TITLE
[5.x] Add exception context on failed jobs

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -198,6 +198,16 @@
             </div>
         </div>
 
+        <div class="card mt-4" v-if="ready">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h5>Exception Context</h5>
+            </div>
+
+            <div class="card-body code-bg text-white">
+                <vue-json-pretty :data="prettyPrintJob(job.context)"></vue-json-pretty>
+            </div>
+        </div>
+
 
         <div class="card mt-4" v-if="ready">
             <div class="card-header d-flex align-items-center justify-content-between">

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -117,6 +117,8 @@ class FailedJobsController extends Controller
 
         $job->exception = mb_convert_encoding($job->exception, 'UTF-8');
 
+        $job->context = json_decode($job->context);
+
         $job->retried_by = collect(json_decode($job->retried_by))
                     ->sortByDesc('retried_at')->values();
 

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -26,7 +26,8 @@ class RedisJobRepository implements JobRepository
      */
     public $keys = [
         'id', 'connection', 'queue', 'name', 'status', 'payload',
-        'exception', 'failed_at', 'completed_at', 'retried_by', 'reserved_at',
+        'exception', 'context', 'failed_at', 'completed_at', 'retried_by',
+        'reserved_at',
     ];
 
     /**
@@ -597,7 +598,7 @@ class RedisJobRepository implements JobRepository
     /**
      * Mark the job as failed.
      *
-     * @param  string  $exception
+     * @param  \Exception  $exception
      * @param  string  $connection
      * @param  string  $queue
      * @param  \Laravel\Horizon\JobPayload  $payload
@@ -620,6 +621,9 @@ class RedisJobRepository implements JobRepository
                     'status' => 'failed',
                     'payload' => $payload->value,
                     'exception' => (string) $exception,
+                    'context' => method_exists($exception, 'context')
+                        ? json_encode($exception->context())
+                        : null,
                     'failed_at' => str_replace(',', '.', microtime(true)),
                 ]
             );


### PR DESCRIPTION
This PR adds the exception context when displaying a failed job.

<img width="1302" alt="Capture d’écran 2022-01-28 à 02 06 20" src="https://user-images.githubusercontent.com/15859384/151469535-8c1c0920-ca86-4fbe-b2c8-0bade6786418.png">
