### PR TITLE
an option to split queues for auto balancing

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -170,6 +170,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Process Per Queue
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to execute separate processes for every
+    | supervisor's queue if the balancing strategy is "auto".
+    | Disabling it will stop splitting queues so the worker will
+    | will handle many queues
+    |
+    */
+
+    'process_per_queue' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Queue Worker Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -80,9 +80,9 @@ class RedisWorkloadRepository implements WorkloadRepository
 
                 $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses, &$wait) {
                     return [
-                        'name' => $queueName,
+                        'name' => "$queueName",
                         'length' => $length,
-                        'wait' => $wait += $this->waitTime->calculateTimeToClear($connection, $queueName, $totalProcesses),
+                        'wait' => $wait += $this->waitTime->calculateTimeToClear($connection, "$queueName", $totalProcesses),
                     ];
                 }) : null;
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -87,7 +87,7 @@ class Supervisor implements Pausable, Restartable, Terminable
      */
     public function createProcessPools()
     {
-        return $this->options->balancing()
+        return $this->options->balancing() && config('horizon.process_per_queue', true)
                         ? $this->createProcessPoolPerQueue()
                         : $this->createSingleProcessPool();
     }


### PR DESCRIPTION
When using the "auto" balancing, Horizon always split the queues.

I added a new option to control whether Horizon should split the queues.

https://github.com/laravel/framework/discussions/52945