### PR TITLE
Ignore IDE local workspace folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /phpunit.xml
 composer.lock
 .phpunit.result.cache
+/.idea
+/.fleet
+/.vscode


### PR DESCRIPTION
To work more efficiently on the project and contribute effectively, I believe it's a good idea to add local IDE workspace folders to the .gitignore file.