### PR TITLE
Enhance forget command

### DIFF
--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -52,6 +52,10 @@ class ForgetFailedCommand extends Command
             return;
         }
 
+        if (! $this->argument('id')) {
+            $this->components->error('No failed job ID provided.');
+        }
+        
         $repository->deleteFailed($this->argument('id'));
 
         if ($this->laravel['queue.failer']->forget($this->argument('id'))) {

--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -14,7 +14,7 @@ class ForgetFailedCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:forget {id : The ID of the failed job}';
+    protected $signature = 'horizon:forget {id? : The ID of the failed job} {--all : To delete all failed jobs}';
 
     /**
      * The console command description.
@@ -30,6 +30,28 @@ class ForgetFailedCommand extends Command
      */
     public function handle(JobRepository $repository)
     {
+        if ($this->option('all')) {
+            $totalFailedCount = $repository->totalFailed();
+
+            do {
+                collect($repository->getFailed())->pluck('id')->each(function ($failedId) use ($repository): void {
+                    $repository->deleteFailed($failedId);
+
+                    if ($this->laravel['queue.failer']->forget($failedId)) {
+                        $this->components->info('Failed job (id): '.$failedId.' deleted successfully!');
+                    }
+                });
+            } while ($repository->totalFailed() !== 0);
+
+            if ($totalFailedCount) {
+                $this->components->info('All failed jobs ('.$totalFailedCount.') deleted successfully!');
+            } else {
+                $this->components->info('Nothing to be deleted as failed jobs are empty');
+            }
+
+            return;
+        }
+
         $repository->deleteFailed($this->argument('id'));
 
         if ($this->laravel['queue.failer']->forget($this->argument('id'))) {

--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -14,7 +14,7 @@ class ForgetFailedCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:forget {id? : The ID of the failed job} {--all : To delete all failed jobs}';
+    protected $signature = 'horizon:forget {id? : The ID of the failed job} {--all : Delete all failed jobs}';
 
     /**
      * The console command description.

--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -44,9 +44,9 @@ class ForgetFailedCommand extends Command
             } while ($repository->totalFailed() !== 0);
 
             if ($totalFailedCount) {
-                $this->components->info('All failed jobs ('.$totalFailedCount.') deleted successfully!');
+                $this->components->info($totalFailedCount.' failed jobs deleted successfully!');
             } else {
-                $this->components->info('Nothing to be deleted as failed jobs are empty');
+                $this->components->info('No failed jobs detected.');
             }
 
             return;


### PR DESCRIPTION
As suggested, this pull request enhances the forget command with a new option `--all`, enabling the removal of all failed jobs.

**Benefits to End Users**:
This addition resolves various discussions regarding how to delete failed jobs and prevents users from resorting to using `flushdb` to delete only failed jobs.
