### PR TITLE
Ensure out of memory events are raised before exiting the process

### DIFF
--- a/src/Listeners/MonitorMasterSupervisorMemory.php
+++ b/src/Listeners/MonitorMasterSupervisorMemory.php
@@ -18,9 +18,9 @@ class MonitorMasterSupervisorMemory
         $master = $event->master;
 
         if ($master->memoryUsage() > config('horizon.memory_limit', 64)) {
-            $master->terminate(12);
-
             event(new MasterSupervisorOutOfMemory($master));
+
+            $master->terminate(12);
         }
     }
 }

--- a/src/Listeners/MonitorSupervisorMemory.php
+++ b/src/Listeners/MonitorSupervisorMemory.php
@@ -18,9 +18,9 @@ class MonitorSupervisorMemory
         $supervisor = $event->supervisor;
 
         if ($supervisor->memoryUsage() > $supervisor->options->memory) {
-            $supervisor->terminate(12);
-
             event(new SupervisorOutOfMemory($supervisor));
+
+            $supervisor->terminate(12);
         }
     }
 }


### PR DESCRIPTION
### Problem

I want to introduce extra logging into our application to log when a supervisor (or master) runs out of memory. I was struggling to get these events to fire despite lowering the memory limits to very small amounts.

From my testing it turns out that the `$master->terminate(12);` call will eventually call `exitProcess` on the `Supervisor` which calls to the system `exit` function. This means that the PHP process ends immediately and the line which raises the event is never hit.

![image](https://github.com/laravel/horizon/assets/797280/f06452cc-26a0-4711-9998-059996fcc0e4)

_Terminate calls exit_

![image](https://github.com/laravel/horizon/assets/797280/8b841fa9-4474-43b9-86de-bd834653918a)

_exit in turn calls exitProcess_

### Solution

The solution seems to be simply raising the event before terminating the process.

### Other issues

It is also worth raising that the `$supervisor` instance isn't serialisable as it holds a reference to a `Process` instance. This meant that my first attempt to handle these events on a queue failed.