### PR TITLE
Allow deleting of Tags which contain forward slashes (Fixes #1093)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,7 @@ Route::prefix('api')->group(function () {
     Route::get('/monitoring/{tag}', 'MonitoringController@paginate')->name('horizon.monitoring-tag.paginate');
     Route::delete('/monitoring/{tag}', 'MonitoringController@destroy')
         ->name('horizon.monitoring-tag.destroy')
-        ->where('tag', '.*');;
+        ->where('tag', '.*');
 
     // Job Metric Routes...
     Route::get('/metrics/jobs', 'JobMetricsController@index')->name('horizon.jobs-metrics.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,9 @@ Route::prefix('api')->group(function () {
     Route::get('/monitoring', 'MonitoringController@index')->name('horizon.monitoring.index');
     Route::post('/monitoring', 'MonitoringController@store')->name('horizon.monitoring.store');
     Route::get('/monitoring/{tag}', 'MonitoringController@paginate')->name('horizon.monitoring-tag.paginate');
-    Route::delete('/monitoring/{tag}', 'MonitoringController@destroy')->name('horizon.monitoring-tag.destroy');
+    Route::delete('/monitoring/{tag}', 'MonitoringController@destroy')
+        ->name('horizon.monitoring-tag.destroy')
+        ->where('tag', '.*');;
 
     // Job Metric Routes...
     Route::get('/metrics/jobs', 'JobMetricsController@index')->name('horizon.jobs-metrics.index');


### PR DESCRIPTION
This PR fixes #1093.

If a monitored Tag contains a forward slash it could not be deleted. The forward slash mixed up the route parameter.