### PR TITLE
Add home page link to the horizon dashboard

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -29,7 +29,7 @@
             </svg>
 
             <h4 class="mb-0 ml-2">
-                <strong>Laravel</strong> Horizon{{ config('app.name') ? ' - ' . config('app.name') : '' }}</h4>
+                <strong>Laravel</strong> Horizon{!! config('app.name') ? ' - ' . ( config('app.url') ? '<a href="' . config('app.url') . '">' . config('app.name') . '</a>' : config('app.name') ) : '' !!}</h4>
 
             <button class="btn btn-outline-primary ml-auto" :class="{active: autoLoadsNewEntries}" v-on:click.prevent="autoLoadNewEntries" title="Auto Load Entries">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon fill-primary">


### PR DESCRIPTION
I've added a homepage link to the horizon dashboard, because after accessing horizon from the website (admin) menu, I think it allows for an easy option to get back to the website (and access the menus again).