### PR TITLE
Fix the job repository class based on service bindings

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -47,13 +47,11 @@ class ClearCommand extends Command
             return 1;
         }
 
-        if (! method_exists($jobRepository, 'purge')) {
-            $jobRepository = app(RedisJobRepository::class);
-        }
-
         $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
 
-        $jobRepository->purge($queue = $this->getQueue($connection));
+        if (method_exists($jobRepository, 'purge')) {
+            $jobRepository->purge($queue = $this->getQueue($connection));
+        }
 
         $count = $manager->connection($connection)->clear($queue);
 

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Arr;
+use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\RedisQueue;
 use Laravel\Horizon\Repositories\RedisJobRepository;
 
@@ -34,7 +35,7 @@ class ClearCommand extends Command
      *
      * @return int|null
      */
-    public function handle(RedisJobRepository $jobRepository, QueueManager $manager)
+    public function handle(JobRepository $jobRepository, QueueManager $manager)
     {
         if (! $this->confirmToProceed()) {
             return 1;
@@ -44,6 +45,10 @@ class ClearCommand extends Command
             $this->line('<error>Clearing queues is not supported on this version of Laravel</error>');
 
             return 1;
+        }
+
+        if (! method_exists($jobRepository, 'purge')) {
+            $jobRepository = app(RedisJobRepository::class);
         }
 
         $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Related to #1333 and #1334

Added way to check if purge method exists, or else resolve the original `RedisJobRepository`