### PR TITLE
Create status command for individual supervisors

### DIFF
--- a/src/Console/StatusSupervisorCommand.php
+++ b/src/Console/StatusSupervisorCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\Horizon\Contracts\SupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'horizon:pause-supervisor')]
+class StatusSupervisorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:status-supervisor
+                            {name : The name of the supervisor to show status}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show status for a supervisor';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
+     * @return void
+     */
+    public function handle(SupervisorRepository $supervisors)
+    {
+        $name = $this->argument('name');
+        $supervisorStatus = optional(collect($supervisors->all())->first(function ($supervisor) use ($name) {
+            return Str::startsWith($supervisor->name, MasterSupervisor::basename())
+                    && Str::endsWith($supervisor->name, $name);
+        }))->status;
+
+        if (is_null($supervisorStatus)) {
+            $this->components->error("Failed to find a supervisor with this name: {$name}");
+
+            return 1;
+        }
+
+        $this->components->info("{$name} is {$supervisorStatus}");
+    }
+}

--- a/src/Console/SupervisorStatusCommand.php
+++ b/src/Console/SupervisorStatusCommand.php
@@ -42,7 +42,7 @@ class SupervisorStatusCommand extends Command
         }))->status;
 
         if (is_null($supervisorStatus)) {
-            $this->components->error('Failed to find a supervisor with this name');
+            $this->components->error('Unable to find a supervisor with this name.');
 
             return 1;
         }

--- a/src/Console/SupervisorStatusCommand.php
+++ b/src/Console/SupervisorStatusCommand.php
@@ -9,7 +9,7 @@ use Laravel\Horizon\MasterSupervisor;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'horizon:supervisor-status')]
-class StatusSupervisorCommand extends Command
+class SupervisorStatusCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/src/Console/SupervisorStatusCommand.php
+++ b/src/Console/SupervisorStatusCommand.php
@@ -8,7 +8,7 @@ use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\MasterSupervisor;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'horizon:pause-supervisor')]
+#[AsCommand(name: 'horizon:supervisor-status')]
 class StatusSupervisorCommand extends Command
 {
     /**
@@ -16,15 +16,15 @@ class StatusSupervisorCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:status-supervisor
-                            {name : The name of the supervisor to show status}';
+    protected $signature = 'horizon:supervisor-status
+                            {name : The name of the supervisor}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Show status for a supervisor';
+    protected $description = 'Show the status for a given supervisor';
 
     /**
      * Execute the console command.
@@ -35,13 +35,14 @@ class StatusSupervisorCommand extends Command
     public function handle(SupervisorRepository $supervisors)
     {
         $name = $this->argument('name');
+
         $supervisorStatus = optional(collect($supervisors->all())->first(function ($supervisor) use ($name) {
-            return Str::startsWith($supervisor->name, MasterSupervisor::basename())
-                    && Str::endsWith($supervisor->name, $name);
+            return Str::startsWith($supervisor->name, MasterSupervisor::basename()) &&
+                   Str::endsWith($supervisor->name, $name);
         }))->status;
 
         if (is_null($supervisorStatus)) {
-            $this->components->error("Failed to find a supervisor with this name: {$name}");
+            $this->components->error('Failed to find a supervisor with this name');
 
             return 1;
         }

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -115,6 +115,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\PurgeCommand::class,
                 Console\StatusCommand::class,
                 Console\SupervisorCommand::class,
+                Console\SupervisorStatusCommand::class,
                 Console\SupervisorsCommand::class,
                 Console\TerminateCommand::class,
                 Console\TimeoutCommand::class,


### PR DESCRIPTION
Following the pattern of the `horizon:pause-supervisor` and `horizon:continue-supervisor` commands, this PR aims to address [Issue 1461](https://github.com/laravel/horizon/issues/1461) by introducing a `horizon:status-supervisor` command.

The existing `horizon:status` command only checks for the presence of a single paused supervisor before reporting that "Horizon is paused". This new command will allow users with multiple configurations to see accurate statuses for each supervisor.