### PR TITLE
Added silenced expiration

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -102,6 +102,7 @@ return [
         'recent' => 60,
         'pending' => 60,
         'completed' => 60,
+        'silenced' => 60,
         'recent_failed' => 10080,
         'failed' => 10080,
         'monitored' => 10080,


### PR DESCRIPTION
This feature allows users to configure an expiration time for silenced jobs. This allows having different expiration times between completed and silenced jobs.

If silenced expiration is not present, it uses the completed expiration time by default.
