### PR TITLE
Add missing keys that should be cleared when running `horizon:clear-metrics`

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -384,8 +384,13 @@ class RedisMetricsRepository implements MetricsRepository
         $this->forget('measured_jobs');
         $this->forget('measured_queues');
         $this->forget('metrics:snapshot');
+        $this->forget('completed_jobs');
+        $this->forget('recent_jobs');
+        $this->forget('failed_jobs');
+        $this->forget('recent_failed_jobs');
+        $this->forget('pending_jobs');
 
-        foreach (['queue:*', 'job:*', 'snapshot:*'] as $pattern) {
+        foreach (['queue:*', 'job:*', 'snapshot:*', 'failed:*'] as $pattern) {
             $cursor = null;
 
             do {


### PR DESCRIPTION
This update enhances the `clear()` method to include additional Redis keys, ensuring that the `horizon:clear-metrics` command comprehensively removes all relevant metrics stored in the cache.

#### Dashboard State Comparison
- Before Executing `horizon:clear-metrics`:
![Screenshot from 2024-07-28 08-37-56](https://github.com/user-attachments/assets/bd58dfbd-3bec-4e88-8f9b-eb57128cb832)

- After Executing `horizon:clear-metrics` (Current Version):
![Screenshot from 2024-07-28 08-38-17](https://github.com/user-attachments/assets/817f0682-d550-4c4c-903f-4e0c280e187b)

- After Updating the `clear()` Method:
![Screenshot from 2024-07-28 08-53-01](https://github.com/user-attachments/assets/ec9004b7-89ba-4f4a-8160-5ad56cc15e6d)

## Note on Job Hashes in Cache
Currently, `job hashes` remain in the cache, as illustrated below. Ideally, these should also be cleared. However, removing them without flushing the entire Redis queue connection or using wildcard patterns `('*')` is not feasible unless the specific keys to target are known.

A potential improvement would be to store job hashes under a specific key, such as `jobs`, to facilitate direct targeting.

![Screenshot from 2024-07-28 09-10-00](https://github.com/user-attachments/assets/36b70fbe-3f0a-4d93-89ab-ecbc85d849f6)
