### PR TITLE
[5.x] Add cancelled status to batch overview

### DIFF
--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -171,14 +171,17 @@
                         </router-link>
                     </td>
                     <td>
-                        <small class="badge badge-danger badge-sm" v-if="batch.failedJobs > 0 && batch.totalJobs - batch.pendingJobs < batch.totalJobs">
+                        <small class="badge bg-danger badge-sm" v-if="!batch.cancelledAt && batch.failedJobs > 0 && batch.totalJobs - batch.pendingJobs < batch.totalJobs">
                             Failures
                         </small>
-                        <small class="badge badge-success badge-sm" v-if="batch.totalJobs - batch.pendingJobs == batch.totalJobs">
+                        <small class="badge bg-success badge-sm" v-if="!batch.cancelledAt && batch.totalJobs - batch.pendingJobs == batch.totalJobs">
                             Finished
                         </small>
-                        <small class="badge badge-secondary badge-sm" v-if="batch.pendingJobs > 0 && !batch.failedJobs">
+                        <small class="badge bg-secondary badge-sm" v-if="!batch.cancelledAt && batch.pendingJobs > 0 && !batch.failedJobs">
                             Pending
+                        </small>
+                        <small class="badge bg-info badge-sm" v-if="batch.cancelledAt">
+                            Cancelled
                         </small>
                     </td>
                     <td class="text-right text-muted">{{batch.totalJobs}}</td>

--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -180,7 +180,7 @@
                         <small class="badge badge-secondary badge-sm" v-if="!batch.cancelledAt && batch.pendingJobs > 0 && !batch.failedJobs">
                             Pending
                         </small>
-                        <small class="badge badge-info badge-sm" v-if="batch.cancelledAt">
+                        <small class="badge badge-warning badge-sm" v-if="batch.cancelledAt">
                             Cancelled
                         </small>
                     </td>

--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -171,16 +171,16 @@
                         </router-link>
                     </td>
                     <td>
-                        <small class="badge bg-danger badge-sm" v-if="!batch.cancelledAt && batch.failedJobs > 0 && batch.totalJobs - batch.pendingJobs < batch.totalJobs">
+                        <small class="badge badge-danger badge-sm" v-if="!batch.cancelledAt && batch.failedJobs > 0 && batch.totalJobs - batch.pendingJobs < batch.totalJobs">
                             Failures
                         </small>
-                        <small class="badge bg-success badge-sm" v-if="!batch.cancelledAt && batch.totalJobs - batch.pendingJobs == batch.totalJobs">
+                        <small class="badge badge-success badge-sm" v-if="!batch.cancelledAt && batch.totalJobs - batch.pendingJobs == batch.totalJobs">
                             Finished
                         </small>
-                        <small class="badge bg-secondary badge-sm" v-if="!batch.cancelledAt && batch.pendingJobs > 0 && !batch.failedJobs">
+                        <small class="badge badge-secondary badge-sm" v-if="!batch.cancelledAt && batch.pendingJobs > 0 && !batch.failedJobs">
                             Pending
                         </small>
-                        <small class="badge bg-info badge-sm" v-if="batch.cancelledAt">
+                        <small class="badge badge-info badge-sm" v-if="batch.cancelledAt">
                             Cancelled
                         </small>
                     </td>


### PR DESCRIPTION
Currently it's not visible if a batch is cancelled and instead it still shows `Pending` even when the batch is cancelled and not running anymore.

I found this quite confusing when cancelling batches for a specific use case where only one batch may run at once and the previous needs to be cancelled when there is already one pending.

So this adds the functionality to show the status of cancelled batches:

<img width="1194" alt="CleanShot 2023-03-06 at 16 28 55@2x" src="https://user-images.githubusercontent.com/1925388/223155038-85341215-1621-4fe2-a6b4-b85940ad4c22.png">