### PR TITLE
when register, keep the original redis options, only overwrite prefix

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -102,7 +102,7 @@ class Horizon
         } elseif (is_null($config) && is_null($config = config("database.redis.{$connection}"))) {
             throw new Exception("Redis connection [{$connection}] has not been configured.");
         }
-        
+
         $config['options']['prefix'] = config('horizon.prefix') ?: 'horizon:';
         config(['database.redis.horizon' => $config]);
     }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -102,10 +102,9 @@ class Horizon
         } elseif (is_null($config) && is_null($config = config("database.redis.{$connection}"))) {
             throw new Exception("Redis connection [{$connection}] has not been configured.");
         }
-
-        config(['database.redis.horizon' => array_merge($config, [
-            'options' => ['prefix' => config('horizon.prefix') ?: 'horizon:'],
-        ])]);
+        
+        $config['options']['prefix'] = config('horizon.prefix') ?: 'horizon:';
+        config(['database.redis.horizon' => $config]);
     }
 
     /**

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -104,6 +104,7 @@ class Horizon
         }
 
         $config['options']['prefix'] = config('horizon.prefix') ?: 'horizon:';
+
         config(['database.redis.horizon' => $config]);
     }
 


### PR DESCRIPTION
current:
when register, the origin redis option is overwritten, leaving only the prefix.

expect:
keep the origin redis option, only overwrite prefix

explanation:
when using redis sentinel with predis driver, the config is like:
```
        'default' => [
            'redis-sentinel:26379',
            'options' => [
                'replication' => 'sentinel',
                'service' => 'mymaster',
                'parameters' => [
                    'password' => 'xxxxxx',
                    'database' => 0,
                ],
            ]
        ]
```
the current situation: when using horizon, the sentinel option will be overwritten and cannot create connection correctly. And it will throw exception like:
```
ERR unknown command 'ZADD', with args beginning with: 'laravel_horizon:recent_jobs' '-1657159739.0121' 'a6ea2c53-565b-4f1b-927c-f5f1d2b8af34'
```

It's expected that the original option is preserved then the sentinel is connect correctly.