### PR TITLE
Add `Horizon@usingConnection()`

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -107,7 +107,6 @@ class Horizon
         static::setHorizonConfig($config, $prefix);
     }
 
-
     /**
      * @param  array  $config
      * @param  string|null  $prefix
@@ -134,6 +133,7 @@ class Horizon
 
         try {
             static::use($connection, $prefix);
+
             return $callback();
         } finally {
             static::setHorizonConfig($initialConfig, $initialConfig['options']['prefix'] ?? null);

--- a/tests/Feature/UsingConnectionTest.php
+++ b/tests/Feature/UsingConnectionTest.php
@@ -17,7 +17,7 @@ class UsingConnectionTest extends IntegrationTest
 
         config(['database.redis.test' => $secondConfig]);
 
-        Horizon::usingConnection('test', function() {
+        Horizon::usingConnection('test', function () {
             $this->assertSame('100', config('database.redis.horizon.database'));
             $this->assertSame('custom:', config('database.redis.horizon.options.prefix'));
         }, 'custom:');
@@ -36,7 +36,7 @@ class UsingConnectionTest extends IntegrationTest
                 $this->assertSame('custom:', config('database.redis.horizon.options.prefix'));
             });
         } catch (Throwable $exception) {
-            $this->assertEquals("Redis connection [test] has not been configured.", $exception->getMessage());
+            $this->assertEquals('Redis connection [test] has not been configured.', $exception->getMessage());
         }
 
         $this->assertEqualsCanonicalizing($initialConfig, config('database.redis.horizon'));


### PR DESCRIPTION
Working on a total rewrite for our platform, we will have a beta platform sharing the infrastructure with our production app.

There will be jobs that exist only in the old app and jobs that exist only in the new app.  We can push manually to the queue, but then we lose Horizon statistics.

I thought it would be nice to be able to dispatch a job to the old version like this:

```php
Horizon::usingConnection('production', fn() => ComputeUserStatistics::dispatch());
```

Otherwise it's a lot of manual juggling of static values.