### PR TITLE
[5.x] Failed job list: Modify job retry tooltip label to include status of last job retry

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -154,7 +154,7 @@
             /**
              * Construct the tooltip label for a retried job.
              */
-            retriedJobTooltip(job){
+            retriedJobTooltip(job) {
                 let lastRetry = job.retried_by[job.retried_by.length - 1];
 
                 return `Total retries: ${job.retried_by.length}, Last retry status: ${_.upperFirst(lastRetry.status)}`;

--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -152,7 +152,7 @@
             },
 
             /**
-             * Construct the tooltip label for the job containing retry count and the last retry status.
+             * Construct the tooltip label for the job containing retry count and the status of the last retry.
              */
             jobTooltipLabel(job){
                 let lastRetry = job.retried_by[job.retried_by.length - 1]

--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -155,14 +155,8 @@
              * Construct the tooltip label for the job containing retry count and the last retry status.
              */
             jobTooltipLabel(job){
-                let label  = `Total retries: ${job.retried_by.length}`
                 let lastRetry = job.retried_by[job.retried_by.length - 1]
-
-                if(lastRetry){
-                    label += `, Last retry status: ${_.upperFirst(lastRetry.status)}`
-                }
-
-                return label;
+                return `Total retries: ${job.retried_by.length}, Last retry status: ${_.upperFirst(lastRetry.status)}`;
             },
 
             /**

--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -151,6 +151,19 @@
                 return job.payload.retry_of;
             },
 
+            /**
+             * Construct the tooltip label for the job containing retry count and the last retry status.
+             */
+            jobTooltipLabel(job){
+                let label  = `Total retries: ${job.retried_by.length}`
+                let lastRetry = job.retried_by[job.retried_by.length - 1]
+
+                if(lastRetry){
+                    label += `, Last retry status: ${_.upperFirst(lastRetry.status)}`
+                }
+
+                return label;
+            },
 
             /**
              * Refresh the jobs every period of time.
@@ -240,7 +253,7 @@
                         </router-link>
 
                         <small class="badge badge-secondary badge-sm"
-                               v-tooltip:top="`Total retries: ${job.retried_by.length}`"
+                               v-tooltip:top="jobTooltipLabel(job)"
                                v-if="wasRetried(job)">
                             Retried
                         </small>

--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -152,10 +152,11 @@
             },
 
             /**
-             * Construct the tooltip label for the job containing retry count and the status of the last retry.
+             * Construct the tooltip label for a retried job.
              */
-            jobTooltipLabel(job){
-                let lastRetry = job.retried_by[job.retried_by.length - 1]
+            retriedJobTooltip(job){
+                let lastRetry = job.retried_by[job.retried_by.length - 1];
+
                 return `Total retries: ${job.retried_by.length}, Last retry status: ${_.upperFirst(lastRetry.status)}`;
             },
 
@@ -247,7 +248,7 @@
                         </router-link>
 
                         <small class="badge badge-secondary badge-sm"
-                               v-tooltip:top="jobTooltipLabel(job)"
+                               v-tooltip:top="retriedJobTooltip(job)"
                                v-if="wasRetried(job)">
                             Retried
                         </small>


### PR DESCRIPTION
Hi, 

I hope you are doing well.

At the moment the only way to see if a retried job has been completed is to either:
- Navigate to the job detail view
- By checking if a job with the "retried" label still has the retry spinner button or not (not very obvious or self-evident in my opinion)

I believe adding the last job retry status to the failed job tooltip would add value, since it would show the status explicitly without needing any further page navigation.
