### PR TITLE
horizon base path and app url conflicts

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -33,20 +33,29 @@ const app = createApp({
 
 app.config.globalProperties.$http = axios.create();
 
-window.Horizon.basePath = '/' + window.Horizon.path;
+const appUrl = window.Horizon.appUrl || '';
+const horizonPath = window.Horizon.path || 'horizon';
 
+// Construct the base path dynamically using APP_URL and HORIZON_PATH
+// Check if appUrl ends with a slash and handle accordingly
+window.Horizon.basePath = appUrl.replace(/\/+$/, '') + '/' + horizonPath.replace(/^\/+/, '');
+
+// Construct the router base path using the newly set basePath
 let routerBasePath = window.Horizon.basePath + '/';
 
-if (window.Horizon.path === '' || window.Horizon.path === '/') {
-    routerBasePath = '/';
-    window.Horizon.basePath = '';
+// Adjust the base path if Horizon's path is empty or set to root
+if (horizonPath === '' || horizonPath === '/') {
+    routerBasePath = appUrl + '/';
+    window.Horizon.basePath = appUrl;
 }
 
+// Use the constructed base path in the router configuration
 const router = createRouter({
     history: createWebHistory(routerBasePath),
     routes: Routes,
 });
 
+// Use the router in the Vue app
 app.use(router);
 
 app.component('vue-json-pretty', VueJsonPretty);


### PR DESCRIPTION
### Issue
This PR addresses the issue where Laravel Horizon's `basePath` is incorrectly constructed when the `APP_URL` has a suffix or when `HORIZON_PATH` is not properly handled. This causes 404 errors when accessing Horizon routes like `/jobs` and other resources.

### Solution
- The code dynamically constructs `window.Horizon.basePath` using `APP_URL` and `HORIZON_PATH`, ensuring that any suffix or prefix is handled correctly.
- It removes trailing slashes from `APP_URL` and leading slashes from `HORIZON_PATH` to avoid double slashes in the path.
- Adjustments are made in the router configuration to ensure compatibility with different path structures.

### Example Scenarios
1. `APP_URL=https://example.com` and `HORIZON_PATH=horizon` results in `window.Horizon.basePath = 'https://example.com/horizon'`.
2. `APP_URL=https://example.com/suffix` and `HORIZON_PATH=horizon` results in `window.Horizon.basePath = 'https://example.com/suffix/horizon'`.
3. `APP_URL=https://example.com` and `HORIZON_PATH=/horizon` results in `window.Horizon.basePath = 'https://example.com/horizon'`.

### Impact
This change ensures that Horizon's base path is constructed correctly for all configurations of `APP_URL` and `HORIZON_PATH`, preventing 404 errors and enhancing compatibility for users with custom URL setups.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
