### PR TITLE
[5.x] Use PHP 8.0's Attribute to enrich Laravel Horizon Job Tags 

### DIFF
--- a/src/Attributes/Tag.php
+++ b/src/Attributes/Tag.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laravel\Horizon\Attributes;
+
+use Attribute;
+
+/**
+ * An Attribute to mark properties of a Job to be added as tag.
+ */
+#[Attribute]
+class Tag
+{
+    /**
+     * @param string $attribute
+     */
+    public function __construct(public $attribute = null)
+    {
+    }
+}

--- a/tests/Feature/Fakes/User.php
+++ b/tests/Feature/Fakes/User.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Auth\User as BaseUser;
 
 class User extends BaseUser
 {
-    //
+    protected $guarded = [];
 }

--- a/tests/Feature/Jobs/TaggedJob.php
+++ b/tests/Feature/Jobs/TaggedJob.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Jobs;
+
+use Illuminate\Support\Collection;
+use Laravel\Horizon\Attributes\Tag;
+use Laravel\Horizon\Tests\Feature\Fakes\User;
+
+class TaggedJob
+{
+    public function __construct(
+        #[Tag]
+        public $foo,
+
+        #[Tag('name')]
+        public User $user,
+
+        #[Tag('create')]
+        public array $data,
+
+        #[Tag('count')]
+        public Collection $posts,
+    )
+    {
+        //
+    }
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/Feature/TagEnrichmentTest.php
+++ b/tests/Feature/TagEnrichmentTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Laravel\Horizon\Tags;
+use Laravel\Horizon\Tests\Feature\Fakes\User;
+use Laravel\Horizon\Tests\Feature\Jobs\TaggedJob;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class TagEnrichmentTest extends IntegrationTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (version_compare(phpversion(), '8.0', '<')) {
+            $this->markTestSkipped(
+                'Tag enrichment only works in PHP 8.0+.'
+            );
+        }
+    }
+
+    public function test_can_collect_additional_tags()
+    {
+        $model = User::make([
+            'id' => 1,
+            'name' => 'John Doe'
+        ]);
+        $job = new TaggedJob(
+            'bar',
+            $model,
+            ['create' => true],
+            collect(['count' => 10])
+        );
+
+        $tags = Tags::for($job);
+
+        $this->assertEquals([
+            'Laravel\Horizon\Tests\Feature\Fakes\User:1',
+            'foo:bar',
+            'user:john-doe',
+            'data:true',
+            'posts:10'
+        ], $tags);
+    }
+}


### PR DESCRIPTION
Hi,

I recently used a PHP 8.0 Attribute to mark properties to be included as tags without adding the `tags()` function to a Job.

I also created a new thread https://github.com/laravel/framework/discussions/41938 with further details.

