### PR TITLE
Add redis.replicate_commands() to make purging of queue work

### DIFF
--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -48,6 +48,8 @@ LUA;
     public static function purge()
     {
         return <<<'LUA'
+
+            redis.replicate_commands()
             
             local count = 0
             local cursor = 0


### PR DESCRIPTION
It is impossible to clear a queue using the `horizon:clear` artisan command. This is also seeen in issue #1068 
The following exception is then thrown:

```
ERR Error running script (call to f_281c23c60c642d42fdedcc1acc8adc7317dd75a5): @user_script:18: @user_script: 18: Write commands not allowed after non deterministic commands. Call redis.replicate_commands() at the start of your script in order to switch to single commands replication mode.
```

This resolves the issue by adding the `redis.replicate_commands()` call in the Lua script.