### PR TITLE
Ensure Autoscaler never reduces processes to less than 1

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -132,8 +132,7 @@ class AutoScaler
 
         if ($desiredProcessCount > $totalProcessCount) {
             $maxUpShift = min(
-                0,
-                $supervisor->options->maxProcesses - $supervisor->totalProcessCount(),
+                max(0, $supervisor->options->maxProcesses - $supervisor->totalProcessCount()),
                 $supervisor->options->balanceMaxShift
             );
 
@@ -152,6 +151,7 @@ class AutoScaler
 
             $pool->scale(
                 max(
+                    1,
                     $totalProcessCount - $maxDownShift,
                     $supervisor->options->minProcesses,
                     $desiredProcessCount

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -132,6 +132,7 @@ class AutoScaler
 
         if ($desiredProcessCount > $totalProcessCount) {
             $maxUpShift = min(
+                0,
                 $supervisor->options->maxProcesses - $supervisor->totalProcessCount(),
                 $supervisor->options->balanceMaxShift
             );

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -218,4 +218,26 @@ class AutoScalerTest extends IntegrationTest
         $this->assertEquals(100, $supervisor->processPools['first']->totalProcessCount());
         $this->assertEquals(50, $supervisor->processPools['second']->totalProcessCount());
     }
+
+    public function test_scaler_does_not_permit_going_to_zero_processes_despite_exceeding_max_processes()
+    {
+        $external = Mockery::mock(SystemProcessCounter::class);
+        $external->shouldReceive('get')->with('name')->andReturn(5);
+        $this->app->instance(SystemProcessCounter::class, $external);
+
+        [$scaler, $supervisor] = $this->with_scaling_scenario(15, [
+            'first' => ['current' => 16, 'size' => 1, 'runtime' => 1],
+            'second' => ['current' => 1, 'size' => 1, 'runtime' => 1],
+        ], ['minProcesses' => 1]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(15, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(14, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
+    }
 }

--- a/tests/Feature/Fakes/FakePool.php
+++ b/tests/Feature/Fakes/FakePool.php
@@ -15,7 +15,7 @@ class FakePool
 
     public function scale($processCount)
     {
-        $this->processCount = $processCount;
+        $this->processCount = max(0, (int) $processCount);
     }
 
     public function queue()


### PR DESCRIPTION
![CleanShot 2022-11-25 at 22 25 39](https://user-images.githubusercontent.com/2689341/204007025-1b35dcaa-b23c-4264-ab49-8f29ee03fea4.png)

Last week, we started noticing some of our **queues having 0 Processes assigned**, despite this being against how Horizon is designed to work. [Processes must always be positive](https://github.com/laravel/horizon/issues/587), even if you specifically set `minProcesses = 0`. 

After much digging, I eventually went through and added `Log::debug` statements all over the AutoScaler:

```
[2022-11-25 14:40:20]: Horizon maxProcesses: 15  
[2022-11-25 14:40:20]: Horizon processPools: 2  
[2022-11-25 14:40:20]: Horizon minProcesses: 1  
[2022-11-25 14:40:20]: Horizon $totalProcessCount: 1            <---- 
[2022-11-25 14:40:20]: Horizon totalProcessCountMethod: 16  
[2022-11-25 14:40:20]: Horizon $maxUpShift: -1                  <----
[2022-11-25 14:40:20]: Horizon desiredProcessCount: 15  
[2022-11-25 14:40:20]: Horizon pool->scale: 0  
```

Somehow Horizon would spawn 1 more process than was allowed (another issue for another day) and when then subtracting `maxProcesses` with `totalProcessCount()`, we would get -1.

Later down in the code it then picks which value to use for scaling:

```php
min(
    $totalProcessCount + $maxUpShift,
    $supervisor->options->maxProcesses - (($supervisor->processPools->count() - 1) * $supervisor->options->minProcesses),
    $desiredProcessCount
)
```

### Conclusion

As we saw above, `$totalProcessCount = 1` and `$maxUpShift = -1`, which means this will return 0, setting processes to zero!

So when it tries to scale UP, it actually ends up scaling DOWN. Once it then hits 0, it seems to never be able to recover.

## Solution

It is luckily not a difficult problem to solve. Wrapping `max(0, ...)` around the code that calculates `$maxUpShift` will prevent it from ever being negative, thus solving our problem.

I am aware that this technically fixes a problem that you might think is not there (_why is processes greater than maxProcesses?_) and whilst I agree, I also don't see the harm in covering all the bases.

## Similar issue(s)

- https://github.com/laravel/horizon/issues/981

## My abbreviated config for reference
```php
[
    "waits" => [
      "redis:default" => 60,
    ],
    "fast_termination" => false,
    "memory_limit" => 512,
    "defaults" => [
      "app" => [
        "connection" => "redis",
        "queue" => [
          "default",
          "test",
        ],
        "balance" => "auto",
        "maxProcesses" => 1,
        "memory" => 512,
        "tries" => 2,
        "nice" => 5,
        "timeout" => 1800,
      ],
    ],
    "environments" => [
      "production" => [
        "app" => [
          "maxProcesses" => 15,
          "balance" => "auto",
          "tries" => 10,
          "backoff" => [
            60,
            300,
            600,
            900,
          ],
        ],
      ],
    ],
  ]
  ```