### PR TITLE
Add environment option to horizon:status command to allow for liveness check on individual environment

### DIFF
--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -12,7 +12,7 @@ class StatusCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:status';
+    protected $signature = 'horizon:status {--environment= : The environment name}';
 
     /**
      * The console command description.
@@ -29,13 +29,20 @@ class StatusCommand extends Command
      */
     public function handle(MasterSupervisorRepository $masterSupervisorRepository)
     {
-        if (! $masters = $masterSupervisorRepository->all()) {
+        $masters = collect($masterSupervisorRepository->all());
+        if ($environment = $this->option('environment')) {
+            $masters->filter(function ($supervisor) use ($environment) {
+                return $supervisor->environment === $environment;
+            });
+        }
+
+        if ($masters->isEmpty()) {
             $this->error('Horizon is inactive.');
 
             return 1;
         }
 
-        if (collect($masters)->contains(function ($master) {
+        if ($masters->contains(function ($master) {
             return $master->status === 'paused';
         })) {
             $this->warn('Horizon is paused.');


### PR DESCRIPTION
When working with multiple environments<sup><a href="https://github.com/laravel/horizon/pull/1294#issuecomment-1634274948">1</a></sup><sup><a href="https://github.com/laravel/horizon/pull/1286">2</a></sup> the 'horizon:status' command only tells you _if a master supervisor is running_, but not _if a master supervisor is running **for a specific environment**_.

So when running the command
```
php artisan horizon
```

We can check if that command was successful and is running by executing:
```
php artisan horizon:status
```

Things become murky when we run the following commands:
```
php artisan horizon --environment=foo
php artisan horizon --environment=bar
```

When we now run the ```php artisan horizon:status``` command we know that horizon is running, but not if horizon is running for both environments. After this PR gets merged, the following now all become valid commands:
```
php artisan horizon:status // Works as usual and is BC
php artisan horizon:status --environment=foo
php artisan horizon:status --environment=bar
```