### PR TITLE
Fix worker scaling when balance mode is auto

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -96,9 +96,13 @@ class SupervisorCommand extends Command
 
         $supervisor->working = ! $this->option('paused');
 
-        $supervisor->scale(max(
-            0, $this->option('max-processes') - $supervisor->totalSystemProcessCount()
-        ));
+        if ($this->option('balance') === 'auto') {
+            $supervisor->scale(1);
+        } else {
+            $supervisor->scale(max(
+                0, $this->option('max-processes') - $supervisor->totalSystemProcessCount()
+            ));
+        }
 
         $supervisor->monitor();
     }


### PR DESCRIPTION
fix https://github.com/laravel/framework/issues/51765 
fix https://github.com/laravel/horizon/issues/1295

as explained: https://github.com/laravel/framework/discussions/48431

if horizon is in mode balance=auto, there is no need to start hundreds of workers if the queue is empty.
it's okay to start with only 1 worker. if the queue fills, horizon scales up. that's the way it should work.
