### PR TITLE
Clear timers during each queue worker iteration

### DIFF
--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -67,5 +67,9 @@ trait EventMap
         Events\LongWaitDetected::class => [
             Listeners\SendNotification::class,
         ],
+
+        \Illuminate\Queue\Events\Looping::class => [
+            Listeners\ClearJobTimers::class,
+        ],
     ];
 }

--- a/src/Listeners/ClearJobTimers.php
+++ b/src/Listeners/ClearJobTimers.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Horizon\Listeners;
+
+use Laravel\Horizon\Stopwatch;
+
+class ClearJobTimers
+{
+    /**
+     * The stopwatch instance.
+     *
+     * @var \Laravel\Horizon\Stopwatch
+     */
+    public $watch;
+
+    /**
+     * Create a new listener instance.
+     *
+     * @param  \Laravel\Horizon\Stopwatch  $watch
+     * @return void
+     */
+    public function __construct(Stopwatch $watch)
+    {
+        $this->watch = $watch;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->watch->clear();
+    }
+}

--- a/src/Stopwatch.php
+++ b/src/Stopwatch.php
@@ -34,4 +34,14 @@ class Stopwatch
             return round((microtime(true) - $this->timers[$key]) * 1000, 2);
         }
     }
+
+    /**
+     * Clear all registered timers.
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $this->timers = [];
+    }
 }


### PR DESCRIPTION
Fixes #1125 by clearing the `Stopwatch::$timers` while the queue worker is looping. Using the `Looping` event ensures the timers are reset before taking on the next job.

I've created [a repository with a minimal reproducible example](https://github.com/Namoshek/laravel-horizon-memory-leak).

### Alternatives

If using the `Looping` event in Horizon is not desired or seems excessive due to the listener also being run if no job has been executed, it may also work to clear the timers from listeners for the `JobDeleted`, `JobFailed` and maybe `JobReleased` events. Since I'm not entirely sure when which of these events is run, I opted for the safest solution to always clear the timers.