### PR TITLE
[5.x] Fallback array for `retried_by`

### DIFF
--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -119,7 +119,7 @@ class FailedJobsController extends Controller
 
         $job->context = json_decode($job->context);
 
-        $job->retried_by = collect(json_decode($job->retried_by))
+        $job->retried_by = collect(! is_null($job->retried_by) ? json_decode($job->retried_by) : [])
                     ->sortByDesc('retried_at')->values();
 
         return $job;


### PR DESCRIPTION
In some situations, `retried_by` on a job could be `null` instead of a json array. When this happens, a warning on PHP 8.1 gets triggered and logs can get filled up with these. We should fallback on an empty array when that happens.

See https://github.com/laravel/horizon/issues/1165