### PR TITLE
fix: replace lte,gte,addSecond deprecated function

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -99,6 +99,6 @@ class MonitorWaitTimes
      */
     protected function timeToMonitor()
     {
-        return Chronos::now()->subMinutes(1)->lte($this->lastMonitored);
+        return Chronos::now()->subMinutes(1)->lessthanOrEquals($this->lastMonitored);
     }
 }

--- a/src/Listeners/TrimFailedJobs.php
+++ b/src/Listeners/TrimFailedJobs.php
@@ -38,7 +38,7 @@ class TrimFailedJobs
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lessthanOrEquals(Chronos::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimFailedJobs();
 
             $this->lastTrimmed = Chronos::now();

--- a/src/Listeners/TrimMonitoredJobs.php
+++ b/src/Listeners/TrimMonitoredJobs.php
@@ -38,7 +38,7 @@ class TrimMonitoredJobs
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lessthanOrEquals(Chronos::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimMonitoredJobs();
 
             $this->lastTrimmed = Chronos::now();

--- a/src/Listeners/TrimRecentJobs.php
+++ b/src/Listeners/TrimRecentJobs.php
@@ -34,7 +34,7 @@ class TrimRecentJobs
             $this->lastTrimmed = Chronos::now()->subMinutes($this->frequency + 1);
         }
 
-        if ($this->lastTrimmed->lte(Chronos::now()->subMinutes($this->frequency))) {
+        if ($this->lastTrimmed->lessthanOrEquals(Chronos::now()->subMinutes($this->frequency))) {
             app(JobRepository::class)->trimRecentJobs();
 
             $this->lastTrimmed = Chronos::now();

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -179,7 +179,7 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
         // process does not get stuck in an infinite loop here waiting for these.
         while (count($this->supervisors->filter->isRunning())) {
             if (Chronos::now()->subSeconds($longest)
-                        ->gte($startedTerminating)) {
+                        ->greaterThanOrEquals($startedTerminating)) {
                 break;
             }
 

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -270,7 +270,7 @@ class ProcessPool implements Countable
         foreach ($this->terminatingProcesses as $process) {
             $timeout = $this->options->timeout;
 
-            if ($process['terminatedAt']->addSeconds($timeout)->lte(Chronos::now())) {
+            if ($process['terminatedAt']->addSeconds($timeout)->lessthanOrEquals(Chronos::now())) {
                 $process['process']->stop();
             }
         }

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -334,7 +334,7 @@ class Supervisor implements Pausable, Restartable, Terminable
         $this->lastAutoScaled = $this->lastAutoScaled ?:
                     Chronos::now()->subSeconds($this->autoScaleCooldown + 1);
 
-        if (Chronos::now()->subSeconds($this->autoScaleCooldown)->gte($this->lastAutoScaled)) {
+        if (Chronos::now()->subSeconds($this->autoScaleCooldown)->greaterThanOrEquals($this->lastAutoScaled)) {
             $this->lastAutoScaled = Chronos::now();
 
             app(AutoScaler::class)->scale($this);

--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -166,7 +166,7 @@ class WorkerProcess
                 event(new UnableToLaunchProcess($this));
             }
         } else {
-            $this->restartAgainAt = Chronos::now()->addSecond();
+            $this->restartAgainAt = Chronos::now()->addSeconds(1);
         }
     }
 


### PR DESCRIPTION
# Error when running horizon:

lte deprecated:

 local.ERROR: 2.5 lte() is deprecated. Use lessthanOrEquals() instead. {"exception":"[object] (ErrorException(code: 0): 2.5 lte() is deprecated. Use lessthanOrEquals() instead. at /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php:199)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(16384, '2.5 lte() is de...', '/Users/maomao/r...', 199, Array)
#1 /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php(199): trigger_error('2.5 lte() is de...', 16384)
#2 /Users/maomao/reservation-api/vendor/laravel/horizon/src/Listeners/TrimFailedJobs.php(41): Cake\\Chronos\\Chronos->lte(Object(Cake\\Chronos\\Chronos))


gte deprecated:

local.ERROR: 2.5 gte() is deprecated. Use greaterThanOrEquals() instead. {"exception":"[object] (ErrorException(code: 0): 2.5 gte() is deprecated. Use greaterThanOrEquals() instead. at /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php:149)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError(16384, '2.5 gte() is de...', '/Users/maomao/r...', 149, Array)
#1 /Users/maomao/reservation-api/vendor/cakephp/chronos/src/Traits/ComparisonTrait.php(149): trigger_error('2.5 gte() is de...', 16384)
#2 /Users/maomao/reservation-api/vendor/laravel/horizon/src/MasterSupervisor.php(182): Cake\\Chronos\\Chronos->gte(Object(Cake\\Chronos\\Chronos))
