### PR TITLE
[5.x] Pass event instance to event listeners tag() method

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -137,7 +137,7 @@ class JobPayload implements ArrayAccess
     {
         return array_merge(
             $this->decoded['tags'] ?? [],
-            ! $job || is_string($job) ? [] : Tags::for($job)
+            ! $job || is_string($job) ? [] : Tags::for($job, true)
         );
     }
 

--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -137,7 +137,7 @@ class JobPayload implements ArrayAccess
     {
         return array_merge(
             $this->decoded['tags'] ?? [],
-            ! $job || is_string($job) ? [] : Tags::for($job, true)
+            ! $job || is_string($job) ? [] : Tags::for($job)
         );
     }
 

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -15,7 +15,7 @@ use stdClass;
 class Tags
 {
     /**
-     * The event that is currently being handled.
+     * The event that was last handled.
      *
      * @var object|null
      */
@@ -68,7 +68,7 @@ class Tags
         )->map(function ($job) {
             return static::for($job);
         })->collapse()->unique()->tap(function () {
-            static::resetEvent();
+            static::flushEventState();
         })->toArray();
     }
 
@@ -188,11 +188,11 @@ class Tags
     }
 
     /**
-     * Reset the event currently being handled.
+     * Flush the event currently being handled.
      *
      * @return void
      */
-    protected static function resetEvent()
+    protected static function flushEventState()
     {
         static::$event = null;
     }

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -25,10 +25,9 @@ class Tags
      * Determine the tags for the given job.
      *
      * @param  mixed  $job
-     * @param  bool   $clearEvent
      * @return array
      */
-    public static function for($job, $clearEvent = false)
+    public static function for($job)
     {
         if ($tags = static::extractExplicitTags($job)) {
             return $tags;
@@ -66,7 +65,7 @@ class Tags
 
         return collect(
             [static::extractListener($job), $event]
-        )->map(function ($job) use ($event) {
+        )->map(function ($job) {
             return static::for($job);
         })->collapse()->unique()->tap(function () {
             static::resetEvent();

--- a/tests/Feature/Fixtures/FakeListenerWithDynamicTags.php
+++ b/tests/Feature/Fixtures/FakeListenerWithDynamicTags.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Fixtures;
+
+class FakeListenerWithDynamicTags
+{
+    public function tags(FakeEvent $event)
+    {
+        return [
+            'listenerTag1',
+            get_class($event),
+        ];
+    }
+}

--- a/tests/Feature/RedisPayloadTest.php
+++ b/tests/Feature/RedisPayloadTest.php
@@ -17,6 +17,7 @@ use Laravel\Horizon\Tests\Feature\Fixtures\FakeJobWithEloquentModel;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeJobWithTagsMethod;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListener;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListenerSilenced;
+use Laravel\Horizon\Tests\Feature\Fixtures\FakeListenerWithDynamicTags;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListenerWithProperties;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListenerWithTypedProperties;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeModel;
@@ -97,6 +98,19 @@ class RedisPayloadTest extends IntegrationTest
 
         $this->assertEquals([
             'listenerTag1', 'listenerTag2', 'eventTag1', 'eventTag2',
+        ], $JobPayload->decoded['tags']);
+    }
+
+    public function test_tags_are_correctly_extracted_for_listeners_with_dynamic_event_information()
+    {
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $job = new CallQueuedListener(FakeListenerWithDynamicTags::class, 'handle', [new FakeEvent()]);
+
+        $JobPayload->prepare($job);
+
+        $this->assertEquals([
+            'listenerTag1', FakeEvent::class, 'eventTag1', 'eventTag2',
         ], $JobPayload->decoded['tags']);
     }
 


### PR DESCRIPTION
A common problem I have is that it's hard to deal with tags on queued event listeners.
On a regular job, you have the payload available on the constructor, so you can use that as usual, e.g:

```php
public function tags()
{
    return ['user_id' => $this->userId];
}
```  

On an event listener, the event instance is passed to the `handle` method, so when Horizon calls `->tags()`, we can't access any context.
This PR aims to improve that by storing the event that's being handled when building tags, and passing that event instance to the tags method, so we can do something like this:

```php
<?php

class MyEventListener implements ShouldQueue
{
  public function handle(MyEvent $event)
  {}
  
  public function tags(MyEvent $event)
  {
    return [
      'context_id' => $event->uniqueId(),
    ];
  }
}
```