### PR TITLE
Add `horizon:reset-metrics` command

### DIFF
--- a/src/Console/ResetMetricsCommand.php
+++ b/src/Console/ResetMetricsCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Laravel\Horizon\Contracts\MetricsRepository;
+
+class ResetMetricsCommand extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:reset-metrics';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete metrics for all jobs and queues';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
+     * @return void
+     */
+    public function handle(MetricsRepository $metrics)
+    {
+        $metrics->reset();
+
+        $this->info('Metrics reset successfully.');
+    }
+}

--- a/src/Contracts/MetricsRepository.php
+++ b/src/Contracts/MetricsRepository.php
@@ -120,6 +120,13 @@ interface MetricsRepository
     public function snapshot();
 
     /**
+     * Reset all stored metrics information.
+     *
+     * @return void
+     */
+    public function reset();
+
+    /**
      * Attempt to acquire a lock to monitor the queue wait times.
      *
      * @return bool

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -120,6 +120,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\PauseSupervisorCommand::class,
                 Console\PublishCommand::class,
                 Console\PurgeCommand::class,
+                Console\ResetMetricsCommand::class,
                 Console\StatusCommand::class,
                 Console\SupervisorCommand::class,
                 Console\SupervisorsCommand::class,

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -362,8 +362,9 @@ class RedisMetricsRepository implements MetricsRepository
         $this->forget('measured_jobs');
         $this->forget('measured_queues');
         $this->forget('last_snapshot_at');
+        $this->forget('metrics:snapshot');
 
-        foreach(['queue:*', 'job:*', 'snapshot:*', 'metrics:*'] as $pattern) {
+        foreach(['queue:*', 'job:*', 'snapshot:*'] as $pattern) {
             $cursor = null;
             do {
                 [$cursor, $keys] = $this->connection()->scan(


### PR DESCRIPTION
# Problem

If a Job is renamed or moved, it will persist in Horizon under Metrics and never be removed. This ends up cluttering the Metrics with obsolete jobs. The problem is described in https://github.com/laravel/horizon/issues/1152

![CleanShot 2023-09-15 at 00 40 06@2x](https://github.com/laravel/horizon/assets/3209864/5ef10b5d-bed0-4578-9987-024a82c2670e)

# Solution

The simplest solution IMO is to just add a command to reset the metrics for Horizon entirely. I've given this command the signature `horizon:reset-metrics`.

It will remove all metric data in Horizon's Redis database, including:

- List of jobs and queues that have metrics: `measured_jobs` / `measured_queues`
- Current metrics (average runtime & throughput) for those jobs and queues: `job:*` / `queue:*`
- Snapshots of metrics: `snapshot:*`
- Timestamp of the last snapshot: `last_snapshot_at`
- Snapshot lock key: `metrics:snapshot`

I believe I have covered everything relating to metrics without touching anything else. 

Additionally, because I have to search Redis by wildcard to find some of the metrics data, I used SCAN instead of KEYS which is what Redis recommends to prevent locking issues: 

> Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout. Don't use KEYS in your regular application code. If you're looking for a way to find keys in a subset of your keyspace, consider using [SCAN](https://redis.io/commands/scan)...

> https://redis.io/commands/keys/

# After Running Command

![CleanShot 2023-09-15 at 01 01 09@2x](https://github.com/laravel/horizon/assets/3209864/b75c4669-8772-488f-b2ec-898c309a9c2e)

<img width="815" alt="CleanShot 2023-09-15 at 01 02 39@2x" src="https://github.com/laravel/horizon/assets/3209864/e073ff9c-0d42-411f-8e5e-d982ea4244e1">

<img width="786" alt="CleanShot 2023-09-15 at 01 02 42@2x" src="https://github.com/laravel/horizon/assets/3209864/f9d516c5-686c-475d-a042-87fe61018b87">