### PR TITLE
[5.x] Add silence method override

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -79,6 +79,16 @@ class JobPayload implements ArrayAccess
     }
 
     /**
+     * Determine if the job is silenced.
+     *
+     * @return bool
+     */
+    public function isSilenced()
+    {
+        return $this->decoded['silenced'] ?? false;
+    }
+
+    /**
      * Prepare the payload for storage on the queue by adding tags, etc.
      *
      * @param  mixed  $job
@@ -89,6 +99,7 @@ class JobPayload implements ArrayAccess
         return $this->set([
             'type' => $this->determineType($job),
             'tags' => $this->determineTags($job),
+            'silenced' => $this->determineIfSilenced($job),
             'pushedAt' => str_replace(',', '.', microtime(true)),
         ]);
     }
@@ -127,6 +138,21 @@ class JobPayload implements ArrayAccess
             $this->decoded['tags'] ?? [],
             ! $job || is_string($job) ? [] : Tags::for($job)
         );
+    }
+
+    /**
+     * Determine if the job is silenced using the method override.
+     *
+     * @param mixed $job
+     * @return bool
+     */
+    protected function determineIfSilenced($job)
+    {
+        if (! $job) {
+            return false;
+        }
+
+        return method_exists($job, 'silenced') ? $job->silenced() : false;
     }
 
     /**

--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -143,7 +143,7 @@ class JobPayload implements ArrayAccess
     /**
      * Determine if the job is silenced using the method override.
      *
-     * @param mixed $job
+     * @param  mixed  $job
      * @return bool
      */
     protected function determineIfSilenced($job)

--- a/src/Listeners/MarkJobAsComplete.php
+++ b/src/Listeners/MarkJobAsComplete.php
@@ -45,7 +45,8 @@ class MarkJobAsComplete
     public function handle(JobDeleted $event)
     {
         $isSilenced = in_array($event->payload->commandName(), config('horizon.silenced', [])) ||
-            is_a($event->payload->commandName(), Silenced::class, true);
+            is_a($event->payload->commandName(), Silenced::class, true) ||
+            $event->payload->isSilenced();
 
         $this->jobs->completed($event->payload, $event->job->hasFailed(), $isSilenced);
 

--- a/tests/Feature/Listeners/MarkJobAsCompleteTest.php
+++ b/tests/Feature/Listeners/MarkJobAsCompleteTest.php
@@ -84,7 +84,7 @@ class MarkJobAsCompleteTest extends IntegrationTest
     {
         $this->runScenarioWithMethodOverride(SilencedJobWithMethodFalse::class, false);
     }
-        public function runScenarioWithMethodOverride(string $job, bool $silenced): void
+    public function runScenarioWithMethodOverride(string $job, bool $silenced): void
     {
         $payload = m::mock(JobPayload::class);
         $payload->shouldReceive('commandName')->andReturn($job);

--- a/tests/Feature/Listeners/MarkJobAsCompleteTest.php
+++ b/tests/Feature/Listeners/MarkJobAsCompleteTest.php
@@ -84,6 +84,7 @@ class MarkJobAsCompleteTest extends IntegrationTest
     {
         $this->runScenarioWithMethodOverride(SilencedJobWithMethodFalse::class, false);
     }
+
     public function runScenarioWithMethodOverride(string $job, bool $silenced): void
     {
         $payload = m::mock(JobPayload::class);

--- a/tests/Unit/Fixtures/FakeJobWithSilencedMethod.php
+++ b/tests/Unit/Fixtures/FakeJobWithSilencedMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit\Fixtures;
+
+class FakeJobWithSilencedMethod
+{
+    public function silenced()
+    {
+        return true;
+    }
+}

--- a/tests/Unit/RedisPayloadTest.php
+++ b/tests/Unit/RedisPayloadTest.php
@@ -53,7 +53,7 @@ class RedisPayloadTest extends UnitTest
         $second->id = 2;
 
         $JobPayload->prepare(new FakeJobWithEloquentModel($first, $second));
-        $this->assertEquals([FakeModel::class . ':1', FakeModel::class . ':2'], $JobPayload->decoded['tags']);
+        $this->assertEquals([FakeModel::class.':1', FakeModel::class.':2'], $JobPayload->decoded['tags']);
     }
 
     public function test_tags_are_correctly_gathered_from_collections()
@@ -67,7 +67,7 @@ class RedisPayloadTest extends UnitTest
         $second->id = 2;
 
         $JobPayload->prepare(new FakeJobWithEloquentCollection(new EloquentCollection([$first, $second])));
-        $this->assertEquals([FakeModel::class . ':1', FakeModel::class . ':2'], $JobPayload->decoded['tags']);
+        $this->assertEquals([FakeModel::class.':1', FakeModel::class.':2'], $JobPayload->decoded['tags']);
     }
 
     public function test_tags_are_correctly_extracted_for_internal_special_jobs()
@@ -81,7 +81,7 @@ class RedisPayloadTest extends UnitTest
         $second->id = 2;
 
         $JobPayload->prepare(new FakeJobWithEloquentCollection(new EloquentCollection([$first, $second])));
-        $this->assertEquals([FakeModel::class . ':1', FakeModel::class . ':2'], $JobPayload->decoded['tags']);
+        $this->assertEquals([FakeModel::class.':1', FakeModel::class.':2'], $JobPayload->decoded['tags']);
     }
 
     public function test_tags_are_correctly_extracted_for_listeners()
@@ -105,7 +105,7 @@ class RedisPayloadTest extends UnitTest
 
         $JobPayload->prepare($job);
 
-        $this->assertEquals([FakeModel::class . ':42'], $JobPayload->decoded['tags']);
+        $this->assertEquals([FakeModel::class.':42'], $JobPayload->decoded['tags']);
     }
 
     /**
@@ -119,7 +119,7 @@ class RedisPayloadTest extends UnitTest
 
         $JobPayload->prepare($job);
 
-        $this->assertEquals([FakeModel::class . ':21'], $JobPayload->decoded['tags']);
+        $this->assertEquals([FakeModel::class.':21'], $JobPayload->decoded['tags']);
     }
 
     public function test_listener_and_event_tags_can_merge_auto_tag_events()
@@ -131,7 +131,7 @@ class RedisPayloadTest extends UnitTest
         $JobPayload->prepare($job);
 
         $this->assertEquals([
-            'listenerTag1', 'listenerTag2', FakeModel::class . ':5',
+            'listenerTag1', 'listenerTag2', FakeModel::class.':5',
         ], $JobPayload->decoded['tags']);
     }
 
@@ -143,7 +143,7 @@ class RedisPayloadTest extends UnitTest
 
         $JobPayload->prepare($job);
 
-        $this->assertEquals(['mytag', FakeModel::class . ':42'], $JobPayload->decoded['tags']);
+        $this->assertEquals(['mytag', FakeModel::class.':42'], $JobPayload->decoded['tags']);
     }
 
     public function test_jobs_can_have_tags_method_to_override_auto_tagging()


### PR DESCRIPTION
Hacked a little bit on this to get some feedback on being able to silence a job using a method.

Was mentioned in https://github.com/laravel/horizon/pull/1236

Wasn't sure about the best way to test this but was hoping this was close enough - but I don't have the biggest hope it's correct as Dries said we need to use reflection so maybe I"m missing something by storing the silenced result in the payload.

This PR enabled you to silence a job using a method instead of an interface or the config file;
```php
class SilencedJob implements ShouldQueue
{
    public function silenced()
    {
        return true;
    }
}
```

I wasn't sure if the method name should be `silenced` or `silence` or if the method should override the interface or config. At the moment if **any** of the Interface is there, class is in config or silenced method returns true, then the job will be silenced.

Happy to PR the docs if this is merged.