### PR TITLE
Use class binding in HorizonCommand

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -31,17 +31,17 @@ class HorizonCommand extends Command
      */
     public function handle(MasterSupervisorRepository $masters)
     {
-        if ($masters->find(MasterSupervisor::name())) {
+        if ($masters->find(app(MasterSupervisor::class)::name())) {
             return $this->components->warn('A master supervisor is already running on this machine.');
         }
 
         $environment = $this->option('environment') ?? config('horizon.env') ?? config('app.env');
 
-        $master = (new MasterSupervisor($environment))->handleOutputUsing(function ($type, $line) {
+        $master = app()->make(MasterSupervisor::class, ['environment' => $environment])->handleOutputUsing(function ($type, $line) {
             $this->output->write($line);
         });
 
-        ProvisioningPlan::get(MasterSupervisor::name())->deploy($environment);
+        ProvisioningPlan::get(app(MasterSupervisor::class)::name())->deploy($environment);
 
         $this->components->info('Horizon started successfully.');
 


### PR DESCRIPTION
This pull request modify the horizon command to permit class binding to the MasterSupervisor.

Reason: Modifying Laravel\Horizon\MasterSupervisor require changes to the HorizonCommand which will cause unnecessary issues when upgrading