### PR TITLE
Add job retry panel to under job information

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -176,36 +176,6 @@
             </div>
         </div>
 
-        <div class="card overflow-hidden mt-4" v-if="ready">
-            <div class="card-header d-flex align-items-center justify-content-between">
-                <h2 class="h6 m-0">Exception</h2>
-            </div>
-            <div>
-                <stack-trace :trace="job.exception.split('\n')"></stack-trace>
-            </div>
-        </div>
-
-        <div class="card overflow-hidden mt-4" v-if="ready">
-            <div class="card-header d-flex align-items-center justify-content-between">
-                <h2 class="h6 m-0">Exception Context</h2>
-            </div>
-
-            <div class="card-body code-bg text-white">
-                <vue-json-pretty :data="prettyPrintJob(job.context)"></vue-json-pretty>
-            </div>
-        </div>
-
-
-        <div class="card overflow-hidden mt-4" v-if="ready">
-            <div class="card-header d-flex align-items-center justify-content-between">
-                <h2 class="h6 m-0">Data</h2>
-            </div>
-
-            <div class="card-body code-bg text-white">
-                <vue-json-pretty :data="prettyPrintJob(job.payload.data)"></vue-json-pretty>
-            </div>
-        </div>
-
         <div class="card overflow-hidden mt-4" v-if="ready && job.retried_by.length">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h2 class="h6 m-0">Recent Retries</h2>
@@ -254,5 +224,34 @@
             </table>
         </div>
 
+        <div class="card overflow-hidden mt-4" v-if="ready">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h2 class="h6 m-0">Exception</h2>
+            </div>
+            <div>
+                <stack-trace :trace="job.exception.split('\n')"></stack-trace>
+            </div>
+        </div>
+
+        <div class="card overflow-hidden mt-4" v-if="ready">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h2 class="h6 m-0">Exception Context</h2>
+            </div>
+
+            <div class="card-body code-bg text-white">
+                <vue-json-pretty :data="prettyPrintJob(job.context)"></vue-json-pretty>
+            </div>
+        </div>
+
+
+        <div class="card overflow-hidden mt-4" v-if="ready">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h2 class="h6 m-0">Data</h2>
+            </div>
+
+            <div class="card-body code-bg text-white">
+                <vue-json-pretty :data="prettyPrintJob(job.payload.data)"></vue-json-pretty>
+            </div>
+        </div>
     </div>
 </template>


### PR DESCRIPTION
This pull request relocates the retry widget shifting it from the bottom of the page to a more prominent position beneath the job information section. While seemingly minor, this adjustment addresses a significant issue. Myself and several colleagues, were unaware of its existence due to its placement at the page's bottom. Particularly with larger payloads, it was effectively concealed.

![image](https://github.com/laravel/horizon/assets/9604666/c39f1234-d9b3-4c4f-be89-e82bb0472da1)