### PR TITLE
Output console error when terminating due to memory usage

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -38,11 +38,7 @@ class HorizonCommand extends Command
         $environment = $this->option('environment') ?? config('horizon.env') ?? config('app.env');
 
         $master = (new MasterSupervisor($environment))->handleOutputUsing(function ($type, $line) {
-            if ($type === 'error') {
-                $this->components->error($line);
-            } else {
-                $this->output->write($line);
-            }
+            $this->output->write($line);
         });
 
         ProvisioningPlan::get(MasterSupervisor::name())->deploy($environment);

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -38,7 +38,11 @@ class HorizonCommand extends Command
         $environment = $this->option('environment') ?? config('horizon.env') ?? config('app.env');
 
         $master = (new MasterSupervisor($environment))->handleOutputUsing(function ($type, $line) {
-            $this->output->write($line);
+            if ($type === 'error') {
+                $this->components->error($line);
+            } else {
+                $this->output->write($line);
+            }
         });
 
         ProvisioningPlan::get(MasterSupervisor::name())->deploy($environment);

--- a/src/Listeners/MonitorMasterSupervisorMemory.php
+++ b/src/Listeners/MonitorMasterSupervisorMemory.php
@@ -17,8 +17,12 @@ class MonitorMasterSupervisorMemory
     {
         $master = $event->master;
 
-        if ($master->memoryUsage() > config('horizon.memory_limit', 64)) {
+        $memoryLimit = config('horizon.memory_limit', 64);
+
+        if ($master->memoryUsage() > $memoryLimit) {
             event(new MasterSupervisorOutOfMemory($master));
+
+            $master->output('error', 'Memory limit exceeded: Using '.ceil($master->memoryUsage()).'/'.$memoryLimit.'MB. Consider increasing horizon.memory_limit.');
 
             $master->terminate(12);
         }

--- a/tests/Feature/MonitorMasterSupervisorMemoryTest.php
+++ b/tests/Feature/MonitorMasterSupervisorMemoryTest.php
@@ -17,6 +17,7 @@ class MonitorMasterSupervisorMemoryTest extends IntegrationTest
         $master = Mockery::mock(MasterSupervisor::class);
 
         $master->shouldReceive('memoryUsage')->andReturn(192);
+        $master->shouldReceive('output')->once()->with('error', 'Memory limit exceeded: Using 192/64MB. Consider increasing horizon.memory_limit.');
         $master->shouldReceive('terminate')->once()->with(12);
 
         $monitor->handle(new MasterSupervisorLooped($master));


### PR DESCRIPTION
In #463 the memory limit was made configurable, however, when the memory limit is set too low (e.g. in my case more memory was being used than the default 64MB), Horizon will just fail silently.

For months Horizon was "broken" in one of my projects and I couldn't figure out why. No console output, no log output. The same is the case for #375.

This PR adds clear console output when `php artisan horizon` terminates due to using more memory than configured (or the default 64MB)

Before this PR:
![image](https://github.com/laravel/horizon/assets/9074391/ee6a1de1-e5c6-4387-85f2-fe2868e4a461)


After this PR: 
![image](https://github.com/laravel/horizon/assets/9074391/679082cd-3cd2-492c-bb27-a19ee251d5ae)


I first just added the output without the change in `src/Console/HorizonCommand.php`, that is still an option.
The output is then:

![image](https://github.com/laravel/horizon/assets/9074391/297e38ad-69e2-47f0-9c2b-0ae7f2bc8058)
