### PR TITLE
Test wildcard environments config

### DIFF
--- a/tests/Feature/ProvisioningPlanTest.php
+++ b/tests/Feature/ProvisioningPlanTest.php
@@ -46,17 +46,10 @@ class ProvisioningPlanTest extends IntegrationTest
                     'max_processes' => 20,
                 ],
             ],
-            '*' => [
-                'supervisor-1' => [
-                    'connection' => 'redis',
-                    'queue' => 'second',
-                    'max_processes' => 8,
-                ],
-            ],
         ];
 
         $plan = new ProvisioningPlan(MasterSupervisor::name(), $plan);
-        $plan->deploy('develop');
+        $plan->deploy('production');
 
         $commands = Redis::connection('horizon')->lrange(
             'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
@@ -65,8 +58,8 @@ class ProvisioningPlanTest extends IntegrationTest
         $this->assertCount(1, $commands);
         $command = (object) json_decode($commands[0], true);
         $this->assertSame(AddSupervisor::class, $command->command);
-        $this->assertSame('second', $command->options['queue']);
-        $this->assertSame(8, $command->options['maxProcesses']);
+        $this->assertSame('first', $command->options['queue']);
+        $this->assertSame(20, $command->options['maxProcesses']);
     }
 
     public function test_plan_is_converted_into_array_of_supervisor_options()

--- a/tests/Feature/ProvisioningPlanTest.php
+++ b/tests/Feature/ProvisioningPlanTest.php
@@ -46,10 +46,17 @@ class ProvisioningPlanTest extends IntegrationTest
                     'max_processes' => 20,
                 ],
             ],
+            '*' => [
+                'supervisor-1' => [
+                    'connection' => 'redis',
+                    'queue' => 'second',
+                    'max_processes' => 8,
+                ],
+            ],
         ];
 
         $plan = new ProvisioningPlan(MasterSupervisor::name(), $plan);
-        $plan->deploy('production');
+        $plan->deploy('develop');
 
         $commands = Redis::connection('horizon')->lrange(
             'commands:'.MasterSupervisor::commandQueueFor(MasterSupervisor::name()), 0, -1
@@ -58,8 +65,8 @@ class ProvisioningPlanTest extends IntegrationTest
         $this->assertCount(1, $commands);
         $command = (object) json_decode($commands[0], true);
         $this->assertSame(AddSupervisor::class, $command->command);
-        $this->assertSame('first', $command->options['queue']);
-        $this->assertSame(20, $command->options['maxProcesses']);
+        $this->assertSame('second', $command->options['queue']);
+        $this->assertSame(8, $command->options['maxProcesses']);
     }
 
     public function test_plan_is_converted_into_array_of_supervisor_options()


### PR DESCRIPTION
I might be looking at this totally wrong but I believe `ProvisioningPlanTest`::[test_supervisors_are_added_by_wildcard](https://github.com/laravel/horizon/blob/14eed5662588cd115cd4b6b3c4248b540357be42/tests/Feature/ProvisioningPlanTest.php#L39) isn't testing anything related to wildcard environments. It just looks like a duplicate of `ProvisioningPlanTest`::[test_supervisors_are_added](https://github.com/laravel/horizon/blob/14eed5662588cd115cd4b6b3c4248b540357be42/tests/Feature/ProvisioningPlanTest.php#L13).

I came by this because each member of my team is using a different APP_ENV and I was looking for a simple way to declare that in the Horizon config without having to list them all. I thought adding a wildcard environment wasn't possible, but it is, only missing documentation. If my assumptions are correct, here's a fix to that test. I've also sent https://github.com/laravel/docs/pull/9706 for documenting the wildcard usage.

Thanks!