### PR TITLE
Forget job timer in case of exception or failed job

### DIFF
--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -32,8 +32,13 @@ trait EventMap
         Events\JobsMigrated::class => [
             Listeners\MarkJobsAsMigrated::class,
         ],
+        
+        \Illuminate\Queue\Events\JobExceptionOccurred::class => [
+            Listeners\ForgetJobTimer::class,
+        ],
 
         \Illuminate\Queue\Events\JobFailed::class => [
+            Listeners\ForgetJobTimer::class,
             Listeners\MarshalFailedEvent::class,
         ],
 

--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -32,7 +32,7 @@ trait EventMap
         Events\JobsMigrated::class => [
             Listeners\MarkJobsAsMigrated::class,
         ],
-        
+
         \Illuminate\Queue\Events\JobExceptionOccurred::class => [
             Listeners\ForgetJobTimer::class,
         ],

--- a/src/Listeners/ForgetJobTimer.php
+++ b/src/Listeners/ForgetJobTimer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Horizon\Listeners;
+
+use Laravel\Horizon\Stopwatch;
+
+class ForgetJobTimer
+{
+    /**
+     * The stopwatch instance.
+     *
+     * @var \Laravel\Horizon\Stopwatch
+     */
+    public $watch;
+
+    /**
+     * Create a new listener instance.
+     *
+     * @param  \Laravel\Horizon\Stopwatch  $watch
+     * @return void
+     */
+    public function __construct(Stopwatch $watch)
+    {
+        $this->watch = $watch;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Queue\Events\JobExceptionOccurred|\Illuminate\Queue\Events\JobFailed  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $this->watch->forget($event->job->getJobId());
+    }
+}


### PR DESCRIPTION
This PR fixes the remaining cases not handled by 69486d5e4fad8b6ee02c97ed0bea39ef241df956.

I wasn't sure if having two event listeners doing the exact same thing would be preferred over a single listener supporting both events.

---

Currently, jobs throwing an exception and jobs which fail (e.g. using `$this->fail()`) still leak the job timer:

> [2022-02-21 20:13:27] local.DEBUG: The first job is run.
[2022-02-21 20:13:27] local.DEBUG: Stopwatch {"timers":0}
[2022-02-21 20:13:27] local.DEBUG: The first job is run.
[2022-02-21 20:13:27] local.DEBUG: Stopwatch {"timers":0}
[2022-02-21 20:13:30] local.DEBUG: The first job is run.
[2022-02-21 20:13:30] local.DEBUG: Stopwatch {"timers":0}
[2022-02-21 20:13:30] local.DEBUG: The second job is started.
[2022-02-21 20:13:30] local.DEBUG: The third job throws an exception.
[2022-02-21 20:13:30] local.ERROR: Oh no! {"exception":"[object] (Exception(code: 0): Oh no! at /home/marvin/projects/laravel-horizon-memory-leak/app/Jobs/ThirdJob.php:22)"}
[2022-02-21 20:13:30] local.DEBUG: The second job is started.
[2022-02-21 20:13:30] local.DEBUG: The third job throws an exception.
[2022-02-21 20:13:30] local.ERROR: Oh no! {"exception":"[object] (Exception(code: 0): Oh no! at /home/marvin/projects/laravel-horizon-memory-leak/app/Jobs/ThirdJob.php:22)"}
[2022-02-21 20:13:33] local.DEBUG: The first job is run.
[2022-02-21 20:13:33] local.DEBUG: Stopwatch {"timers":2}
[2022-02-21 20:13:33] local.DEBUG: The second job is started.
[2022-02-21 20:13:33] local.DEBUG: The third job throws an exception.
[2022-02-21 20:13:33] local.ERROR: Oh no! {"exception":"[object] (Exception(code: 0): Oh no! at /home/marvin/projects/laravel-horizon-memory-leak/app/Jobs/ThirdJob.php:22)"}
[2022-02-21 20:13:33] local.DEBUG: The first job is run.
[2022-02-21 20:13:33] local.DEBUG: Stopwatch {"timers":3}