### PR TITLE
Add event for when supervisor process died

### DIFF
--- a/src/Events/SupervisorProcessDied.php
+++ b/src/Events/SupervisorProcessDied.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Horizon\Events;
+
+use Laravel\Horizon\SupervisorProcess;
+
+class SupervisorProcessDied
+{
+    /**
+     * The supervisor process.
+     *
+     * @var \Laravel\Horizon\SupervisorProcess
+     */
+    public $supervisorProcess;
+
+    /**
+     * The code with which the process exited.
+     *
+     * @var int|null
+     */
+    public $exitCode;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Laravel\Horizon\SupervisorProcess  $supervisorProcess
+     * @param  int|null  $exitCode
+     * @return void
+     */
+    public function __construct(SupervisorProcess $supervisorProcess, ?int $exitCode)
+    {
+        $this->supervisorProcess = $supervisorProcess;
+        $this->exitCode = $exitCode;
+    }
+}

--- a/src/Events/SupervisorProcessDied.php
+++ b/src/Events/SupervisorProcessDied.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Laravel\Horizon\Events;
 
 use Laravel\Horizon\SupervisorProcess;


### PR DESCRIPTION
Following #1282, we are still figuring out why our supervisors are disappearing. As they are not terminated but die, this PR adds events so third-party code can process these occurrences.