### PR TITLE
[5.x] Customize the lock time for the notification to be re-sent.

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -89,6 +89,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Queue Wait Time Notification Sending Locks
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to configure the amount of time (in seconds) that
+    | Horizon will wait before sending another notification about long wait time
+    | for a specific connection / queue combination.
+    | Every connection / queue combination may have its own unique lock time
+    | (in seconds).
+    |
+    */
+
+    'notification_lock_times' => [
+        'redis:default' => 300,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Job Trimming Times
     |--------------------------------------------------------------------------
     |

--- a/src/Listeners/SendNotification.php
+++ b/src/Listeners/SendNotification.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon\Listeners;
 
 use Illuminate\Support\Facades\Notification;
+use Laravel\Horizon\Events\LongWaitDetected;
 use Laravel\Horizon\Horizon;
 use Laravel\Horizon\Lock;
 
@@ -11,14 +12,15 @@ class SendNotification
     /**
      * Handle the event.
      *
-     * @param  mixed  $event
+     * @param  \Laravel\Horizon\Events\LongWaitDetected  $event
      * @return void
      */
-    public function handle($event)
+    public function handle(LongWaitDetected $event)
     {
         $notification = $event->toNotification();
+        $lockTime = config(sprintf('horizon.notification_lock_times.%s:%s', $event->connection, $event->queue), 300);
 
-        if (! app(Lock::class)->get('notification:'.$notification->signature(), 300)) {
+        if (! app(Lock::class)->get('notification:'.$notification->signature(), $lockTime)) {
             return;
         }
 

--- a/tests/Feature/Listeners/SendNotificationTest.php
+++ b/tests/Feature/Listeners/SendNotificationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Listeners;
+
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\Horizon;
+use Laravel\Horizon\Lock;
+use Laravel\Horizon\Notifications\LongWaitDetected as LongWaitDetectedNotification;
+use Laravel\Horizon\Tests\IntegrationTest;
+use Mockery as m;
+
+class SendNotificationTest extends IntegrationTest
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('horizon.notification_lock_times', [
+            'redis:foo' => 444,
+            'redis:baz' => 555,
+        ]);
+    }
+
+    public function test_send_notification_after_lock_time_as_default_when_config_value_not_found(): void
+    {
+        Notification::fake();
+        Horizon::$email = 'foo@baz.bar';
+
+        $lockMock = m::mock(Lock::class);
+        $lockMock->shouldReceive('get')
+            ->once()
+            ->with(m::any(), 300)
+            ->andReturn(true);
+
+        $this->instance(Lock::class, $lockMock);
+
+        $this->app->make(Dispatcher::class)->dispatch(new LongWaitDetected(
+            'redis', 'default', 600
+        ));
+
+        Notification::assertSentTimes(LongWaitDetectedNotification::class, 1);
+    }
+
+    public function test_send_notification_after_lock_time_set_in_config(): void
+    {
+        Notification::fake();
+        Horizon::$slackWebhookUrl = 'https://slack.com';
+
+        $lockMock = m::mock(Lock::class);
+        $lockMock->shouldReceive('get')
+            ->once()
+            ->with(m::any(), 444)
+            ->andReturn(true);
+
+        $this->instance(Lock::class, $lockMock);
+
+        $this->app->make(Dispatcher::class)->dispatch(new LongWaitDetected(
+            'redis', 'foo', 600
+        ));
+
+        Notification::assertSentTimes(LongWaitDetectedNotification::class, 1);
+    }
+
+    public function test_do_not_send_notification_if_lock_not_acquired(): void
+    {
+        Notification::fake();
+        Horizon::$slackWebhookUrl = 'https://slack.com';
+
+        $lockMock = m::mock(Lock::class);
+        $lockMock->shouldReceive('get')
+            ->once()
+            ->with(m::any(), 555)
+            ->andReturn(false);
+
+        $this->instance(Lock::class, $lockMock);
+
+        $this->app->make(Dispatcher::class)->dispatch(new LongWaitDetected(
+            'redis', 'baz', 600
+        ));
+
+        Notification::assertSentTimes(LongWaitDetectedNotification::class, 0);
+    }
+}


### PR DESCRIPTION
In order to be able to "silent" the notifications about the same long wait times, there could be a setting.

For example, we are aware about the situation for long waiting time in queue and would like to get notifications not so often (now it can not be customized as is sent every 5 minutes). Example in Slack:
<img width="630" alt="Screenshot 2024-04-03 at 15 01 01" src="https://github.com/laravel/horizon/assets/12799259/39eed745-4ee0-4393-b037-35db2c026897">

This setting could be customizable the same way as `waits`, where the combination of connection / queue could have it's own setting. 