### PR TITLE
Fix error when loading monitoried tags page(#1478)

### DIFF
--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -70,7 +70,7 @@
 
                 tag = this.type == 'failed' ? 'failed:' + tag : tag;
 
-                this.$http.get(Horizon.basePath + '/api/monitoring/' + encodeURIComponent(tag) + '?starting_at=' + starting + '&limit=' + this.perPage)
+                this.$http.get(Horizon.basePath + '/api/monitoring/' + encodeURIComponent(tag) + '?starting_at=' + starting + '&limit=' + this.perPage + '&tag=' + encodeURIComponent(tag))
                     .then(response => {
                         if (!this.$root.autoLoadsNewEntries && refreshing && this.jobs.length && response.data.jobs[0]?.id !== this.jobs[0]?.id) {
                             this.hasNewEntries = true;

--- a/src/Http/Controllers/MonitoringController.php
+++ b/src/Http/Controllers/MonitoringController.php
@@ -58,11 +58,12 @@ class MonitoringController extends Controller
      * Paginate the jobs for a given tag.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  string  $tag
      * @return array
      */
-    public function paginate(Request $request, $tag)
+    public function paginate(Request $request)
     {
+        $tag = $request->query('tag');
+
         $jobIds = $this->tags->paginate(
             $tag, $startingAt = $request->query('starting_at', 0),
             $request->query('limit', 25)

--- a/tests/Controller/MonitoringControllerTest.php
+++ b/tests/Controller/MonitoringControllerTest.php
@@ -47,7 +47,7 @@ class MonitoringControllerTest extends ControllerTest
 
         // Paginate first set...
         $response = $this->actingAs(new Fakes\User)
-                    ->get('/horizon/api/monitoring/tag');
+                    ->get('/horizon/api/monitoring/tag?tag=tag');
 
         $results = $response->original['jobs'];
 
@@ -57,7 +57,7 @@ class MonitoringControllerTest extends ControllerTest
 
         // Paginate second set...
         $response = $this->actingAs(new Fakes\User)
-                    ->get('/horizon/api/monitoring/tag?starting_at=25');
+                    ->get('/horizon/api/monitoring/tag?starting_at=25&tag=tag');
 
         $results = $response->original['jobs'];
 


### PR DESCRIPTION
This PR fixes an issue when viewing the show page of a monitored tag
```
Too few arguments to function Laravel\\Horizon\\Http\\Controllers\\MonitoringController::paginate(), 1 passed in 
```

The underlying cause of this error is `MonitoringController::paginate()` was expecting the request, and a `$tag` parameter. Since the non-API routes are defined in Vue Router, Laravel is not resolving the `{tag}` parameter in the controller with route model binding.

In light of that, I added `tag` as a querystring parameter as well so we can grab the value with `$request->query('tag')`. 

I am not sure this is the best way to fix this, but after trying a few different ways, this seemed like the only solution.
