### PR TITLE
make the expiration time for temporarily failed jobs configurable

### DIFF
--- a/src/Listeners/StoreTagsForFailedJob.php
+++ b/src/Listeners/StoreTagsForFailedJob.php
@@ -38,7 +38,7 @@ class StoreTagsForFailedJob
         })->all();
 
         $this->tags->addTemporary(
-            2880, $event->payload->id(), $tags
+            config('horizon.trim.failed', 2880), $event->payload->id(), $tags
         );
     }
 }

--- a/tests/Feature/Listeners/StoreTagsForFailedTest.php
+++ b/tests/Feature/Listeners/StoreTagsForFailedTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Listeners;
+
+use Exception;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Jobs\Job;
+use Laravel\Horizon\Contracts\TagRepository;
+use Laravel\Horizon\Events\JobFailed;
+use Laravel\Horizon\Tests\IntegrationTest;
+use Mockery as m;
+
+class StoreTagsForFailedTest extends IntegrationTest
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function test_temporary_failed_job_should_be_deleted_when_the_main_job_is_deleted(): void
+    {
+        config()->set('horizon.trim.failed', 120);
+
+        $tagRepository = m::mock(TagRepository::class);
+
+        $tagRepository->shouldReceive('addTemporary')->once()->with(120, '1', ['failed:foobar'])->andReturn([]);
+
+        $this->instance(TagRepository::class, $tagRepository);
+
+        $this->app->make(Dispatcher::class)->dispatch(new JobFailed(
+            new Exception('job failed'), new FailedJob(), '{"id":"1","displayName":"displayName","tags":["foobar"]}'
+        ));
+    }
+}
+
+class FailedJob extends Job
+{
+    public function getJobId()
+    {
+        return '1';
+    }
+
+    public function getRawBody()
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
In order to be able to search for failed jobs by their tags, we need to make the time of saving those keys based on the trim time that the user has configured.