### PR TITLE
Remove leftover publishing command in install command after simplified assets.

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -34,7 +34,6 @@ class InstallCommand extends Command
         $this->components->info('Installing Horizon resources.');
 
         collect([
-            'Assets' => fn () => $this->callSilent('vendor:publish', ['--tag' => 'horizon-assets']) == 0,
             'Service Provider' => fn () => $this->callSilent('vendor:publish', ['--tag' => 'horizon-provider']) == 0,
             'Configuration' => fn () => $this->callSilent('vendor:publish', ['--tag' => 'horizon-config']) == 0,
         ])->each(fn ($task, $description) => $this->components->task($description, $task));


### PR DESCRIPTION
Hello.

Following the merge of PR #1438, it appears that the `vendor:publish --tag=horizon-assets` command is no longer necessary. The associated publishing tag has been removed, as referenced here: [PR #1438 - File Changes \#1](https://github.com/laravel/horizon/pull/1438/files#diff-2097bffdb48de86543ba8c9c65f5f9ab7365cb2a362dfa09bea9e5ad6764d0e0L26) & [PR #1438 - File Changes \#2](https://github.com/laravel/horizon/pull/1438/files#diff-2097bffdb48de86543ba8c9c65f5f9ab7365cb2a362dfa09bea9e5ad6764d0e0L78-L89).

Running this command manually now produces the following output:
```
> php artisan vendor:publish --tag=horizon-assets

   INFO  No publishable resources for tag [horizon-assets]. 
```