### PR TITLE
Update runningProcesses to also include terminating processes

### DIFF
--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -293,7 +293,11 @@ class ProcessPool implements Countable
      */
     public function runningProcesses()
     {
-        return collect($this->processes)->filter(function ($process) {
+        $terminatingProcesses = $this->terminatingProcesses()->map(function ($process) {
+            return $process['process'];
+        });
+
+        return collect($this->processes)->concat($terminatingProcesses)->filter(function ($process) {
             return $process->process->isRunning();
         });
     }


### PR DESCRIPTION
This PR is an alternative for https://github.com/laravel/horizon/pull/1433 which both solve https://github.com/laravel/horizon/issues/1450. The difference with this PR is that terminating processes will be included in the `runningProcesses()` function, as suggested by @crynobone. Whenever there is a need to check for running processes elsewhere in the project the terminating processes will be included by default, instead of having to keep adding an additional check for terminating process like the other PR does https://github.com/laravel/horizon/pull/1433.