### PR TITLE
Set 0 as the default runtime of the job

### DIFF
--- a/src/Listeners/UpdateJobMetrics.php
+++ b/src/Listeners/UpdateJobMetrics.php
@@ -47,7 +47,7 @@ class UpdateJobMetrics
             return;
         }
 
-        $time = $this->watch->check($id = $event->payload->id());
+        $time = $this->watch->check($id = $event->payload->id()) ?: 0;
 
         $this->metrics->incrementQueue(
             $event->job->getQueue(), $time


### PR DESCRIPTION
Sometimes `Stopwatch::check` returns `null`, so when trying to update job metrics the LuaScript failed with this error

`ERR user_script:11: attempt to perform arithmetic on a nil value script: 0ac1d0b183ba9e097017cf4800a6a65400ae3539, on @user_script:11.`

the exception happened when trying to parse `runtime` (the value was `null` or blank) to number `tonumber(ARGV[1])`

In this PR, I set zero to be the default runtime