### PR TITLE
fix connection configuration is overwritten

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -103,9 +103,8 @@ class Horizon
             throw new Exception("Redis connection [{$connection}] has not been configured.");
         }
 
-        config(['database.redis.horizon' => array_merge($config, [
-            'options' => ['prefix' => config('horizon.prefix') ?: 'horizon:'],
-        ])]);
+        $config['options']['prefix'] = config('horizon.prefix') ?: 'horizon:';
+        config(['database.redis.horizon' => $config]);
     }
 
     /**


### PR DESCRIPTION
When executing array_merge, the custom options will be overwritten