### PR TITLE
Add support for notification class overrides

### DIFF
--- a/src/Contracts/LongWaitDetectedNotification.php
+++ b/src/Contracts/LongWaitDetectedNotification.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Horizon\Contracts;
+
+interface LongWaitDetectedNotification
+{
+    //
+}

--- a/src/Events/LongWaitDetected.php
+++ b/src/Events/LongWaitDetected.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Horizon\Events;
 
-use Laravel\Horizon\Horizon;
-use Laravel\Horizon\Notifications\LongWaitDetected as LongWaitDetectedNotification;
+use Illuminate\Container\Container;
+use Laravel\Horizon\Contracts\LongWaitDetectedNotification;
 
 class LongWaitDetected
 {
@@ -50,10 +50,10 @@ class LongWaitDetected
      */
     public function toNotification()
     {
-        $notificationClass = Horizon::$notificationOverrides[$this::class] ?: LongWaitDetectedNotification::class;
-
-        return new $notificationClass(
-            $this->connection, $this->queue, $this->seconds
-        );
+        return Container::getInstance()->make(LongWaitDetectedNotification::class, [
+            'connection' => $this->connection,
+            'queue' => $this->queue,
+            'seconds' => $this->seconds,
+        ]);
     }
 }

--- a/src/Events/LongWaitDetected.php
+++ b/src/Events/LongWaitDetected.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Events;
 
+use Laravel\Horizon\Horizon;
 use Laravel\Horizon\Notifications\LongWaitDetected as LongWaitDetectedNotification;
 
 class LongWaitDetected
@@ -49,7 +50,9 @@ class LongWaitDetected
      */
     public function toNotification()
     {
-        return new LongWaitDetectedNotification(
+        $notificationClass = Horizon::$notificationOverrides[$this::class] ?: LongWaitDetectedNotification::class;
+
+        return new $notificationClass(
             $this->connection, $this->queue, $this->seconds
         );
     }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -55,6 +55,14 @@ class Horizon
     public static $useDarkTheme = false;
 
     /**
+     * The custom notifications to use.
+     *
+     * @var array
+     */
+    public static $notificationOverrides;
+
+
+    /**
      * The database configuration methods.
      *
      * @var array
@@ -221,6 +229,19 @@ class Horizon
     public static function routeSmsNotificationsTo($number)
     {
         static::$smsNumber = $number;
+
+        return new static;
+    }
+
+    /**
+     * Specify any custom notification classes which should be used.
+     *
+     * @param  array  $overrides
+     * @return static
+     */
+    public static function overrideNotifications($overrides)
+    {
+        static::$notificationOverrides = $overrides;
 
         return new static;
     }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -55,14 +55,6 @@ class Horizon
     public static $useDarkTheme = false;
 
     /**
-     * The custom notifications to use.
-     *
-     * @var array
-     */
-    public static $notificationOverrides;
-
-
-    /**
      * The database configuration methods.
      *
      * @var array
@@ -229,19 +221,6 @@ class Horizon
     public static function routeSmsNotificationsTo($number)
     {
         static::$smsNumber = $number;
-
-        return new static;
-    }
-
-    /**
-     * Specify any custom notification classes which should be used.
-     *
-     * @param  array  $overrides
-     * @return static
-     */
-    public static function overrideNotifications($overrides)
-    {
-        static::$notificationOverrides = $overrides;
 
         return new static;
     }

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -10,9 +10,10 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
 use Illuminate\Notifications\Slack\SlackMessage as ChannelIdSlackMessage;
 use Illuminate\Support\Str;
+use Laravel\Horizon\Contracts\LongWaitDetectedNotification;
 use Laravel\Horizon\Horizon;
 
-class LongWaitDetected extends Notification
+class LongWaitDetected extends Notification implements LongWaitDetectedNotification
 {
     use Queueable;
 

--- a/src/ServiceBindings.php
+++ b/src/ServiceBindings.php
@@ -27,5 +27,8 @@ trait ServiceBindings
         Contracts\SupervisorRepository::class => Repositories\RedisSupervisorRepository::class,
         Contracts\TagRepository::class => Repositories\RedisTagRepository::class,
         Contracts\WorkloadRepository::class => Repositories\RedisWorkloadRepository::class,
+
+        // Notifications...
+        Contracts\LongWaitDetectedNotification::class => Notifications\LongWaitDetected::class,
     ];
 }

--- a/tests/Feature/NotificationOverridesTest.php
+++ b/tests/Feature/NotificationOverridesTest.php
@@ -25,6 +25,17 @@ class NotificationOverridesTest extends IntegrationTest
 
         Notification::assertSentOnDemand(CustomLongWaitDetectedNotification::class);
     }
+
+    public function test_normal_notifications_are_sent_if_not_specified()
+    {
+        Notification::fake();
+
+        Horizon::routeMailNotificationsTo('taylor@laravel.com');
+
+        event(new LongWaitDetected('redis', 'test-queue-2', 60));
+
+        Notification::assertSentOnDemand(LongWaitDetectedNotification::class);
+    }
 }
 
 class CustomLongWaitDetectedNotification extends LongWaitDetectedNotification implements LongWaitDetectedNotificationContract

--- a/tests/Feature/NotificationOverridesTest.php
+++ b/tests/Feature/NotificationOverridesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\Horizon;
+use Laravel\Horizon\Notifications\LongWaitDetected as LongWaitDetectedNotification;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class NotificationOverridesTest extends IntegrationTest
+{
+    public function test_custom_notifications_are_sent_if_specified()
+    {
+        Notification::fake();
+
+        $customNotification = new class('redis', 'test-queue-2', 60) extends LongWaitDetectedNotification {
+            public function toMail($notifiable)
+            {
+                return (new MailMessage)
+                    ->line('This is a custom notification for a long wait.');
+            }
+        };
+
+        Horizon::routeMailNotificationsTo('taylor@laravel.com');
+
+        Horizon::overrideNotifications([
+            LongWaitDetected::class => get_class($customNotification)
+        ]);
+
+        event(new LongWaitDetected('redis', 'test-queue-2', 60));
+
+        Notification::assertSentOnDemand(get_class($customNotification));
+    }
+}


### PR DESCRIPTION
Back in July I raised issue #1475, because my team wanted to be able to customise the notification that was sent when a long wait occurs. I was told to attempt a PR and this is certainly... an attempt. Please be nice, this is my first ever PR into an open source project.

**Usage**
```
// Pass a map of $event => $notification into the function
Horizon::overrideNotifications([
    LongWaitDetected::class => MyCustomNotification::class
]);
```

**Considerations**
- Currently Horizon has only one notification class (`LongWaitDetected`), but this implementation is designed with future extensibility in mind. Using a map provides flexibility for additional notifications if they are introduced, instead of being limited to a single notification override.
- Any future Horizon events would also need to include similar logic to `LongWaitDetected::toNotification()` to determine whether to construct a custom notification. I considered alternative, more abstract approaches, but they would involve more significant changes to the codebase.
- For compatibility, custom notification classes must extend the original notification associated with the event.

I am quite expecting this PR to be declined, but if that is so, I would greatly appreciate any feedback - as mentioned above this is my first contribution to an open source project so your feedback/advice is genuinely valuable to me. Thanks.