### PR TITLE
Check that minProcesses times the nr of queues is less than maxProcesses

### DIFF
--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -182,6 +182,10 @@ class ProvisioningPlan
             throw new Exception("The value of [{$supervisor}.minProcesses] must be greater than 0.");
         }
 
+        if (isset($options['minProcesses']) && $options['minProcesses'] * count(explode(',', $options['queue'] ?? '')) > ($options['maxProcesses'] ?? 1)) {
+            throw new Exception("The value of minProcesses per queue times the number of queues should be less than or equal to maxProcesses per supervisor [{$supervisor}].");
+        }
+
         $options['parentId'] = getmypid();
 
         return SupervisorOptions::fromArray(


### PR DESCRIPTION
When changing the number for minProcesses, maxProcesses or the amount of queues for a supervisor, there might be 0 processes assigned for all queues within a supervisor. This happens when minProcesses * count(queues) is more than maxProcesses:
```php
'environments' => [
    'production' => [
        'supervisor-1' => [
            'minProcesses' => 2,
            'maxProcesses' => 5,
            'queues' => ['queue-1', 'queue-2', 'queue-3']
        ]
    ]
],
```

This PR adds an exception to prevent this from silently happening.

If maxProcesses is less than the number of queues, the maxProcesses is ignored and a process is added for each queue silently. This will still work after this change, but might be unexpected as well.