### PR TITLE
Add suggestion for laravel-horizon-watcher package from Spatie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     },
     "suggest": {
         "ext-redis": "Required to use the Redis PHP driver.",
-        "predis/predis": "Required when not using the Redis PHP driver (^1.1|^2.0)."
+        "predis/predis": "Required when not using the Redis PHP driver (^1.1|^2.0).",
+        "spatie/laravel-horizon-watcher": "Automatically restarts Horizon when local PHP files change"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds a composer suggestion for the https://github.com/spatie/laravel-horizon-watcher package from Spatie. 

This handy package can watch for local file changes and automatically restart horizon so that the new changes take effect. 