### PR TITLE
Adding Pause Support on Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    restart: always

--- a/src/Console/ContinueCommand.php
+++ b/src/Console/ContinueCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Laravel\Horizon\MasterSupervisor;
@@ -52,5 +53,7 @@ class ContinueCommand extends Command
                     $this->components->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
                 }
             })->whenNotEmpty(fn () => $this->output->writeln(''));
+
+        Cache::forget('horizon:pause');
     }
 }

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Horizon\Console;
 
-use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;

--- a/src/Console/PauseCommand.php
+++ b/src/Console/PauseCommand.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Horizon\Console;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Laravel\Horizon\MasterSupervisor;
@@ -34,6 +36,8 @@ class PauseCommand extends Command
      */
     public function handle(MasterSupervisorRepository $masters)
     {
+        Cache::forever('horizon:pause', true);
+
         $masters = collect($masters->all())->filter(function ($master) {
             return Str::startsWith($master->name, MasterSupervisor::basename());
         })->all();

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -3,8 +3,8 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
@@ -34,13 +34,14 @@ class TerminateCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Contracts\Cache\Factory  $cache
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle(MasterSupervisorRepository $masters)
+    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters)
     {
         if (config('horizon.fast_termination')) {
-            Cache::forever(
+            $cache->forever(
                 'horizon:terminate:wait', $this->option('wait')
             );
         }
@@ -64,7 +65,7 @@ class TerminateCommand extends Command
                 }
             })->whenNotEmpty(fn () => $this->output->writeln(''));
 
-        Cache::forever('illuminate:queue:restart', $this->currentTime());
-        Cache::forget('horizon:pause');
+        $cache->forever('illuminate:queue:restart', $this->currentTime());
+        $cache->forget('horizon:pause');
     }
 }

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -3,8 +3,8 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
@@ -34,14 +34,13 @@ class TerminateCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Illuminate\Contracts\Cache\Factory  $cache
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters)
+    public function handle(MasterSupervisorRepository $masters)
     {
         if (config('horizon.fast_termination')) {
-            $cache->forever(
+            Cache::forever(
                 'horizon:terminate:wait', $this->option('wait')
             );
         }
@@ -65,6 +64,7 @@ class TerminateCommand extends Command
                 }
             })->whenNotEmpty(fn () => $this->output->writeln(''));
 
-        $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
+        Cache::forever('illuminate:queue:restart', $this->currentTime());
+        Cache::forget('horizon:pause');
     }
 }

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -19,7 +19,7 @@ use Throwable;
 
 class MasterSupervisor implements Pausable, Restartable, Terminable
 {
-    use ListensForSignals;
+    use ListensForSignals, Pause;
 
     /**
      * The environment that was used to provision this master supervisor.
@@ -246,6 +246,8 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     {
         try {
             $this->processPendingSignals();
+
+            $this->processPause();
 
             $this->processPendingCommands();
 

--- a/src/Pause.php
+++ b/src/Pause.php
@@ -37,7 +37,7 @@ trait Pause
     abstract protected function pause();
 
     /**
-     * Instruct the supervisors / worker processes to continue working.
+     * Instruct the supervisors and worker processes to continue working.
      *
      * @return void
      */

--- a/src/Pause.php
+++ b/src/Pause.php
@@ -8,6 +8,11 @@ trait Pause
 {
     protected $isPaused = false;
 
+    /**
+     * Process pause from cache.
+     *
+     * @return void
+     */
     protected function processPause()
     {
         $isPaused = Cache::get('horizon:pause', false);
@@ -23,4 +28,18 @@ trait Pause
 
         $this->isPaused = $isPaused;
     }
+
+    /**
+     * Pause all supervisors and worker processes.
+     *
+     * @return void
+     */
+    abstract protected function pause();
+
+    /**
+     * Instruct the supervisors / worker processes to continue working.
+     *
+     * @return void
+     */
+    abstract protected function continue();
 }

--- a/src/Pause.php
+++ b/src/Pause.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Horizon;
+
+use Illuminate\Support\Facades\Cache;
+
+trait Pause
+{
+    protected $isPaused = false;
+
+    protected function processPause()
+    {
+        $isPaused = Cache::get('horizon:pause', false);
+
+        if ($this->isPaused === $isPaused) {
+            return;
+        }
+
+        match ($isPaused) {
+            true => $this->pause(),
+            false => $this->continue(),
+        };
+
+        $this->isPaused = $isPaused;
+    }
+}

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -17,7 +17,7 @@ use Throwable;
 
 class Supervisor implements Pausable, Restartable, Terminable
 {
-    use ListensForSignals;
+    use ListensForSignals, Pause;
 
     /**
      * The name of this supervisor instance.
@@ -286,6 +286,8 @@ class Supervisor implements Pausable, Restartable, Terminable
             $this->ensureParentIsRunning();
 
             $this->processPendingSignals();
+
+            $this->processPause();
 
             $this->processPendingCommands();
 

--- a/tests/worker.php
+++ b/tests/worker.php
@@ -29,6 +29,7 @@ $appLoader = new class
 $app = $appLoader->createApplication();
 $app->register(Laravel\Horizon\HorizonServiceProvider::class);
 $app->make('config')->set('queue.default', 'redis');
+$app->make('config')->set('database.redis.client', 'predis');
 
 $worker = new Worker(
     $app->make(QueueManager::class),


### PR DESCRIPTION
This PR adds support to use redis for pause / continue horizons instances, without removing existing behavior.

### Motivation

The current implementation relies on you being able to ssh into the server is running horizon so you can pause, which can be limiting in the following scenarios:

#### Multiple Servers

If you have multiple horizons instances running, in case you need to pause, you would need to ssh on each instance and call pause.

#### Blue/green deploying on Kubernetes

On Kubernetes it's quite a challenge ssh into the container, specially if you have replicas, etc.

Also, if you want to pause while deploying for example, you probably want to use something like initContainer or before helm hook to run that, which will spawn a new container to run that.

On current implementation it's quite impossible.

In my case, as the old horizon is still running while we're deploying, we can have race conditions, running job on old code until we finish deploy and kill the old one. We should always recommend running pause before deploying i think (not sure it's already done somewhere) 🤔 

### Looking for Feedback

I kept the existing signals approach so we kind of do the pause logic twice... what we could do:

* Add some config to choose between approaches
* Remove signals and rely on cache / redis for this
* I added a `docker-compose.yml` to make easier to test locally
* I changed the test worker driver to `predis` as it skips the requirement of redis extension on local