### PR TITLE
Delete completed jobs if expires equal to zero

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -415,6 +415,11 @@ class RedisJobRepository implements JobRepository
      */
     public function remember($connection, $queue, JobPayload $payload)
     {
+        if ($this->monitoredJobExpires === 0) {
+            $this->connection()->del($payload->id());
+            return;
+        }
+
         $this->connection()->pipeline(function ($pipe) use ($connection, $queue, $payload) {
             $this->storeJobReference($pipe, 'monitored_jobs', $payload);
 
@@ -471,6 +476,11 @@ class RedisJobRepository implements JobRepository
     {
         if ($payload->isRetry()) {
             $this->updateRetryInformationOnParent($payload, $failed);
+        }
+
+        if ($this->completedJobExpires === 0) {
+            $this->connection()->del($payload->id());
+            return;
         }
 
         $this->connection()->pipeline(function ($pipe) use ($payload, $silenced) {
@@ -636,6 +646,11 @@ class RedisJobRepository implements JobRepository
      */
     public function failed($exception, $connection, $queue, JobPayload $payload)
     {
+        if ($this->failedJobExpires === 0) {
+            $this->connection()->del($payload->id());
+            return;
+        }
+        
         $this->connection()->pipeline(function ($pipe) use ($exception, $connection, $queue, $payload) {
             $this->storeJobReference($pipe, 'failed_jobs', $payload);
             $this->storeJobReference($pipe, 'recent_failed_jobs', $payload);

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -417,6 +417,7 @@ class RedisJobRepository implements JobRepository
     {
         if ($this->monitoredJobExpires === 0) {
             $this->connection()->del($payload->id());
+
             return;
         }
 
@@ -480,6 +481,7 @@ class RedisJobRepository implements JobRepository
 
         if ($this->completedJobExpires === 0) {
             $this->connection()->del($payload->id());
+
             return;
         }
 
@@ -648,6 +650,7 @@ class RedisJobRepository implements JobRepository
     {
         if ($this->failedJobExpires === 0) {
             $this->connection()->del($payload->id());
+
             return;
         }
 

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -650,7 +650,7 @@ class RedisJobRepository implements JobRepository
             $this->connection()->del($payload->id());
             return;
         }
-        
+
         $this->connection()->pipeline(function ($pipe) use ($exception, $connection, $queue, $payload) {
             $this->storeJobReference($pipe, 'failed_jobs', $payload);
             $this->storeJobReference($pipe, 'recent_failed_jobs', $payload);


### PR DESCRIPTION
Immediately removes the job if the expiration time is equal to zero, thus optimizing memory usage.

Context: https://github.com/laravel/horizon/issues/1348