### PR TITLE
Monitor specific queue for long wait if configured

### DIFF
--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -15,13 +15,17 @@ class MonitorWaitTimesTest extends IntegrationTest
 {
     public function test_queues_with_long_waits_are_found()
     {
+        config(['horizon.waits' => []]);
+
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->shouldReceive('calculate')->andReturn([
-            'redis:test-queue' => 10,
-            'redis:test-queue-2' => 80,
-        ]);
+        $calc->expects('calculate')
+            ->withNoArgs()
+            ->andReturn([
+                'redis:test-queue' => 10,
+                'redis:test-queue-2' => 80,
+            ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $listener = new MonitorWaitTimes(resolve(MetricsRepository::class));
@@ -41,9 +45,11 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->andReturn([
-            'redis:ignore-queue' => 10,
-        ]);
+        $calc->expects('calculate')
+            ->withNoArgs()
+            ->andReturn([
+                'redis:ignore-queue' => 10,
+            ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $listener = new MonitorWaitTimes(resolve(MetricsRepository::class));
@@ -52,5 +58,33 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener->handle();
 
         Event::assertNotDispatched(LongWaitDetected::class);
+    }
+
+    public function test_monitors_specific_queue_with_long_wait()
+    {
+        config(['horizon.waits' => ['redis:default' => 0, 'redis:shared-1' => 10]]);
+
+        Event::fake();
+
+        $calc = Mockery::mock(WaitTimeCalculator::class);
+        $calc->expects('calculate')
+            ->withNoArgs()
+            ->andReturn([
+                'redis:default' => 90,
+                'redis:shared-1,shared-2' => 25,
+            ]);
+        $calc->expects('calculateFor')
+            ->with('redis:shared-1')
+            ->andReturn(15);
+        $this->app->instance(WaitTimeCalculator::class, $calc);
+
+        $listener = new MonitorWaitTimes(resolve(MetricsRepository::class));
+        $listener->lastMonitoredAt = CarbonImmutable::now()->subDay();
+
+        $listener->handle();
+
+        Event::assertDispatched(LongWaitDetected::class, function ($event) {
+            return $event->connection == 'redis' && $event->queue == 'shared-1';
+        });
     }
 }

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -38,7 +38,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         });
     }
 
-    public function test_queue_ignores_long_waits()
+    public function test_ignores_queue_with_long_wait()
     {
         config(['horizon.waits' => ['redis:ignore-queue' => 0]]);
 
@@ -53,7 +53,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $listener = new MonitorWaitTimes(resolve(MetricsRepository::class));
-        $listener->lastMonitoredAt = CarbonImmutable::now()->subDays(1);
+        $listener->lastMonitoredAt = CarbonImmutable::now()->subDay();
 
         $listener->handle();
 


### PR DESCRIPTION
This is a proposed solution for #1171 to monitor a specific queue if configured.

Currently, when running multiple queues an event is emitted for that "shared" queue. So there's no way to be notified when a specific queue within a "shared" queue has a long wait.

This PR allows you to receive an event for a specific queue, even if running within a multiple queue, when configured via `waits`.

For example:

```php
    'waits' => [
        // ...
        'redis:automation' => 1800,
    ],

    // ...

    'environments' => [
        'worker' => [
            'shifts' => [
                // ...
                'queue' => ['automation', 'subscriber', 'paid', 'workbench'],
                'balance' => false,
            ],
        ],
    ],
```

In an effort to be backwards compatible, I did not change the underlying `WaitTimeCalculator`. Instead, I isolated the change to the listener. It now also monitors any queues configured via `waits`. This actually provides more flexibility as you may now monitor individual and multiple queues, but potentially combinations of queues which may not run under the same supervisor (would need more testing).

Combined with #1172, I hope this makes the `waits` configuration more robust for developers needs.