### PR TITLE
Add exit codes to status command

### DIFF
--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -25,27 +25,26 @@ class StatusCommand extends Command
      * Execute the console command.
      *
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masterSupervisorRepository
-     * @return void
+     * @return int
      */
     public function handle(MasterSupervisorRepository $masterSupervisorRepository)
     {
-        $this->line($this->currentStatus($masterSupervisorRepository));
-    }
-
-    /**
-     * Get the current status of Horizon.
-     *
-     * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masterSupervisorRepository
-     * @return string
-     */
-    protected function currentStatus(MasterSupervisorRepository $masterSupervisorRepository)
-    {
         if (! $masters = $masterSupervisorRepository->all()) {
-            return 'Horizon is inactive.';
+            $this->error('Horizon is inactive.');
+
+            return 1;
         }
 
-        return collect($masters)->contains(function ($master) {
+        if (collect($masters)->contains(function ($master) {
             return $master->status === 'paused';
-        }) ? 'Horizon is paused.' : 'Horizon is running.';
+        })) {
+            $this->warn('Horizon is paused.');
+
+            return 1;
+        }
+
+        $this->info("Horizon is running.");
+
+        return 0;
     }
 }

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -43,7 +43,7 @@ class StatusCommand extends Command
             return 1;
         }
 
-        $this->info("Horizon is running.");
+        $this->info('Horizon is running.');
 
         return 0;
     }


### PR DESCRIPTION
This PR adds exit codes to the `horizon:status` artisan command.

The use-case for this is to monitor the Horizon status via monitoring tools, which we run on top of the normal supervisor configuration. 

We've noticed in production usage that supervisor didn't restart the Horizon worker in a specific edge-case where Redis crashed. The status command however gave the correct status of `inactive`. We wish to monitor the `horizon:status` output to ensure the queue is always running. 

Our current workaround is checking the output string, but we would prefer to use exit code checking.

I was unsure which exit code to assign to the `paused` status. I've landed on exit code 1. Happy to receive input on that.

This PR also adds colored output to the status:
- `error` for inactive (red) - exit code 1
- `warn` for paused (orange) - exit code 1
- `info` for running (green) - exit code 0