### PR TITLE
[5.x] Increase `perPage` variable for monitored tags

### DIFF
--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -13,7 +13,7 @@
                 loadingNewEntries: false,
                 hasNewEntries: false,
                 page: 1,
-                perPage: 3,
+                perPage: 50,
                 totalPages: 1,
                 jobs: []
             };


### PR DESCRIPTION
Currently, all pages show 50 jobs per page. Only the Monitored Tags page is limited to 3 jobs per page. In my opinion, this makes little sense and especially if you want to monitor a lot more jobs, it is very difficult to find the right jobs or to get an overview of the last jobs that have been run.
