### PR TITLE
Use morph-name instead of class-name for a tag

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -34,7 +34,7 @@ class Tags
         }
 
         return static::modelsFor(static::targetsFor($job))->map(function ($model) {
-            return get_class($model).':'.$model->getKey();
+            return $model->getMorphClass().':'.$model->getKey();
         })->all();
     }
 


### PR DESCRIPTION
If job has no explicit tags, Horizon builds tags with every model, passed to a job constructor. Model's tag is a full class name and primary key.

I think, that we may use model's morph name intead of class name. It would be more laconic. 

You can see the difference:
![image](https://github.com/laravel/horizon/assets/1220316/f8ec244f-b77e-4b7b-a916-44acd66f3c09)

