### PR TITLE
[5.x] Add autoScalingStrategy option

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -104,9 +104,8 @@ class AutoScaler
                 $numberOfProcesses = $supervisor->options->autoScaleByNumberOfJobs()
                     ? ($timeToClear['size'] / $totalJobs)
                     : ($timeToClear['time'] / $timeToClearAll);
-                $numberOfProcesses *= $supervisor->options->maxProcesses;
 
-                return [$queue => $numberOfProcesses];
+                return [$queue => $numberOfProcesses *= $supervisor->options->maxProcesses];
             } elseif ($timeToClearAll == 0 &&
                       $supervisor->options->autoScaling()) {
                 return [

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -96,11 +96,17 @@ class AutoScaler
     protected function numberOfWorkersPerQueue(Supervisor $supervisor, Collection $queues)
     {
         $timeToClearAll = $queues->sum('time');
+        $totalJobs = $queues->sum('size');
 
-        return $queues->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll) {
+        return $queues->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll, $totalJobs) {
             if ($timeToClearAll > 0 &&
                 $supervisor->options->autoScaling()) {
-                return [$queue => (($timeToClear['time'] / $timeToClearAll) * $supervisor->options->maxProcesses)];
+                $numberOfProcesses = $supervisor->options->autoScaleByNumberOfJobs()
+                    ? ($timeToClear['size'] / $totalJobs)
+                    : ($timeToClear['time'] / $timeToClearAll);
+                $numberOfProcesses *= $supervisor->options->maxProcesses;
+
+                return [$queue => $numberOfProcesses];
             } elseif ($timeToClearAll == 0 &&
                       $supervisor->options->autoScaling()) {
                 return [

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -36,7 +36,8 @@ class SupervisorCommand extends Command
                             {--balance-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}
                             {--workers-name=default : The name that should be assigned to the workers}
                             {--parent-id=0 : The parent process ID}
-                            {--rest=0 : Number of seconds to rest between jobs}';
+                            {--rest=0 : Number of seconds to rest between jobs}
+                            {--auto-scaling-strategy=runtime : If supervisor should scale by jobs or time to complete}';
 
     /**
      * The console command description.
@@ -111,12 +112,15 @@ class SupervisorCommand extends Command
                     ? $this->option('backoff')
                     : $this->option('delay');
 
+        $balance = $this->option('balance');
+        $autoScalingStrategy = $balance === 'auto' ? $this->option('auto-scaling-strategy') : null;
+
         return new SupervisorOptions(
             $this->argument('name'),
             $this->argument('connection'),
             $this->getQueue($this->argument('connection')),
             $this->option('workers-name'),
-            $this->option('balance'),
+            $balance,
             $backoff,
             $this->option('max-time'),
             $this->option('max-jobs'),
@@ -131,7 +135,8 @@ class SupervisorCommand extends Command
             $this->option('balance-cooldown'),
             $this->option('balance-max-shift'),
             $this->option('parent-id'),
-            $this->option('rest')
+            $this->option('rest'),
+            $autoScalingStrategy
         );
     }
 

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -32,12 +32,12 @@ class SupervisorCommand extends Command
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--auto-scaling-strategy=time : If supervisor should scale by jobs or time to complete}
                             {--balance-cooldown=3 : The number of seconds to wait in between auto-scaling attempts}
                             {--balance-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}
                             {--workers-name=default : The name that should be assigned to the workers}
                             {--parent-id=0 : The parent process ID}
-                            {--rest=0 : Number of seconds to rest between jobs}
-                            {--auto-scaling-strategy=runtime : If supervisor should scale by jobs or time to complete}';
+                            {--rest=0 : Number of seconds to rest between jobs}';
 
     /**
      * The console command description.
@@ -113,6 +113,7 @@ class SupervisorCommand extends Command
                     : $this->option('delay');
 
         $balance = $this->option('balance');
+
         $autoScalingStrategy = $balance === 'auto' ? $this->option('auto-scaling-strategy') : null;
 
         return new SupervisorOptions(

--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -27,7 +27,7 @@ class QueueCommandString
      */
     public static function toSupervisorOptionsString(SupervisorOptions $options)
     {
-        return sprintf('--workers-name=%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s --balance-cooldown=%s --balance-max-shift=%s --parent-id=%s %s',
+        return sprintf('--workers-name=%s --balance=%s --max-processes=%s --min-processes=%s --nice=%s --balance-cooldown=%s --balance-max-shift=%s --parent-id=%s --auto-scaling-strategy=%s %s',
             $options->workersName,
             $options->balance,
             $options->maxProcesses,
@@ -36,6 +36,7 @@ class QueueCommandString
             $options->balanceCooldown,
             $options->balanceMaxShift,
             $options->parentId,
+            $options->autoScalingStrategy,
             static::toOptionsString($options)
         );
     }

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -152,14 +152,7 @@ class SupervisorOptions
     public $rest;
 
     /**
-     * Indicates if the supervisor should auto-scale.
-     *
-     * @var bool
-     */
-    public $autoScale;
-
-    /**
-     * Indicates auto-scaling strategy should use runtime (time-to-complete) or size (total count of jobs).
+     * Indicates whether auto-scaling strategy should use "time" (time-to-complete) or "size" (total count of jobs) strategies.
      *
      * @var string|null
      */

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -203,7 +203,7 @@ class SupervisorOptions
                                 $balanceMaxShift = 1,
                                 $parentId = 0,
                                 $rest = 0,
-                                $autoScalingStrategy = 'runtime'
+                                $autoScalingStrategy = 'time'
     ) {
         $this->name = $name;
         $this->connection = $connection;

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -159,6 +159,13 @@ class SupervisorOptions
     public $autoScale;
 
     /**
+     * Indicates auto-scaling strategy should use runtime (time-to-complete) or size (total count of jobs).
+     *
+     * @var string|null
+     */
+    public $autoScalingStrategy = null;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -181,6 +188,7 @@ class SupervisorOptions
      * @param  int  $balanceMaxShift
      * @param  int  $parentId
      * @param  int  $rest
+     * @param  string|null  $autoScalingStrategy
      */
     public function __construct($name,
                                 $connection,
@@ -201,7 +209,9 @@ class SupervisorOptions
                                 $balanceCooldown = 3,
                                 $balanceMaxShift = 1,
                                 $parentId = 0,
-                                $rest = 0)
+                                $rest = 0,
+                                $autoScalingStrategy = 'runtime'
+    )
     {
         $this->name = $name;
         $this->connection = $connection;
@@ -223,6 +233,7 @@ class SupervisorOptions
         $this->balanceMaxShift = $balanceMaxShift;
         $this->parentId = $parentId;
         $this->rest = $rest;
+        $this->autoScalingStrategy = $autoScalingStrategy;
     }
 
     /**
@@ -256,6 +267,16 @@ class SupervisorOptions
     public function autoScaling()
     {
         return $this->balance === 'auto';
+    }
+
+    /**
+     * Determine if auto-scaling should be based count of jobs per queue.
+     *
+     * @return bool
+     */
+    public function autoScaleByNumberOfJobs()
+    {
+        return $this->autoScalingStrategy === 'size';
     }
 
     /**
@@ -316,6 +337,7 @@ class SupervisorOptions
             'balanceMaxShift' => $this->balanceMaxShift,
             'parentId' => $this->parentId,
             'rest' => $this->rest,
+            'autoScalingStrategy' => $this->autoScalingStrategy,
         ];
     }
 

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -262,7 +262,7 @@ class SupervisorOptions
     }
 
     /**
-     * Determine if auto-scaling should be based count of jobs per queue.
+     * Determine if auto-scaling should be based on the number of jobs on the queue instead of time-to-clear.
      *
      * @return bool
      */

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -211,8 +211,7 @@ class SupervisorOptions
                                 $parentId = 0,
                                 $rest = 0,
                                 $autoScalingStrategy = 'runtime'
-    )
-    {
+    ) {
         $this->name = $name;
         $this->connection = $connection;
         $this->queue = $queue ?: config('queue.connections.'.$connection.'.queue');

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -40,6 +40,13 @@ class SupervisorOptions
     public $balance = 'off';
 
     /**
+     * Indicates whether auto-scaling strategy should use "time" (time-to-complete) or "size" (total count of jobs) strategies.
+     *
+     * @var string|null
+     */
+    public $autoScalingStrategy = null;
+
+    /**
      * The maximum number of total processes to start when auto-scaling.
      *
      * @var int
@@ -150,13 +157,6 @@ class SupervisorOptions
      * @var int
      */
     public $rest;
-
-    /**
-     * Indicates whether auto-scaling strategy should use "time" (time-to-complete) or "size" (total count of jobs) strategies.
-     *
-     * @var string|null
-     */
-    public $autoScalingStrategy = null;
 
     /**
      * Create a new worker options instance.

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertSame(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --rest=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --auto-scaling-strategy=time --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --rest=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertSame(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --auto-scaling-strategy=time --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --rest=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --auto-scaling-strategy=runtime --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --rest=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/AddSupervisorTest.php
+++ b/tests/Feature/AddSupervisorTest.php
@@ -28,7 +28,7 @@ class AddSupervisorTest extends IntegrationTest
         $this->assertCount(1, $master->supervisors);
 
         $this->assertSame(
-            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --auto-scaling-strategy=runtime --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --rest=0',
+            'exec '.$phpBinary.' artisan horizon:supervisor my-supervisor redis --workers-name=default --balance=off --max-processes=1 --min-processes=1 --nice=0 --balance-cooldown=3 --balance-max-shift=1 --parent-id=0 --auto-scaling-strategy=time --backoff=0 --max-time=0 --max-jobs=0 --memory=128 --queue="default" --sleep=3 --timeout=60 --tries=0 --rest=0',
             $master->supervisors->first()->process->getCommandLine()
         );
     }

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -240,4 +240,22 @@ class AutoScalerTest extends IntegrationTest
         $this->assertSame(14, $supervisor->processPools['first']->totalProcessCount());
         $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
     }
+
+    public function test_scaler_assigns_more_processes_to_queue_with_more_jobs_when_using_size_strategy()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(100, [
+            'first' => ['current' => 50, 'size' => 1000, 'runtime' => 10],
+            'second' => ['current' => 50, 'size' => 500, 'runtime' => 1000],
+        ], ['autoScalingStrategy' => 'size']);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(51, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(49, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(52, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(48, $supervisor->processPools['second']->totalProcessCount());
+    }
 }


### PR DESCRIPTION
This PR adds an option to configure how a supervisor auto-scales queues. It allows for `runtime` or `size`, set on the supervisor level under the `autoScalingBehavior` key.

`runtime` is the current behavior (portion the number of available processes based on time to complete a queue / total time to complete all queues), where as `size` portions processes based on total number of jobs in queue / total number of jobs in all supervised queues.

For some context:

We have a Horizon supervisor set up like this:
```php
'supervisor-medium' => [
    'connection' => 'redis_medium',
    'queue' => [
        'ai',
        'notifications',
        'import',
        'other-queue',
    ],
    'balance' => 'auto',
    'minProcesses' => 1,
    'maxProcesses' => 10,
    'memory' => 64,
    'tries' => 3,
    'timeout' => 300,
],
```

How should the queue supervisor balance when there are 2700 jobs in the `ai` queue and 5000 jobs in the `import` queue?

We are seeing that, though the supervisor spins up more processes, they are all given to the `ai` queue and not allocated to the `import` queue. So, we would see that `ai` queue processes went from 1 to 6 processes, but `import` stayed at 1.

To solve this problem, we extended the AutoScaler class to add this behavior. I thought it might be a nice feature for Horizon to have.

Also, I think it's worth noting in the Horizon docs about the time-to-complete behavior. As they currently read:
>The auto strategy adjusts the number of worker processes per queue based on the current workload of the queue. For example, if your notifications queue has 1,000 pending jobs while your render queue is empty, Horizon will allocate more workers to your notifications queue until the queue is empty.

I think this is easy to misunderstand as it reads like it's balanced on job count, not time to complete. It required digging into the AutoScaler code to understand the behavior we were seeing.

Additionally, I think it might be nice to:
1. allow for configuring a custom strategy per supervisor, and/or
2. make the process allocation based on a combination of size + runtime

For the second point, I couldn't think of a good way to do that. I was thinking maybe that jobs should be a factor in the calculation, weighted lower than the time to complete. But I didn't spend much time trying things out.