### PR TITLE
remove use of deprecated methods

### DIFF
--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -159,14 +159,14 @@ class WorkerProcess
 
         if ($this->restartAgainAt) {
             $this->restartAgainAt = ! $this->process->isRunning()
-                            ? Chronos::now()->addMinute()
+                            ? Chronos::now()->addMinutes()
                             : null;
 
             if (! $this->process->isRunning()) {
                 event(new UnableToLaunchProcess($this));
             }
         } else {
-            $this->restartAgainAt = Chronos::now()->addSecond();
+            $this->restartAgainAt = Chronos::now()->addSeconds();
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
On September 8, 2023, version 2.4.0 of cakephp/chronos was released. Due to this release, several methods have been deprecated. In Laravel horizon 4.x, it specifies chronos = ^2.0, which has led to exceptions being thrown in parts where the deprecated methods are used. This PR modifies the code to avoid using the deprecated methods from chronos.