### PR TITLE
Add cache check before registering routes

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -50,6 +51,10 @@ class HorizonServiceProvider extends ServiceProvider
      */
     protected function registerRoutes()
     {
+        if ($this->app instanceof CachesRoutes && $this->app->routesAreCached()) {
+            return;
+        }
+
         Route::group([
             'domain' => config('horizon.domain', null),
             'prefix' => config('horizon.path'),


### PR DESCRIPTION
If routes are already cached, it is not necessary to re-register Horizon routes on every request.

I've found that many Laravel packages don't check for already cached routes and will needlessly re-register routes that already exist in the cache anyway.  This reduces boot times in production by ~0.5 ms which adds up when applied to multiple other first-party Laravel packages. 

I can open PRs in other projects if this is approved.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
