### PR TITLE
Handle non-array parameters for "queue" setting in supervisor config

### DIFF
--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -33,7 +33,7 @@ class MasterSupervisorController extends Controller
                                 'status' => 'inactive',
                                 'processes' => [],
                                 'options' => [
-                                    'queue' => implode(',', $value['queue'] ?? []),
+                                    'queue' => array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : $value['queue'] ?? '',
                                     'balance' => $value['balance'] ?? null,
                                 ],
                             ];


### PR DESCRIPTION
When working with supervisors that only handle one queue, it is apparently possible to supply a single string instead of an array of strings (#1298):
```diff
'environments' => [
    'production' => [
        'supervisor-1' => [
-            'queue' => [
-                'default',
-                'high-prio'
-            ]
+            'queue' => 'default'
        ],
    ],
],
```
I can't find in the documentation if this was ever mentioned as a feature, but apparently this broke with the introduction of displaying crashed supervisors.

Fixes #1298 
