### PR TITLE
Set default value for job `$payload['pushedAt']` when retrying

### DIFF
--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -77,8 +77,10 @@ class RetryFailedJob
     {
         $retryUntil = $payload['retryUntil'] ?? $payload['timeoutAt'] ?? null;
 
+        $pushedAt = $payload['pushedAt'] ?? microtime(true);
+
         return $retryUntil
-                        ? CarbonImmutable::now()->addSeconds(ceil($retryUntil - $payload['pushedAt']))->getTimestamp()
+                        ? CarbonImmutable::now()->addSeconds(ceil($retryUntil - $pushedAt))->getTimestamp()
                         : null;
     }
 }

--- a/tests/Feature/RetryJobTest.php
+++ b/tests/Feature/RetryJobTest.php
@@ -2,8 +2,11 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
+use Exception;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\JobPayload;
 use Laravel\Horizon\Jobs\MonitorTag;
 use Laravel\Horizon\Jobs\RetryFailedJob;
 use Laravel\Horizon\Tests\IntegrationTest;
@@ -78,5 +81,18 @@ class RetryJobTest extends IntegrationTest
 
         // Test status is now failed on the retry...
         $this->assertSame('failed', $retried[0]['status']);
+    }
+
+    public function test_retry_failed_job_with_retry_until_and_without_pushed_at()
+    {
+        $repository = $this->app->make(JobRepository::class);
+
+        $payload = new JobPayload(
+            json_encode(['id' => 1, 'displayName' => 'foo', 'retryUntil' => now()])
+        );
+
+        $repository->failed(new Exception('Failed Job'), 'redis', 'default', $payload);
+        
+        dispatch(new RetryFailedJob($payload->id()));
     }
 }

--- a/tests/Feature/RetryJobTest.php
+++ b/tests/Feature/RetryJobTest.php
@@ -89,20 +89,20 @@ class RetryJobTest extends IntegrationTest
 
         $payload = new JobPayload(
             json_encode([
-                'id' => 1, 
+                'id' => 1,
                 'displayName' => 'foo',
-                'retryUntil' => now()->addMinute()->timestamp
+                'retryUntil' => now()->addMinute()->timestamp,
             ])
         );
 
         $repository->failed(new Exception('Failed Job'), 'redis', 'default', $payload);
-        
+
         dispatch(new RetryFailedJob(1));
         $this->work();
 
         $retried = Redis::connection('horizon')->hget(1, 'retried_by');
         $retried = json_decode($retried, true);
-        
+
         $this->assertSame('pending', $retried[0]['status']);
     }
 }


### PR DESCRIPTION
Closes #1210

This PR implements using the current time as the default `pushedAt` value, in case one is not present in the encoded job payload.

I've added a test to ensure the `Undefined array key` exception is no longer thrown when retrying a job that contains a `retryUntil`, but not a `pushedAt` timestamp in its payload.