### PR TITLE
Fix deprecation errors for PHP 8.2

### DIFF
--- a/src/Contracts/MetricsRepository.php
+++ b/src/Contracts/MetricsRepository.php
@@ -82,7 +82,7 @@ interface MetricsRepository
      * Increment the metrics information for a job.
      *
      * @param  string  $job
-     * @param  float  $runtime
+     * @param  float|null  $runtime
      * @return void
      */
     public function incrementJob($job, $runtime);
@@ -91,7 +91,7 @@ interface MetricsRepository
      * Increment the metrics information for a queue.
      *
      * @param  string  $queue
-     * @param  float  $runtime
+     * @param  float|null  $runtime
      * @return void
      */
     public function incrementQueue($queue, $runtime);

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -177,13 +177,13 @@ class RedisMetricsRepository implements MetricsRepository
      * Increment the metrics information for a job.
      *
      * @param  string  $job
-     * @param  float  $runtime
+     * @param  float|null  $runtime
      * @return void
      */
     public function incrementJob($job, $runtime)
     {
         $this->connection()->eval(LuaScripts::updateMetrics(), 2,
-            'job:'.$job, 'measured_jobs', str_replace(',', '.', $runtime)
+            'job:'.$job, 'measured_jobs', str_replace(',', '.', (string) $runtime)
         );
     }
 
@@ -191,13 +191,13 @@ class RedisMetricsRepository implements MetricsRepository
      * Increment the metrics information for a queue.
      *
      * @param  string  $queue
-     * @param  float  $runtime
+     * @param  float|null  $runtime
      * @return void
      */
     public function incrementQueue($queue, $runtime)
     {
         $this->connection()->eval(LuaScripts::updateMetrics(), 2,
-            'queue:'.$queue, 'measured_queues', str_replace(',', '.', $runtime)
+            'queue:'.$queue, 'measured_queues', str_replace(',', '.', (string) $runtime)
         );
     }
 


### PR DESCRIPTION
Horizon is throwing some deprecation errors for PHP 8.2 as a null value is being passed to `str_replace` 

This PR fixes this issue and corrects the docblocks for allowing a null value to be passed in as the time.

```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php on line 201
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php on line 187
```