### PR TITLE
feat: Adding Horizon Flush Command to delete all keys on horizon conn

### DIFF
--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -3,10 +3,12 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 
 class FlushCommand extends Command
 {
+    use ConfirmableTrait;
     /**
      * The name and signature of the console command.
      *
@@ -29,9 +31,10 @@ class FlushCommand extends Command
    */
     public function handle(RedisFactory $redis)
     {
-      if(app()->environment('local')) {
+        if (! $this->confirmToProceed()) {
+          return;
+        }
         $redis->connection('horizon')->client()->flushAll();
         $this->info('All queue jobs flushed successfully.');
-      }
     }
 }

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -20,13 +20,13 @@ class FlushCommand extends Command
      * @var string
      */
     protected $description = "Truncate all horizon-related information from Redis";
-
-    /**
-     * Execute the console command.
-     *
-     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
-     * @return void
-     */
+  
+  /**
+   * Execute the console command.
+   * @param RedisFactory $redis
+   * @return void
+   * @throws \RedisException
+   */
     public function handle(RedisFactory $redis)
     {
       if(app()->environment('local')) {

--- a/src/Console/FlushCommand.php
+++ b/src/Console/FlushCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+
+class FlushCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:flush';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Truncate all horizon-related information from Redis";
+  
+  /**
+   * Execute the console command.
+   * @param RedisFactory $redis
+   * @return void
+   * @throws \RedisException
+   */
+    public function handle(RedisFactory $redis)
+    {
+      if(app()->environment('local')) {
+        $redis->connection('horizon')->client()->flushAll();
+        $this->info('All queue jobs flushed successfully.');
+      }
+    }
+}


### PR DESCRIPTION
This feature is useful in local environments to truncate all horizon-related information from Redis, It includes confirmation when running the command in production.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
