### PR TITLE
[4.X] fix: correct deprecated fn: lte, gte, addSecond

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -99,6 +99,6 @@ class MonitorWaitTimes
      */
     protected function timeToMonitor()
     {
-        return Chronos::now()->subMinutes(1)->lte($this->lastMonitored);
+        return Chronos::now()->subMinutes(1)->lessthanOrEquals($this->lastMonitored);
     }
 }

--- a/src/Listeners/TrimFailedJobs.php
+++ b/src/Listeners/TrimFailedJobs.php
@@ -30,15 +30,17 @@ class TrimFailedJobs
      */
     public function handle(MasterSupervisorLooped $event)
     {
-        if (! isset($this->lastTrimmed)) {
+        if (!isset($this->lastTrimmed)) {
             $this->frequency = max(1, intdiv(
-                config('horizon.trim.failed', 10080), 12
-            ));
+                config('horizon.trim.failed', 10080),
+                12
+            )
+            );
 
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lessthanOrEquals(Chronos::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimFailedJobs();
 
             $this->lastTrimmed = Chronos::now();

--- a/src/Listeners/TrimMonitoredJobs.php
+++ b/src/Listeners/TrimMonitoredJobs.php
@@ -30,15 +30,17 @@ class TrimMonitoredJobs
      */
     public function handle(MasterSupervisorLooped $event)
     {
-        if (! isset($this->lastTrimmed)) {
+        if (!isset($this->lastTrimmed)) {
             $this->frequency = max(1, intdiv(
-                config('horizon.trim.monitored', 10080), 12
-            ));
+                config('horizon.trim.monitored', 10080),
+                12
+            )
+            );
 
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lessthanOrEquals(Chronos::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimMonitoredJobs();
 
             $this->lastTrimmed = Chronos::now();

--- a/src/Listeners/TrimRecentJobs.php
+++ b/src/Listeners/TrimRecentJobs.php
@@ -30,11 +30,11 @@ class TrimRecentJobs
      */
     public function handle(MasterSupervisorLooped $event)
     {
-        if (! isset($this->lastTrimmed)) {
+        if (!isset($this->lastTrimmed)) {
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lessthanOrEquals(Chronos::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimRecentJobs();
 
             $this->lastTrimmed = Chronos::now();

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -179,7 +179,7 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
         // process does not get stuck in an infinite loop here waiting for these.
         while (count($this->supervisors->filter->isRunning())) {
             if (Chronos::now()->subSeconds($longest)
-                        ->gte($startedTerminating)) {
+                        ->greaterThanOrEquals($startedTerminating)) {
                 break;
             }
 

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -110,7 +110,9 @@ class ProcessPool implements Countable
         // and remove them from the active process array. We'll be adding them the array
         // of terminating processes where they'll run until they are fully terminated.
         $terminatingProcesses = array_slice(
-            $this->processes, 0, $difference
+            $this->processes,
+            0,
+            $difference
         );
 
         collect($terminatingProcesses)->each(function ($process) {
@@ -123,9 +125,9 @@ class ProcessPool implements Countable
         // terminated so they can start terminating. Terminating is a graceful operation
         // so any jobs they are already running will finish running before these quit.
         collect($this->terminatingProcesses)
-                        ->each(function ($process) {
-                            $process['process']->terminate();
-                        });
+            ->each(function ($process) {
+                $process['process']->terminate();
+            });
     }
 
     /**
@@ -137,7 +139,8 @@ class ProcessPool implements Countable
     public function markForTermination(WorkerProcess $process)
     {
         $this->terminatingProcesses[] = [
-            'process' => $process, 'terminatedAt' => Chronos::now(),
+            'process' => $process,
+            'terminatedAt' => Chronos::now(),
         ];
     }
 
@@ -176,8 +179,8 @@ class ProcessPool implements Countable
     protected function createProcess()
     {
         $class = config('horizon.fast_termination')
-                    ? BackgroundProcess::class
-                    : Process::class;
+            ? BackgroundProcess::class
+            : Process::class;
 
         return new WorkerProcess($class::fromShellCommandline(
             $this->options->toWorkerCommand(), $this->options->directory
@@ -270,7 +273,7 @@ class ProcessPool implements Countable
         foreach ($this->terminatingProcesses as $process) {
             $timeout = $this->options->timeout;
 
-            if ($process['terminatedAt']->addSeconds($timeout)->lte(Chronos::now())) {
+            if ($process['terminatedAt']->addSeconds($timeout)->lessthanOrEquals(Chronos::now())) {
                 $process['process']->stop();
             }
         }

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -334,7 +334,7 @@ class Supervisor implements Pausable, Restartable, Terminable
         $this->lastAutoScaled = $this->lastAutoScaled ?:
                     Chronos::now()->subSeconds($this->autoScaleCooldown + 1);
 
-        if (Chronos::now()->subSeconds($this->autoScaleCooldown)->gte($this->lastAutoScaled)) {
+        if (Chronos::now()->subSeconds($this->autoScaleCooldown)->greaterThanOrEquals($this->lastAutoScaled)) {
             $this->lastAutoScaled = Chronos::now();
 
             app(AutoScaler::class)->scale($this);

--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -166,7 +166,7 @@ class WorkerProcess
                 event(new UnableToLaunchProcess($this));
             }
         } else {
-            $this->restartAgainAt = Chronos::now()->addSecond();
+            $this->restartAgainAt = Chronos::now()->addSeconds(1);
         }
     }
 


### PR DESCRIPTION
lte deprecated:

 local.ERROR: 2.5 lte() is deprecated. Use lessthanOrEquals() instead. {"exception":"[object] (ErrorException(code: 0): 2.5 lte() is deprecated. Use lessthanOrEquals() instead. at /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php:199)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(16384, '2.5 lte() is de...', '/Users/maomao/r...', 199, Array)
#1 /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php(199): trigger_error('2.5 lte() is de...', 16384)
#2 /Users/maomao/reservation-api/vendor/laravel/horizon/src/Listeners/TrimFailedJobs.php(41): Cake\\Chronos\\Chronos->lte(Object(Cake\\Chronos\\Chronos))


gte deprecated:

local.ERROR: 2.5 gte() is deprecated. Use greaterThanOrEquals() instead. {"exception":"[object] (ErrorException(code: 0): 2.5 gte() is deprecated. Use greaterThanOrEquals() instead. at /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php:149)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(16384, '2.5 gte() is de...', '/Users/maomao/r...', 149, Array)
#1 /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php(149): trigger_error('2.5 gte() is de...', 16384)
#2 /Users/maomao/reservation-api/vendor/laravel/horizon/src/MasterSupervisor.php(182): Cake\\Chronos\\Chronos->gte(Object(Cake\\Chronos\\Chronos))
