### PR TITLE
[5.x] add staging environment in config

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -204,6 +204,12 @@ return [
             ],
         ],
 
+        'staging' => [
+            'supervisor-1' => [
+                'maxProcesses' => 3,
+            ],
+        ],
+
         'local' => [
             'supervisor-1' => [
                 'maxProcesses' => 3,


### PR DESCRIPTION
Hi,

I believe all of us has a `staging` environment.

If someone forgets to add the environment in `config/horizon.php`, their Horizon dashboard will show status as "Inactive".

There is no easy way to us to know what is wrong, specially for a beginner.