### PR TITLE
Only creates a reference if minutesForType > 0

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -675,7 +675,9 @@ class RedisJobRepository implements JobRepository
      */
     protected function storeJobReference($pipe, $key, JobPayload $payload)
     {
-        $pipe->zadd($key, str_replace(',', '.', microtime(true) * -1), $payload->id());
+        if ($this->minutesForType($key) > 0) {
+            $pipe->zadd($key, str_replace(',', '.', microtime(true) * -1), $payload->id());
+        }
     }
 
     /**


### PR DESCRIPTION
This avoids consuming too much memory with references.

Conversation here: https://github.com/laravel/horizon/issues/1348