### PR TITLE
quick fix to sync get rid of the  The "json" option does not exist warning 

### DIFF
--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -28,7 +28,8 @@ class WorkCommand extends BaseWorkCommand
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--supervisor= : The name of the supervisor the worker belongs to}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+                            {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--json : Output the queue worker information as JSON}';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -29,7 +29,7 @@ class WorkCommand extends BaseWorkCommand
                             {--supervisor= : The name of the supervisor the worker belongs to}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}
-                            {--json : Output the queue worker information as JSON}';
+                            {--json : This is just a placeholder to make the command compatible with the Horizon Queue}';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -29,7 +29,7 @@ class WorkCommand extends BaseWorkCommand
                             {--supervisor= : The name of the supervisor the worker belongs to}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}
-                            {--json : This is just a placeholder to make the command compatible with the Horizon Queue}';
+                            {--json : This is just a placeholder to make the command compatible with the framework queue}';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.


### PR DESCRIPTION
After upgrading to the latest Framework 11.27 the queue worker introduced a json option. Horizon does't have that option so the worker won't start and starts complaining about `The "json" option does not exist.  `

This is a quick fix, since I don't know the grans scheme of this new option related to horizon. 