### PR TITLE
fix: undefined array key 'queue'

### DIFF
--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -33,7 +33,7 @@ class MasterSupervisorController extends Controller
                                 'status' => 'inactive',
                                 'processes' => [],
                                 'options' => [
-                                    'queue' => array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : $value['queue'] ?? '',
+                                    'queue' => array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : ($value['queue'] ?? ''),
                                     'balance' => $value['balance'] ?? null,
                                 ],
                             ];

--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -33,7 +33,7 @@ class MasterSupervisorController extends Controller
                                 'status' => 'inactive',
                                 'processes' => [],
                                 'options' => [
-                                    'queue' => (array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : $value['queue']) ?? '',
+                                    'queue' => array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : $value['queue'] ?? '',
                                     'balance' => $value['balance'] ?? null,
                                 ],
                             ];


### PR DESCRIPTION
I had some crashes in `MasterSupervisorController`.
In fact, it seems like in the case where `$value` is an array that has no `queue` key, it's failing because we are still trying to access this key.
I think the parenthesis were probably added by mistake, as coalescing ( ?? ) operator cannot be applied "directly" on `$value['queue']`.

For reproducing matter, I don't really know how to reproduce it, it seems like it sometimes enters in this code, but not always. And in fact we are not running any queued job in the route where it fails, maybe some redis usage around session or cache, but no custom application queued jobs that could trigger horizon, so it is quite mysterious for me.

<img width="818" alt="Capture d’écran 2023-11-23 à 16 39 17" src="https://github.com/laravel/horizon/assets/114939186/cd3df36d-2c7e-4bc0-bf6f-87a5351602f1">

