### PR TITLE
Extend Slack Notification to work with Slack Apps for Laravel 11 support

### DIFF
--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -94,9 +94,10 @@ class LongWaitDetected extends Notification
     public function toSlack($notifiable)
     {
         $fromName = 'Laravel Horizon';
-        $imageUrl = 'https://laravel.com/assets/img/horizon-48px.png';
-        $text = 'Oh no! Something needs your attention.';
         $title = 'Long Wait Detected';
+        $text = 'Oh no! Something needs your attention.';
+        $imageUrl = 'https://laravel.com/assets/img/horizon-48px.png';
+
         $content = sprintf(
             '[%s] The "%s" queue on the "%s" connection has a wait time of %s seconds.',
             config('app.name'),
@@ -105,7 +106,9 @@ class LongWaitDetected extends Notification
             $this->seconds
         );
 
-        if (class_exists('\Illuminate\Notifications\Slack\SlackMessage') && class_exists('\Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
+        if (class_exists('\Illuminate\Notifications\Slack\SlackMessage') &&
+            class_exists('\Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock') &&
+            ! (is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
             return (new ChannelIdSlackMessage)
                 ->username($fromName)
                 ->image($imageUrl)

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -105,7 +105,7 @@ class LongWaitDetected extends Notification
             $this->seconds
         );
 
-        if (class_exists('Illuminate\Notifications\Slack\SlackMessage') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
+        if (class_exists('Illuminate\Notifications\Slack\SlackMessage') && class_exists('Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
             return (new ChannelIdSlackMessage)
                 ->username($fromName)
                 ->image($imageUrl)

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -105,26 +105,26 @@ class LongWaitDetected extends Notification
             $this->seconds
         );
 
-        if (is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://'])) {
-            return (new SlackMessage) // @phpstan-ignore-line
-                ->from($fromName)
-                ->to(Horizon::$slackChannel)
+        if (class_exists('Illuminate\Notifications\Slack\SlackMessage') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
+            return (new ChannelIdSlackMessage) // @phpstan-ignore-line
+                ->username($fromName)
                 ->image($imageUrl)
-                ->error()
-                ->content($text)
-                ->attachment(function ($attachment) use ($title, $content) {
-                    $attachment->title($title)
-                        ->content($content);
+                ->text($text)
+                ->headerBlock($title)
+                ->sectionBlock(function (SectionBlock $block) use ($content): void {
+                    $block->text($content);
                 });
         }
 
-        return (new ChannelIdSlackMessage)
-            ->username($fromName)
+        return (new SlackMessage) // @phpstan-ignore-line
+            ->from($fromName)
+            ->to(Horizon::$slackChannel)
             ->image($imageUrl)
-            ->text($text)
-            ->headerBlock($title)
-            ->sectionBlock(function (SectionBlock $block) use ($content): void {
-                $block->text($content);
+            ->error()
+            ->content($text)
+            ->attachment(function ($attachment) use ($title, $content) {
+                $attachment->title($title)
+                    ->content($content);
             });
     }
 

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -111,7 +111,7 @@ class LongWaitDetected extends Notification
                 ->image($imageUrl)
                 ->text($text)
                 ->headerBlock($title)
-                ->sectionBlock(function (SectionBlock $block) use ($content): void {
+                ->sectionBlock(function (SectionBlock $block) use ($content): void { // @phpstan-ignore-line
                     $block->text($content);
                 });
         }

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -106,7 +106,7 @@ class LongWaitDetected extends Notification
         );
 
         if (class_exists('Illuminate\Notifications\Slack\SlackMessage') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
-            return (new ChannelIdSlackMessage) // @phpstan-ignore-line
+            return (new ChannelIdSlackMessage)
                 ->username($fromName)
                 ->image($imageUrl)
                 ->text($text)

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -105,7 +105,7 @@ class LongWaitDetected extends Notification
             $this->seconds
         );
 
-        if (class_exists('Illuminate\Notifications\Slack\SlackMessage') && class_exists('Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
+        if (class_exists('\Illuminate\Notifications\Slack\SlackMessage') && class_exists('\Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock') && !(is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
             return (new ChannelIdSlackMessage)
                 ->username($fromName)
                 ->image($imageUrl)


### PR DESCRIPTION
Reference: https://github.com/laravel/framework/discussions/51879

Laravel 11 supports Slack notifications with not only webhook urls but also using a Slack app, but this repository is configured only for webhook urls. Added a new condition to check if the supplied destination is a webhook url or channel id and return the appropriate response.

![Screenshot-003236-2024-07-25at22 18 01@2x](https://github.com/user-attachments/assets/7f314882-a11f-4b86-a7dd-bafe2c265f4a)
