### PR TITLE
Fix for table headers in the Monitoring tab to match the data that is presented to the user

### DIFF
--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -161,8 +161,8 @@
             <tr>
                 <th>Job</th>
                 <th>Queued At</th>
-                <th v-if="type == 'jobs'">Runtime</th>
-                <th class="text-right" v-if="type == 'jobs'">Status</th>
+                <th v-if="type == 'jobs'">Completed At</th>
+                <th class="text-right" v-if="type == 'jobs'">Runtime</th>
                 <th class="text-right" v-if="type == 'failed'">Failed At</th>
             </tr>
             </thead>


### PR DESCRIPTION
On the Monitoring tab, the headers do not match the data within the table. I don't know what the intention was here, but I at least updated the headers to match what's presented, rather than updating the data to match the headers. Attached is a screenshot showing the issue on fully updated live version of Horizon...

<img width="929" alt="Screen Shot 2022-03-29 at 1 19 38 PM" src="https://user-images.githubusercontent.com/10456109/160709042-ad4f2316-4dea-49da-b12a-02a85ba061d4.png">
.