### PR TITLE
Trim monitored tag sorted sets, not `monitored_jobs`

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -417,8 +417,6 @@ class RedisJobRepository implements JobRepository
     public function remember($connection, $queue, JobPayload $payload)
     {
         $this->connection()->pipeline(function ($pipe) use ($connection, $queue, $payload) {
-            $this->storeJobReference($pipe, 'monitored_jobs', $payload);
-
             $pipe->hmset(
                 $payload->id(), [
                     'id' => $payload->id(),
@@ -604,10 +602,6 @@ class RedisJobRepository implements JobRepository
             ->each(fn ($tag) => $this->connection()->zremrangebyscore(
                 $tag, '-inf', CarbonImmutable::now()->subMinutes($this->monitoredJobExpires)->getTimestamp()
             ));
-
-        $this->connection()->zremrangebyscore(
-            'monitored_jobs', CarbonImmutable::now()->subMinutes($this->monitoredJobExpires)->getTimestamp() * -1, '+inf'
-        );
     }
 
     /**

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -599,9 +599,11 @@ class RedisJobRepository implements JobRepository
     public function trimMonitoredJobs()
     {
         collect(app(TagRepository::class)->monitoring())
-            ->each(fn ($tag) => $this->connection()->zremrangebyscore(
-                $tag, '-inf', CarbonImmutable::now()->subMinutes($this->monitoredJobExpires)->getTimestamp()
-            ));
+            ->each(function ($tag) {
+                $this->connection()->zremrangebyscore(
+                    $tag, '-inf', CarbonImmutable::now()->subMinutes($this->monitoredJobExpires)->getTimestamp()
+                );
+            });
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR addresses [issue 1314](https://github.com/laravel/horizon/issues/1314): for each monitored tag, the redis sorted set containing the timestamp and job ID would grow without trimming. `monitored_jobs` was trimmed, but seems unused so I removed it to avoid confusion.