### PR TITLE
Fix: Make sure that missing supervisors are correctly displayed when using multiple environments

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -36,6 +36,7 @@ class HorizonCommand extends Command
         }
 
         $environment = $this->option('environment') ?? config('horizon.env') ?? config('app.env');
+
         $master = (new MasterSupervisor($environment))->handleOutputUsing(function ($type, $line) {
             $this->output->write($line);
         });

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -35,13 +35,12 @@ class HorizonCommand extends Command
             return $this->comment('A master supervisor is already running on this machine.');
         }
 
-        $master = (new MasterSupervisor)->handleOutputUsing(function ($type, $line) {
+        $environment = $this->option('environment') ?? config('horizon.env') ?? config('app.env');
+        $master = (new MasterSupervisor($environment))->handleOutputUsing(function ($type, $line) {
             $this->output->write($line);
         });
 
-        ProvisioningPlan::get(MasterSupervisor::name())->deploy(
-            $this->option('environment') ?? config('horizon.env') ?? config('app.env')
-        );
+        ProvisioningPlan::get(MasterSupervisor::name())->deploy($environment);
 
         $this->info('Horizon started successfully.');
 

--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -25,7 +25,7 @@ class MasterSupervisorController extends Controller
         return $masters->each(function ($master, $name) use ($supervisors) {
             $master->supervisors = ($supervisors->get($name) ?? collect())
                 ->merge(
-                    collect(ProvisioningPlan::get($name)->plan[config('horizon.env') ?? config('app.env')] ?? [])
+                    collect(ProvisioningPlan::get($name)->plan[$master->environment ?? config('horizon.env') ?? config('app.env')] ?? [])
                         ->map(function ($value, $key) use ($name) {
                             return (object) [
                                 'name' => $name.':'.$key,

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -22,6 +22,13 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     use ListensForSignals;
 
     /**
+     * The environment that was used to provision this master supervisor.
+     *
+     * @var string|null
+     */
+    public $environment;
+
+    /**
      * The name of the master supervisor.
      *
      * @var string
@@ -57,22 +64,17 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     public static $nameResolver;
 
     /**
-     * The environment that is used to provision this master supervisor.
-     *
-     * @var string|null
-     */
-    public $environment;
-
-    /**
      * Create a new master supervisor instance.
      *
+     * @param  string  $environment
      * @return void
      */
     public function __construct(string $environment = null)
     {
+        $this->environment = $environment;
+
         $this->name = static::name();
         $this->supervisors = collect();
-        $this->environment = $environment;
 
         $this->output = function () {
             //

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -57,14 +57,22 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     public static $nameResolver;
 
     /**
+     * The environment that is used to provision this master supervisor.
+     *
+     * @var string|null
+     */
+    public $environment;
+
+    /**
      * Create a new master supervisor instance.
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(string $environment = null)
     {
         $this->name = static::name();
         $this->supervisors = collect();
+        $this->environment = $environment;
 
         $this->output = function () {
             //

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -72,7 +72,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
     {
         $records = $this->connection()->pipeline(function ($pipe) use ($names) {
             foreach ($names as $name) {
-                $pipe->hmget('master:'.$name, ['name', 'pid', 'status', 'supervisors']);
+                $pipe->hmget('master:'.$name, ['name', 'environment', 'pid', 'status', 'supervisors']);
             }
         });
 
@@ -81,9 +81,10 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
 
             return ! $record[0] ? null : (object) [
                 'name' => $record[0],
-                'pid' => $record[1],
-                'status' => $record[2],
-                'supervisors' => json_decode($record[3], true),
+                'environment' => $record[1],
+                'pid' => $record[2],
+                'status' => $record[3],
+                'supervisors' => json_decode($record[4], true),
             ];
         })->filter()->all();
     }
@@ -102,6 +103,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
             $pipe->hmset(
                 'master:'.$master->name, [
                     'name' => $master->name,
+                    'environment' => $master->environment,
                     'pid' => $master->pid(),
                     'status' => $master->working ? 'running' : 'paused',
                     'supervisors' => json_encode($supervisors),


### PR DESCRIPTION
When displaying active/inactive supervisors for a master supervisor that is started with a different environment, the provisioning in the overview is done with the configuration of the environment the horizon endpoint runs on, causing a potential mismatch when using different environments. This PR passes the environment to the master and uses that variable to display a correct overview. (See discussion in PR #1286 for a reproduction)