### PR TITLE
Add signal option to `horizon:purge` (e.g. `SIGKILL`)

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -18,7 +18,7 @@ class PurgeCommand extends Command
      * @var string
      */
     protected $signature = 'horizon:purge
-                            {--signal=SIGTERM : Signal to send to the rogue processes}';
+                            {--signal=SIGTERM : The signal to send to the rogue processes}';
 
     /**
      * The console command description.
@@ -41,11 +41,6 @@ class PurgeCommand extends Command
      * @var \Laravel\Horizon\ProcessInspector
      */
     private $inspector;
-
-    /**
-     * @var int
-     */
-    private $signal = SIGTERM;
 
     /**
      * Create a new command instance.
@@ -75,13 +70,13 @@ class PurgeCommand extends Command
      */
     public function handle(MasterSupervisorRepository $masters)
     {
-        $this->signal = is_numeric(($signal = $this->option('signal')))
-            ? $signal
-            : constant($signal);
+        $signal = is_numeric($signal = $this->option('signal'))
+                        ? $signal
+                        : constant($signal);
 
         foreach ($masters->names() as $master) {
             if (Str::startsWith($master, MasterSupervisor::basename())) {
-                $this->purge($master);
+                $this->purge($master, $signal);
             }
         }
     }
@@ -90,11 +85,12 @@ class PurgeCommand extends Command
      * Purge any orphan processes.
      *
      * @param  string  $master
+     * @param  int  $signal
      * @return void
      */
-    public function purge($master)
+    public function purge($master, $signal = SIGTERM)
     {
-        $this->recordOrphans($master);
+        $this->recordOrphans($master, $signal);
 
         $expired = $this->processes->orphanedFor(
             $master, $this->supervisors->longestActiveTimeout()
@@ -103,7 +99,7 @@ class PurgeCommand extends Command
         collect($expired)->each(function ($processId) use ($master) {
             $this->comment("Killing Process: {$processId}");
 
-            exec("kill -s {$this->signal} {$processId}");
+            exec("kill -s {$signal} {$processId}");
 
             $this->processes->forgetOrphans($master, [$processId]);
         });
@@ -113,9 +109,10 @@ class PurgeCommand extends Command
      * Record the orphaned Horizon processes.
      *
      * @param  string  $master
+     * @param  int  $signal
      * @return void
      */
-    protected function recordOrphans($master)
+    protected function recordOrphans($master, $signal)
     {
         $this->processes->orphaned(
             $master, $orphans = $this->inspector->orphaned()
@@ -124,7 +121,7 @@ class PurgeCommand extends Command
         foreach ($orphans as $processId) {
             $this->info("Observed Orphan: {$processId}");
 
-            if (! posix_kill($processId, $this->signal)) {
+            if (! posix_kill($processId, $signal)) {
                 $this->error("Failed to kill process for Orphan: {$processId} (".posix_strerror(posix_get_last_error()).')');
             }
         }


### PR DESCRIPTION
In some cases, queue workers may become stuck in a state where they don't respond to the `SIGTERM` signal sent by the `horizon:purge` command. We've had a server where swap and memory was nearly exhausted by rogue orphans.

To make cleaning up easier, I propose adding a `--signal=` option to `horizon:purge`. 

The most obvious use-case is to forcefully kill rogue orphan queue workers:

```
php artisan horizon:purge --signal=SIGKILL
```

The option accepts both numeric (`--signal=9`) and text (`--signal=SIGKILL`) signal identifiers, and defaults to `SIGTERM`, to ensure backwards compatibility.
