### PR TITLE
Checking the "viewHorizon" gate first

### DIFF
--- a/src/HorizonApplicationServiceProvider.php
+++ b/src/HorizonApplicationServiceProvider.php
@@ -27,8 +27,7 @@ class HorizonApplicationServiceProvider extends ServiceProvider
         $this->gate();
 
         Horizon::auth(function ($request) {
-            return app()->environment('local') ||
-                   Gate::check('viewHorizon', [$request->user()]);
+            return Gate::check('viewHorizon', [$request->user()]) || app()->environment('local');
         });
     }
 


### PR DESCRIPTION
Checking the "viewHorizon" gate first before checking if its local environment.

This is very useful if the user want to directly test the `viewHorizon` gate in local environment.