### PR TITLE
Fix autoscaler scaling down below zero when (nr. of queues * minProcesses) is higher than maxProcesses

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -144,7 +144,7 @@ class AutoScaler
             $pool->scale(
                 min(
                     $totalProcessCount + $maxUpShift,
-                    $supervisor->options->maxProcesses - (($supervisor->processPools->count() - 1) * $supervisor->options->minProcesses),
+                    max($supervisor->options->minProcesses, $supervisor->options->maxProcesses - (($supervisor->processPools->count() - 1) * $supervisor->options->minProcesses)),
                     $desiredProcessCount
                 )
             );


### PR DESCRIPTION
Example reproduction:
```php
'environments' => [
    'production' => [
        'queue' => ['default', 'low-prio', 'high-prio'],
        'minProcesses' => 2,
        'maxProcesses' => 5,
    ]
]
```
Will result in all queues being scaled down to 0. After this fix, they will be scaled to 1 instead as 2 is not possible for all queues.

Alternative fix is #1289, but that will throw an exception on invalid configuration, which is breaking.