### PR TITLE
Re-add example image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Horizon provides a beautiful dashboard and code-driven configuration for your La
 
 All of your worker configuration is stored in a single, simple configuration file, allowing your configuration to stay in source control where your entire team can collaborate.
 
+<p align="center">
+<img src="https://laravel.com/img/docs/horizon-example.png">
+</p>
+
 ## Official Documentation
 
 Documentation for Horizon can be found on the [Laravel website](https://laravel.com/docs/horizon).


### PR DESCRIPTION
Every repo which has an UI (Telescope, Vapor UI) has an example image in their README. I feel like we need to re-add the one for Horizon as well or remove the other ones.