### PR TITLE
[5.x] Reanimate asset compilation

### DIFF
--- a/.github/workflows/compile-assets.yml
+++ b/.github/workflows/compile-assets.yml
@@ -7,4 +7,5 @@ jobs:
     uses: laravel/.github/.github/workflows/compile-assets.yml@main
     with:
       cmd: build
+      build_path: "dist/"
       node: "21"


### PR DESCRIPTION
PR #1438 moved built assets directory from `/public/build` to `/dist`. This PR fixes corresponding workflow to also point to `/dist` directory. Closes #1478.