### PR TITLE
[5.x] Add clear all queues option

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -22,6 +22,7 @@ class ClearCommand extends Command
      */
     protected $signature = 'horizon:clear
                             {--queue= : The name of the queue to clear}
+                            {--all-queues : Clear all queues}
                             {--force : Force the operation to run when in production}';
 
     /**
@@ -50,28 +51,42 @@ class ClearCommand extends Command
 
         $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
 
-        if (method_exists($jobRepository, 'purge')) {
-            $jobRepository->purge($queue = $this->getQueue($connection));
+        $queues = $this->getQueues($connection);
+
+        foreach ($queues as $queue) {
+            if (method_exists($jobRepository, 'purge')) {
+                $jobRepository->purge($queue);
+            }
+
+            $count = $manager->connection($connection)->clear($queue);
+
+            $this->components->info('Cleared '.$count.' jobs from the ['.$queue.'] queue.');
         }
-
-        $count = $manager->connection($connection)->clear($queue);
-
-        $this->components->info('Cleared '.$count.' jobs from the ['.$queue.'] queue.');
 
         return 0;
     }
 
     /**
-     * Get the queue name to clear.
+     * Get the queue names to clear.
      *
-     * @param  string  $connection
-     * @return string
+     * @return array<string>
      */
-    protected function getQueue($connection)
+    protected function getQueues(string $connection): array
     {
-        return $this->option('queue') ?: $this->laravel['config']->get(
-            "queue.connections.{$connection}.queue",
-            'default'
-        );
+        if ($this->option('queue')) {
+            $queues = [$this->option('queue')];
+        } else {
+            $queues = [$this->laravel['config']->get("queue.connections.{$connection}.queue", 'default')];
+
+            if ($this->option('all-queues')) {
+                $supervisors = $this->laravel['config']->get('horizon.defaults', []);
+                foreach ($supervisors as $supervisor) {
+                    $queues = array_merge($queues, Arr::wrap($supervisor['queue'] ?? []));
+                }
+                $queues = array_values(array_unique($queues));
+            }
+        }
+
+        return $queues;
     }
 }

--- a/tests/Feature/ClearCommandTest.php
+++ b/tests/Feature/ClearCommandTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Feature;
+
+use Laravel\Horizon\Repositories\RedisJobRepository;
+use Illuminate\Queue\QueueManager;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class ClearCommandTest extends IntegrationTest
+{
+    public function test_clear_command_on_single_queue()
+    {
+        config(['queue.connections.redis.queue' => 'default']);
+        $mock = $this->mock(
+            RedisJobRepository::class,
+            function (\Mockery\MockInterface $mock) {
+                $mock->shouldReceive('purge')->twice()->andReturnTrue();
+            }
+        );
+        $this->app->offsetSet(JobRepository::class, $mock);
+
+        $mock = $this->mock(
+            QueueManager::class,
+            function (\Mockery\MockInterface $mock) {
+                $mock->shouldReceive('connection')->twice()->andReturnSelf();
+                $mock->shouldReceive('clear')->twice()->andReturn(1);
+            }
+        );
+        $this->app->offsetSet(QueueManager::class, $mock);
+
+        $this->artisan('horizon:clear')->expectsOutputToContain('Cleared 1 jobs from the [default] queue.');
+
+        $this->artisan('horizon:clear', ['--queue' => 'foo'])->expectsOutputToContain('Cleared 1 jobs from the [foo] queue.');
+    }
+
+    public function test_clear_command_on_all_queues()
+    {
+        config(['queue.connections.redis.queue' => 'default']);
+        config(['horizon.defaults' => [
+            'supervisor-1' => ['queue' => ['a', 'b', 'c']],
+            'supervisor-2' => ['queue' => ['c', 'd', 'e', 'f']],
+            'supervisor-3' => ['queue' => 'foo'],
+        ]]);
+
+        $mock = $this->mock(
+            RedisJobRepository::class,
+            function (\Mockery\MockInterface $mock) {
+                $mock->shouldReceive('purge')->times(8)->andReturnTrue();
+            }
+        );
+        $this->app->offsetSet(JobRepository::class, $mock);
+
+        $mock = $this->mock(
+            QueueManager::class,
+            function (\Mockery\MockInterface $mock) {
+                $mock->shouldReceive('connection')->times(8)->andReturnSelf();
+                $mock->shouldReceive('clear')->times(8)->andReturn(1);
+            }
+        );
+        $this->app->offsetSet(QueueManager::class, $mock);
+
+        $this->artisan('horizon:clear', ['--all-queues' => true])
+            ->expectsOutputToContain('Cleared 1 jobs from the [default] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [a] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [b] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [c] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [d] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [e] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [f] queue.')
+            ->expectsOutputToContain('Cleared 1 jobs from the [foo] queue.')
+        ;
+    }
+}

--- a/tests/Feature/ClearCommandTest.php
+++ b/tests/Feature/ClearCommandTest.php
@@ -2,9 +2,9 @@
 
 namespace Feature;
 
-use Laravel\Horizon\Repositories\RedisJobRepository;
 use Illuminate\Queue\QueueManager;
 use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\Repositories\RedisJobRepository;
 use Laravel\Horizon\Tests\IntegrationTest;
 
 class ClearCommandTest extends IntegrationTest
@@ -68,7 +68,6 @@ class ClearCommandTest extends IntegrationTest
             ->expectsOutputToContain('Cleared 1 jobs from the [d] queue.')
             ->expectsOutputToContain('Cleared 1 jobs from the [e] queue.')
             ->expectsOutputToContain('Cleared 1 jobs from the [f] queue.')
-            ->expectsOutputToContain('Cleared 1 jobs from the [foo] queue.')
-        ;
+            ->expectsOutputToContain('Cleared 1 jobs from the [foo] queue.');
     }
 }


### PR DESCRIPTION
This PR adds an option to clear all queues: `artisan horizon:clear --all-queues`

This is ideal for development as Laravel/Horizon apps might have multiple queues and this would provide a quick and easy way to clear all the queues at once instead of calling the `horizon:clear` command multiple times.

It grabs the default queue, and all the horizon queues from the config and issues the clear command individually to each queue. 

This PR also adds a test for the command as there wasn't previously a test.
