### PR TITLE
Replace implicitly nullable parameters for PHP 8.4

### DIFF
--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -69,7 +69,7 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
      * @param  string  $environment
      * @return void
      */
-    public function __construct(string $environment = null)
+    public function __construct(?string $environment = null)
     {
         $this->environment = $environment;
 

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -51,7 +51,7 @@ class ProcessPool implements Countable
      * @param  \Closure|null  $output
      * @return void
      */
-    public function __construct(SupervisorOptions $options, Closure $output = null)
+    public function __construct(SupervisorOptions $options, ?Closure $output = null)
     {
         $this->options = $options;
 

--- a/src/SupervisorProcess.php
+++ b/src/SupervisorProcess.php
@@ -50,7 +50,7 @@ class SupervisorProcess extends WorkerProcess
      * @param  \Closure|null  $output
      * @return void
      */
-    public function __construct(SupervisorOptions $options, $process, Closure $output = null)
+    public function __construct(SupervisorOptions $options, $process, ?Closure $output = null)
     {
         $this->options = $options;
         $this->name = $options->name;


### PR DESCRIPTION
This PR removes implicitly nullable parameters because of deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

