### PR TITLE
change chart.js intersect mode to false

### DIFF
--- a/resources/js/components/LineChart.vue
+++ b/resources/js/components/LineChart.vue
@@ -17,6 +17,9 @@
             this.chart = new Chart(this.context, {
                 type: 'line',
                 options: {
+                    tooltips: {
+                        intersect: false,
+                    },
                     legend: {
                         display: false,
                     },


### PR DESCRIPTION
Hovering over the right place on the chart to display a tooltip (in the metrics section) is quite difficult. The dot is small so I changed the intersection mode to false (chart.js docs - https://www.chartjs.org/docs/2.9.4/configuration/tooltip.html).

The tooltip will allways be displayed to the nearest point (when hovering over chart).