### PR TITLE
[5.x] Fix setting custom ASSET_URLs and support cache busting without integrity check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "sass": "^1.74.1",
                 "sql-formatter": "^4.0.2",
                 "vite": "^5.2.8",
-                "vite-plugin-manifest-sri": "^0.2.0",
                 "vue": "^2.7.16",
                 "vue-json-pretty": "^1.9.5",
                 "vue-router": "^3.6.5"
@@ -1572,12 +1571,6 @@
                 "picomatch": "^2.3.1"
             }
         },
-        "node_modules/vite-plugin-manifest-sri": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-manifest-sri/-/vite-plugin-manifest-sri-0.2.0.tgz",
-            "integrity": "sha512-Zt5jt19xTIJ91LOuQTCtNG7rTFc5OziAjBz2H5NdCGqaOD1nxrWExLhcKW+W4/q8/jOPCg/n5ncYEQmqCxiGQQ==",
-            "dev": true
-        },
         "node_modules/vue": {
             "version": "2.7.16",
             "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
@@ -2570,12 +2563,6 @@
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
             }
-        },
-        "vite-plugin-manifest-sri": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-manifest-sri/-/vite-plugin-manifest-sri-0.2.0.tgz",
-            "integrity": "sha512-Zt5jt19xTIJ91LOuQTCtNG7rTFc5OziAjBz2H5NdCGqaOD1nxrWExLhcKW+W4/q8/jOPCg/n5ncYEQmqCxiGQQ==",
-            "dev": true
         },
         "vue": {
             "version": "2.7.16",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "sass": "^1.74.1",
         "sql-formatter": "^4.0.2",
         "vite": "^5.2.8",
-        "vite-plugin-manifest-sri": "^0.2.0",
         "vue": "^2.7.16",
         "vue-json-pretty": "^1.9.5",
         "vue-router": "^3.6.5"

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,29 +1,25 @@
 {
   "resources/img/favicon.png": {
-    "file": "favicon.png",
-    "src": "resources/img/favicon.png",
-    "integrity": "sha384-tqnRilkeRgqFt3SUYaxuaQs14WOwuU8Gvk3sqRZmnyWZVhr1Kk19Ecr7dFMb4HZo"
+    "file": "favicon.png?id=1542bfe8a0010dcbee710da13cce367f",
+    "src": "resources/img/favicon.png"
   },
   "resources/js/app.js": {
-    "file": "app.js",
+    "file": "app.js?id=69a73e4fc0356dae6adf8cc33985b1d5",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true,
     "css": [
       "app.css"
-    ],
-    "integrity": "sha384-EV5vlraT2g7leIzueltC7I+UzR7uBT4ndQF5b1G9I+kUrQ4XL0DREuRw/XiU/U3P"
+    ]
   },
   "resources/sass/styles-dark.scss": {
-    "file": "styles-dark.css",
+    "file": "styles-dark.css?id=4147954938fc149998024ad0251831e4",
     "src": "resources/sass/styles-dark.scss",
-    "isEntry": true,
-    "integrity": "sha384-/sLOxh+NTFEdcZ8svIuVTv/lSL65X3QGIXhExXAhntQYWjiez1CQbv4ICbtwRfd8"
+    "isEntry": true
   },
   "resources/sass/styles.scss": {
-    "file": "styles.css",
+    "file": "styles.css?id=452cf65324025421cc414ccb7744885f",
     "src": "resources/sass/styles.scss",
-    "isEntry": true,
-    "integrity": "sha384-4HOmv1E51xgqbUYzCYXaRXPRja5nEho6eq/L/CKs0LlidzTGNTk81VtCAHqLiYSC"
+    "isEntry": true
   }
 }

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,23 +1,8 @@
 @php
-use Illuminate\Support\Facades\Vite;
-use Illuminate\Foundation\Vite as ViteFoundation;
+$nonExistentFileName = public_path('/vendor/horizon/nonExistentFile');
+$previousHotFile = Vite::hotFile();
 
-$nonExistentFileName = '/vendor/horizon/nonExistentFile';
-
-$vite = new ViteFoundation();
-$vite->useHotFile($nonExistentFileName);
-
-$viteDataSchemeLight = new ViteFoundation();
-$viteDataSchemeLight->useHotFile($nonExistentFileName);
-$viteDataSchemeLight->useStyleTagAttributes([
-'data-scheme' => 'light',
-]);
-
-$viteDataSchemeDark = new ViteFoundation();
-$viteDataSchemeDark->useHotFile($nonExistentFileName);
-$viteDataSchemeDark->useStyleTagAttributes([
-'data-scheme' => 'dark',
-]);
+Vite::useHotFile($nonExistentFileName);
 @endphp
 <!DOCTYPE html>
 <html lang="en">
@@ -26,7 +11,7 @@ $viteDataSchemeDark->useStyleTagAttributes([
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <link rel="shortcut icon" href="{{ $vite->asset('resources/img/favicon.png', 'vendor/horizon') }}">
+    <link rel="shortcut icon" href="{{ Vite::asset('resources/img/favicon.png', 'vendor/horizon') }}">
 
     <title>Horizon{{ config('app.name') ? ' - ' . config('app.name') : '' }}</title>
 
@@ -34,8 +19,10 @@ $viteDataSchemeDark->useStyleTagAttributes([
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:300,400,500,600" rel="stylesheet" />
 
-    {{ $viteDataSchemeLight('resources/sass/styles.scss', 'vendor/horizon') }}
-    {{ $viteDataSchemeDark('resources/sass/styles-dark.scss', 'vendor/horizon') }}
+    <link rel="preload" as="style" href="{{ Vite::asset('resources/sass/styles.scss', 'vendor/horizon') }}" />
+    <link rel="stylesheet" href="{{ Vite::asset('resources/sass/styles.scss', 'vendor/horizon') }}" data-scheme="light" />
+    <link rel="preload" as="style" href="{{ Vite::asset('resources/sass/styles-dark.scss', 'vendor/horizon') }}" />
+    <link rel="stylesheet" href="{{ Vite::asset('resources/sass/styles-dark.scss', 'vendor/horizon') }}" data-scheme="dark" />
 </head>
 <body>
 <div id="horizon" v-cloak>
@@ -163,6 +150,9 @@ $viteDataSchemeDark->useStyleTagAttributes([
     window.Horizon = @json($horizonScriptVariables);
 </script>
 
-{{ $vite('resources/js/app.js', 'vendor/horizon') }}
+@vite('resources/js/app.js', 'vendor/horizon')
 </body>
 </html>
+@php
+Vite::useHotFile($previousHotFile);
+@endphp

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,7 +1,41 @@
 import vue2 from "@vitejs/plugin-vue2";
 import { defineConfig } from "vite";
 import laravel from "laravel-vite-plugin";
-import manifestSRI from "vite-plugin-manifest-sri";
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+
+function manifestQueryParam() {
+    return {
+        name: "vite-horizon-manifest-query-param",
+        apply: "build",
+        enforce: "post",
+        writeBundle({ dir }) {
+            const manifestPath = resolve(dir, "manifest.json");
+            const manifest = readFileSync(manifestPath, "utf-8");
+
+            if (manifest) {
+                const parsedManifest = JSON.parse(manifest);
+
+                for (const property in parsedManifest) {
+                    const fileContent = readFileSync(
+                        resolve(dir, parsedManifest[property].file),
+                        "utf-8"
+                    );
+
+                    parsedManifest[property].file += `?id=${createHash("md5")
+                        .update(fileContent)
+                        .digest("hex")}`;
+                }
+
+                writeFileSync(
+                    manifestPath,
+                    JSON.stringify(parsedManifest, null, 2)
+                );
+            }
+        },
+    };
+}
 
 const config = defineConfig({
     plugins: [
@@ -11,7 +45,7 @@ const config = defineConfig({
             "resources/js/app.js",
         ]),
         vue2(),
-        manifestSRI(),
+        manifestQueryParam(),
     ],
     resolve: {
         alias: {


### PR DESCRIPTION
Fixes #1425
Fixes #1426

There were already tries to integrate Vite with [telescope which have been postponed](https://github.com/laravel/telescope/pull/1391) because of the linked issues and other concerns. I think this PR now solves all of these issues.

@timacdonald I would love to hear your opinion as well as you were involved in a lot of these discussions as well:

- https://github.com/laravel/framework/issues/48964
- https://github.com/laravel/framework/pull/49329 (missing cleanup functionality for packages exporting vite files that include the file hash in the filename) because of this, we need to manually craft cache busting ids to the filename in the manifest instead of using the normal hashed files of vite e.g. `app.129hg41.js`. Without the cleanup, users would end up with a lot of outdated files published by packages like laravel/horizon and laravel/telescope
- https://github.com/laravel/telescope/pull/1391 -> has been reverted because of the broken `npm run dev` commands which this version of the vite implementation resolves

also related:
- https://github.com/laravel/framework/pull/45257
- https://github.com/laravel/vite-plugin/pull/251 (cleanup on the javascript side for the laravel-vite-plugin)

Screenshots:

Running vite dev mode renders the "none" vite url
![image](https://github.com/laravel/horizon/assets/10237069/5c41c0e8-89e3-403f-bac3-1edb36eca45e)

Setting a custom ASSET_URL works:

![image](https://github.com/laravel/horizon/assets/10237069/00c90a3a-2dc3-4a98-9775-da13c6bf3633)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
