### PR TITLE
Add --fail Option to Horizon Command for Deployment Failure on Unsuccessful Termination

### DIFF
--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -76,7 +76,7 @@ class TerminateCommand extends Command
     protected function handleNoProcesses(bool $fail)
     {
         $this->components->info('No processes to terminate.');
-        
+
         if ($fail) {
             exit(self::FAILURE);
         }

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -65,7 +65,6 @@ class TerminateCommand extends Command
                     $this->components->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
                 }
             })->whenNotEmpty(fn () => $this->output->writeln(''));
-
         $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
     }
 
@@ -79,7 +78,7 @@ class TerminateCommand extends Command
         $this->components->info('No processes to terminate.');
         
         if ($fail) {
-            exit(1);
+            exit(self::FAILURE);
         }
     }
 }


### PR DESCRIPTION
If you use deployment tools like Envoyer, there is a good chance that you would like the entire deployment process to fail if Horizon was not terminated. This might happen if you change your Redis connection or for another reason.

Currently, the command works successfully with an info message that no process was restarted. This PR does not change that but lets you specify that the command should actually fail in that case.

It does not break any existing feature because the new `--fail` option is an addition. It stops the artisan command by sending a UNIX cli error code 1 (`self::FAILURE`), which indicates that something went wrong.