### PR TITLE
Remove the verbiage to publish assets in the upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,11 +1,4 @@
-# Upgrade Guide
-
-With every upgrade, make sure to publish Horizon's assets and clear the view cache:
-
-    php artisan horizon:publish
-    
-    php artisan view:clear
-    
+# Upgrade Guide 
 
 ## Upgrading To 5.0 From 4.x
 


### PR DESCRIPTION
The need to publish Horizon's assets was removed in https://github.com/laravel/horizon/pull/1438. This PR removes the verbiage to publish Horizon's assets after upgrading.