### PR TITLE
Add exit code to horizon:forget command

### DIFF
--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -24,7 +24,7 @@ class ForgetFailedCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int|null
      */
     public function handle(JobRepository $repository)
     {
@@ -34,6 +34,8 @@ class ForgetFailedCommand extends Command
             $this->info('Failed job deleted successfully!');
         } else {
             $this->error('No failed job matches the given ID.');
+
+            return 1;
         }
     }
 }


### PR DESCRIPTION
When `$this->error()` is called it makes sense to return exit code 1 to show that the command did not complete successfully. The exit code is easier to detect programmatically in comparison to looking for `$this->error()` output.