### PR TITLE
Fix the job repository class based on service bindings

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -6,8 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Arr;
+use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\RedisQueue;
-use Laravel\Horizon\Repositories\RedisJobRepository;
 
 class ClearCommand extends Command
 {
@@ -34,7 +34,7 @@ class ClearCommand extends Command
      *
      * @return int|null
      */
-    public function handle(RedisJobRepository $jobRepository, QueueManager $manager)
+    public function handle(JobRepository $jobRepository, QueueManager $manager)
     {
         if (! $this->confirmToProceed()) {
             return 1;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Basically when extending the `RedisJobRepository.php` it doesn't work properly when calling `horizon:clear`
I've noticed that we're not using the one inside the `ServiceBindings.php`, the code currently calling the original `RedisJobRepository`

PS: In our project, I was able to make the redis-cluster worked, the only remaining issue is this horizon:clear

Extended the class
![image](https://github.com/laravel/horizon/assets/4581415/27f1647d-9d7b-4dac-87af-a53db3d2a54e)

Our redis-cluster production
![image](https://github.com/laravel/horizon/assets/4581415/e5d9098f-61b5-4a2a-8beb-ddc1eaae4830)

