### PR TITLE
Added Command to Remove Specific Job from Queue

### DIFF
--- a/src/Console/ForgetPendingCommand.php
+++ b/src/Console/ForgetPendingCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Arr;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\RedisQueue;
+
+class ForgetPendingCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:forget-pending
+                            {jobId : The id of the job to clear}
+                            {--queue= : The name of the queue where the job is located}
+                            {--force : Force the operation to run when in production}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Delete a specific pending job by its ID from the specified queue";
+
+    /**
+     * Execute the console command.
+     *
+     * @return int|null
+     */
+    public function handle(JobRepository $jobRepository, QueueManager $manager)
+    {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        if (! method_exists(RedisQueue::class, 'clear')) {
+            $this->components->error('Clearing queues is not supported on this version of Laravel.');
+
+            return 1;
+        }
+
+        $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
+
+        if (method_exists($jobRepository, 'purgeSpecificJob')) {
+            $jobRepository->purgePending($queue = $this->getQueue($connection), $this->argument('jobId'));
+        }
+
+        $this->components->info('Cleared pending job ['.$this->argument('jobId').'] from the ['.$queue.'] queue.');
+
+        return 0;
+    }
+
+    /**
+     * Get the queue name to clear.
+     *
+     * @param  string  $connection
+     * @return string
+     */
+    protected function getQueue($connection)
+    {
+        return $this->option('queue') ?: $this->laravel['config']->get(
+            "queue.connections.{$connection}.queue",
+            'default'
+        );
+    }
+}

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -119,6 +119,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\ContinueCommand::class,
                 Console\ContinueSupervisorCommand::class,
                 Console\ForgetFailedCommand::class,
+                Console\ClearCommand::class,
                 Console\HorizonCommand::class,
                 Console\InstallCommand::class,
                 Console\ListCommand::class,

--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -17,9 +17,9 @@ class LuaScripts
     {
         return <<<'LUA'
             redis.call('hsetnx', KEYS[1], 'throughput', 0)
-            
+
             redis.call('sadd', KEYS[2], KEYS[1])
-            
+
             local hash = redis.call('hmget', KEYS[1], 'throughput', 'runtime')
 
             local throughput = hash[1] + 1
@@ -48,10 +48,10 @@ LUA;
     public static function purge()
     {
         return <<<'LUA'
-            
+
             local count = 0
             local cursor = 0
-            
+
             repeat
                 -- Iterate over the recent jobs sorted set
                 local scanner = redis.call('zscan', KEYS[1], cursor)
@@ -69,11 +69,61 @@ LUA;
                         redis.call('zrem', KEYS[2], jobid)
                         redis.call('del', hashkey)
                         count = count + 1
-                    end           
+                    end
                 end
             until cursor == '0'
 
             return count
 LUA;
     }
+
+
+    /**
+     * Get the Lua script to purge a specific job from the queue using its job id.
+     *
+     * KEYS[1] - The recent jobs sorted set
+     * KEYS[2] - The pending jobs sorted set
+     * ARGV[1] - The prefix of the Horizon keys
+     * ARGV[2] - The queue to purge
+     * ARGV[3] - The id of the job to purge
+     *
+     * @return string
+     */
+    public static function purgeSpecific()
+    {
+        return <<<'LUA'
+        -- Ensure that the correct number of ARGV values and KEYS values are provided
+        assert(#ARGV >= 3, "Three ARGV values are required: [Horizon key prefix, queue name, job id]")
+        assert(#KEYS >= 2, "Two KEYS values are required: [name of sorted set for recent jobs, name of sorted set for pending jobs]")
+
+        -- Retrieve the specific job id
+        local jobid = ARGV[3]
+
+        -- Construct the hash key using the prefix and the job id
+        local hashkey = ARGV[1] .. jobid
+
+        -- Retrieve the 'status' and 'queue' fields for the job
+        local job = redis.call('hmget', hashkey, 'status', 'queue')
+
+        -- Ensure 'status' and 'queue' fields are retrieved
+        assert(#job == 2, "hmget was unable to retrieve both 'status' and 'queue' fields for the provided job id")
+
+        -- If the job is reserved or pending, and the job's queue matches the one to be purged
+        if ((job[1] == 'reserved' or job[1] == 'pending') and job[2] == ARGV[2]) then
+            -- Remove job id from the recent and pending jobs sorted sets
+            redis.call('zrem', KEYS[1], jobid)
+            redis.call('zrem', KEYS[2], jobid)
+
+            -- Delete the hash for the job
+            redis.call('del', hashkey)
+
+            -- Return "1" to indicate successful removal
+            return 1
+        end
+
+        -- Return "0" to indicate no job was removed
+        return 0
+LUA;
+    }
+
 }

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -743,6 +743,27 @@ class RedisJobRepository implements JobRepository
     }
 
     /**
+     * Delete a specific pending or reserved job for a queue by its job id.
+     *
+     * @param  string  $queue
+     * @param  string  $jobId
+     * @return int
+     */
+    public function purgePending($queue, $jobId)
+    {
+        return $this->connection()->eval(
+            LuaScripts::purgeSpecific(),
+            2,
+            'recent_jobs',
+            'pending_jobs',
+            config('horizon.prefix'),
+            $queue,
+            $jobId
+        );
+    }
+
+
+    /**
      * Get the Redis connection instance.
      *
      * @return \Illuminate\Redis\Connections\Connection

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -81,6 +81,18 @@ class RedisJobRepositoryTest extends IntegrationTest
         $this->assertCount(2, $repository->getJobs([1, 2, 3, 4, 5]));
     }
 
+    public function test_it_removes_specific_job()
+    {
+        $repository = $this->app->make(JobRepository::class);
+
+        $repository->pushed('horizon', 'foo', new JobPayload(json_encode(['id' => 1, 'displayName' => 'foo'])));
+
+
+        $repository->purgePending('foo', "1");
+
+        $this->assertEquals(0, $repository->countPending());
+    }
+
     public function test_it_will_delete_a_failed_job()
     {
         $repository = $this->app->make(JobRepository::class);


### PR DESCRIPTION
Summary
This PR introduces a new console command horizon:forget-pending which allows specific jobs to be removed from the Laravel queue based on their Job ID.

Benefit to End Users
This contribution enhances the Laravel job handling by providing the users with the capability to specifically target and remove unwanted or troublesome jobs from their queues, thereby allowing for better control and management of the queue jobs.
