### PR TITLE
Improvment: Wont spawn extra queues

### DIFF
--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -111,7 +111,9 @@ class ProvisioningPlan
         }
 
         foreach ($supervisors as $supervisor => $options) {
-            $this->add($options);
+            if ($options->maxProcesses > 0) {
+                $this->add($options);
+            }
         }
 
         event(new MasterSupervisorDeployed($this->master));


### PR DESCRIPTION
Consider the follow setup:

```php

 'defaults' => [
        'supervisor-1' => [
            'connection' => 'redis',
            'queue' => ['default'],
            'balance' => 'auto',
            'autoScalingStrategy' => 'time',
            'maxProcesses' => 1,
            'maxTime' => 0,
            'maxJobs' => 0,
            'memory' => 128,
            'tries' => 1,
            'timeout' => 60,
            'nice' => 0,
        ],
       'supervisor-2' => [
            'connection' => 'redis',
            'queue' => ['high'],
            'balance' => 'auto',
            'autoScalingStrategy' => 'time',
            'maxProcesses' => 1,
            'maxTime' => 0,
            'maxJobs' => 0,
            'memory' => 128,
            'tries' => 1,
            'timeout' => 60,
            'nice' => 0,
        ],
    ],


'production-1' => [
          'supervisor-1' => [
              'maxProcesses' => 10,
              'balanceMaxShift' => 1,
              'balanceCooldown' => 3,
          ],
      ],

'production-2' => [
          'supervisor-2' => [
              'maxProcesses' => 10,
              'balanceMaxShift' => 1,
              'balanceCooldown' => 3,
          ],
      ],
```

Currently, in every environment, the MasterSupervisor run all the supervisors queues.

In a multi server deployment,  if you spawn horizon on second server with the --environment=production-2, you always get a production-1 supervisors too (default queue in this case) (picture 1).
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/808f939b-299f-4292-8fd9-c88e69891bb5">


With this change, we can selectible choice the supervisors that we want to run on each enviroments, just checking for the maxProcess > 0.

Imagine that you want a  horizon instance to only process slow queues, or you have a high power vm/cpu/vps that you just want to run specific queue.

I cant figure out how to dead with this cenario, without this change.

Maybe we can put a global config, to 'dont spawn queues not listed in supervisor'...

What do you think about?

```
    'production-2' => [
            'supervisor-1' => [
                **'maxProcesses' => 0,**
            ],
            'supervisor-2' => [
                'maxProcesses' => 10,
                'balanceMaxShift' => 1,
                'balanceCooldown' => 3,
            ],
        ],
```

<img width="1271" alt="Screenshot 2024-10-14 at 16 42 57" src="https://github.com/user-attachments/assets/1c3d1278-2e5e-4d3b-98be-2330a38ed5bd">
