### PR TITLE
[5.x] Feature: Warn if no supervisor config (#1447)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -50,7 +50,7 @@ class HorizonCommand extends Command
 
         $this->components->info('Horizon started successfully.');
 
-        if (!$provisioningPlan->hasEnvironment(($environment))) {
+        if (! $provisioningPlan->hasEnvironment($environment)) {
             $this->components->warn("No environment configuration found for the environment: $environment. Check 'environments' on config/horizon.php");
         }
 

--- a/tests/Feature/Fakes/MasterSupervisorWithFakeMonitor.php
+++ b/tests/Feature/Fakes/MasterSupervisorWithFakeMonitor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Fakes;
+
+class MasterSupervisorWithFakeMonitor extends MasterSupervisorWithFakeExit
+{
+    public $exited = false;
+
+    /**
+     * Monitor the worker processes.
+     *
+     * @return void
+     */
+    public function monitor()
+    {
+        $this->ensureNoOtherMasterSupervisors();
+
+        $this->listenForSignals();
+
+        $this->persist();
+
+        $this->loop();
+        $this->loop();
+
+        $this->terminate();
+    }
+}

--- a/tests/Feature/HorizonCommandTest.php
+++ b/tests/Feature/HorizonCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\Tests\Feature\Fakes\MasterSupervisorWithFakeMonitor;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class HorizonCommandTest extends IntegrationTest
+{
+    public function test_horizon_command_output_when_supervisor_is_present()
+    {
+        $this->app->bind(MasterSupervisor::class, MasterSupervisorWithFakeMonitor::class);
+
+        $this->with_scenario([
+            'local' => [
+                'supervisor-1' => [
+                    'maxProcesses' => 3,
+                ],
+            ],
+        ]);
+
+        $this->artisan('horizon --environment local')
+            ->expectsOutputToContain('Horizon started successfully.')
+            ->doesntExpectOutputToContain('No environment configuration found for the environment')
+            ->assertExitCode(0);
+    }
+
+    public function test_horizon_command_output_when_supervisor_is_not_present()
+    {
+        $this->app->bind(MasterSupervisor::class, MasterSupervisorWithFakeMonitor::class);
+
+        $this->with_scenario([
+            'local' => [
+                'supervisor-1' => [
+                    'maxProcesses' => 3,
+                ],
+            ],
+        ]);
+
+        $this->artisan('horizon --environment staging')
+            ->expectsOutputToContain('Horizon started successfully.')
+            ->expectsOutputToContain('No environment configuration found for the environment: staging.')
+            ->assertExitCode(0);
+    }
+
+    protected function with_scenario(array $supervisorSettings)
+    {
+        Config::set('horizon.environments', $supervisorSettings);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As discussed in https://github.com/laravel/horizon/issues/1447, users may run `php artisan horizon` in a different environment and forget to configure the supervisors for this new environment. This feature warns if there are no supervisors configured for the current environment.

This PR implements:

- Warning when no supervisor configuration is present;
- Integration tests to check the warning;

Obs.

It's possible to warn from the MasterSupervisor output but I think the HorizonCommand is more appropriate.
