### PR TITLE
Ability to ignore long waits for queue

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -5,7 +5,6 @@ namespace Laravel\Horizon\Listeners;
 use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
-use Laravel\Horizon\Events\SupervisorLooped;
 use Laravel\Horizon\WaitTimeCalculator;
 
 class MonitorWaitTimes
@@ -41,7 +40,7 @@ class MonitorWaitTimes
      * @param  \Laravel\Horizon\Events\SupervisorLooped  $event
      * @return void
      */
-    public function handle(SupervisorLooped $event)
+    public function handle()
     {
         if (! $this->dueToMonitor()) {
             return;

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -52,7 +52,8 @@ class MonitorWaitTimes
         $results = app(WaitTimeCalculator::class)->calculate();
 
         $long = collect($results)->filter(function ($wait, $queue) {
-            return $wait > (config("horizon.waits.{$queue}") ?? 60);
+            return config("horizon.waits.{$queue}") !== 0
+                    && $wait > (config("horizon.waits.{$queue}") ?? 60);
         });
 
         // Once we have determined which queues have long wait times we will raise the

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -27,7 +27,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener = new MonitorWaitTimes(resolve(MetricsRepository::class));
         $listener->lastMonitoredAt = CarbonImmutable::now()->subDay();
 
-        $listener->handle(null);
+        $listener->handle();
 
         Event::assertDispatched(LongWaitDetected::class, function ($event) {
             return $event->connection == 'redis' && $event->queue == 'test-queue-2';
@@ -49,7 +49,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener = new MonitorWaitTimes(resolve(MetricsRepository::class));
         $listener->lastMonitoredAt = CarbonImmutable::now()->subDays(1);
 
-        $listener->handle(null);
+        $listener->handle();
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -3,13 +3,10 @@
 namespace Laravel\Horizon\Tests\Feature;
 
 use Carbon\CarbonImmutable;
-use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\Facades\Event;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
-use Laravel\Horizon\Events\SupervisorLooped;
 use Laravel\Horizon\Listeners\MonitorWaitTimes;
-use Laravel\Horizon\Supervisor;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Laravel\Horizon\WaitTimeCalculator;
 use Mockery;


### PR DESCRIPTION
Currently once you enable "waits" you will be notified on all queues. This PR allows you to configure a queue wait time of `0` to ignore any "long waits".

I chose `0` as other queue related configuration options use `0` for infinite or indefinite values. Also, `null` is not an option as this would fallback to the default wait time of `60` seconds.