### PR TITLE
Remove unnecessary data on index view

### DIFF
--- a/src/Http/Controllers/CompletedJobsController.php
+++ b/src/Http/Controllers/CompletedJobsController.php
@@ -38,6 +38,8 @@ class CompletedJobsController extends Controller
         $jobs = $this->jobs->getCompleted($request->query('starting_at', -1))->map(function ($job) {
             $job->payload = json_decode($job->payload);
 
+            unset($job->payload->data);
+
             return $job;
         })->values();
 
@@ -45,18 +47,5 @@ class CompletedJobsController extends Controller
             'jobs' => $jobs,
             'total' => $this->jobs->countCompleted(),
         ];
-    }
-
-    /**
-     * Decode the given job.
-     *
-     * @param  object  $job
-     * @return object
-     */
-    protected function decode($job)
-    {
-        $job->payload = json_decode($job->payload);
-
-        return $job;
     }
 }

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -68,7 +68,13 @@ class FailedJobsController extends Controller
     protected function paginate(Request $request)
     {
         return $this->jobs->getFailed($request->query('starting_at') ?: -1)->map(function ($job) {
-            return $this->decode($job);
+            $job = $this->decode($job);
+
+            unset($job->payload->data);
+            unset($job->exception);
+            unset($job->context);
+
+            return $job;
         });
     }
 
@@ -88,7 +94,13 @@ class FailedJobsController extends Controller
         $startingAt = $request->query('starting_at', 0);
 
         return $this->jobs->getJobs($jobIds, $startingAt)->map(function ($job) {
-            return $this->decode($job);
+            $job = $this->decode($job);
+
+            unset($job->payload->data);
+            unset($job->exception);
+            unset($job->context);
+
+            return $job;
         });
     }
 

--- a/src/Http/Controllers/PendingJobsController.php
+++ b/src/Http/Controllers/PendingJobsController.php
@@ -38,6 +38,8 @@ class PendingJobsController extends Controller
         $jobs = $this->jobs->getPending($request->query('starting_at', -1))->map(function ($job) {
             $job->payload = json_decode($job->payload);
 
+            unset($job->payload->data);
+
             return $job;
         })->values();
 
@@ -45,18 +47,5 @@ class PendingJobsController extends Controller
             'jobs' => $jobs,
             'total' => $this->jobs->countPending(),
         ];
-    }
-
-    /**
-     * Decode the given job.
-     *
-     * @param  object  $job
-     * @return object
-     */
-    protected function decode($job)
-    {
-        $job->payload = json_decode($job->payload);
-
-        return $job;
     }
 }


### PR DESCRIPTION
This PR fixes #1192.

The response grows too large when there are too many jobs and too much data.