### PR TITLE
Allow to specify connection in ClearCommand

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -21,6 +21,7 @@ class ClearCommand extends Command
      * @var string
      */
     protected $signature = 'horizon:clear
+                            {connection? : The name of the queue connection}
                             {--queue= : The name of the queue to clear}
                             {--force : Force the operation to run when in production}';
 
@@ -48,7 +49,8 @@ class ClearCommand extends Command
             return 1;
         }
 
-        $connection = Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
+        $connection = $this->argument('connection')
+            ?: Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
 
         if (method_exists($jobRepository, 'purge')) {
             $jobRepository->purge($queue = $this->getQueue($connection));


### PR DESCRIPTION
This pull request updates the `horizon:clear` command to allow specifying the connection as an argument. The arguments and options will now match those of Laravel's `queue:clear` command, making both commands consistent and easy to remember.

Example usage:
- `php artisan queue:clear redis --queue=emails`
- `php artisan horizon:clear redis --queue=emails`

Why is it useful?

It will be useful to people who make use of multiple connections. Adding this feature makes it easier to target a specific connection when running `horizon:clear`. Other Horizon commands already support specifying the connection.