### PR TITLE
[5.x] Fix supervisor reprovisioning

### DIFF
--- a/src/SupervisorProcess.php
+++ b/src/SupervisorProcess.php
@@ -114,7 +114,6 @@ class SupervisorProcess extends WorkerProcess
     protected function reprovision()
     {
         if (isset($this->name)) {
-            // When restarting, the Supervisor checks if it is already running based on this key
             app(SupervisorRepository::class)->forget($this->name);
         }
 

--- a/src/SupervisorProcess.php
+++ b/src/SupervisorProcess.php
@@ -4,6 +4,7 @@ namespace Laravel\Horizon;
 
 use Closure;
 use Laravel\Horizon\Contracts\HorizonCommandQueue;
+use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\MasterSupervisorCommands\AddSupervisor;
 use Laravel\Horizon\SupervisorCommands\Terminate;
 
@@ -112,6 +113,11 @@ class SupervisorProcess extends WorkerProcess
      */
     protected function reprovision()
     {
+        if (isset($this->name)) {
+            // When restarting, the Supervisor checks if it is already running based on this key
+            app(SupervisorRepository::class)->forget($this->name);
+        }
+
         app(HorizonCommandQueue::class)->push(
             MasterSupervisor::commandQueue(),
             AddSupervisor::class,


### PR DESCRIPTION
When a supervisor gets killed and the status code is not [0, 2 or 13](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/SupervisorProcess.php#L38), the supervisor tries to restart by calling the [reprovision](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/SupervisorProcess.php#L113) method. That restarting always fails, because the [reprovision](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/SupervisorProcess.php#L113) method puts the [AddSupervisor](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/MasterSupervisorCommands/AddSupervisor.php#L10) on the queue, which results in the [SupervisorCommand](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/Console/SupervisorCommand.php#L62) being executed. One of the first things that are done there is to check if there are already supervisors running with the same name by calling the [ensureNoDuplicateSupervisors](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/Supervisor.php#L271) method, which [checks if a supervisor with that name already exists](https://github.com/laravel/horizon/blob/363386c197fb1dec876d7427a844274264f416eb/src/Supervisor.php#L271).

At the point of restarting, that key will already exist, so reprovisioning doesn't work with the current code.

Why we were running into this issue specifically: We are running horizon on multiple k8s pods. We noticed a bunch of pods with only a few of the supervisors running after a certain amount of time. With the help of #1284 we found that we got a bunch of SuperVisorDiedEvents with exit code 137 (Indicating the pod memory limit was reached), immediately followed by the same event with exit code 13(Indicating that a supervisor with the same name already exists). 

We have been running this fixed code in production, and the second event with status code 13 is now not triggered anymore in this scenario, and our supervisors gracefully restart after exiting with code 137.

This PR makes sure that the key is removed before attempting to restart the supervisor.

Also fixes the underlying issue in #1273 