### PR TITLE
fix predis `clear()` when using redis 7.4

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -390,7 +390,7 @@ class RedisMetricsRepository implements MetricsRepository
 
             do {
                 [$cursor, $keys] = $this->connection()->scan(
-                    $cursor, ['match' => config('horizon.prefix').$pattern]
+                    $cursor ?? 0, ['match' => config('horizon.prefix').$pattern]
                 );
 
                 foreach ($keys ?? [] as $key) {


### PR DESCRIPTION
Hi! We noticed that `horizon:clear-metrics` stopped working after upgrading Redis from 7.2.6 to 7.4.1.

To reproduce, run:

```sh
laravel new example-app -n
cd example-app
composer require "laravel/horizon:5.30" "predis/predis:2.3.0"
REDIS_CLIENT=predis php artisan horizon:clear-metrics
```

When using Redis 7.2.6:
```sh
   INFO  Metrics cleared successfully. 
```

When using Redis 7.4.0 or 7.4.1:
```sh
   Predis\Response\ServerException 

  ERR invalid cursor

  at vendor/predis/predis/src/Client.php:416
    412▕             return $response;
    413▕         }
    414▕ 
    415▕         if ($this->options->exceptions) {
  ➜ 416▕             throw new ServerException($response->getMessage());
    417▕         }
    418▕ 
    419▕         return $response;
    420▕     }

      +19 vendor frames 

  20  artisan:13
      Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))
```

A similar issue was recently fixed in [symfony/cache](https://github.com/symfony/symfony/pull/58753), and applying that fix to Horizon seems to fix the problem when testing locally against the three Redis versions mentioned.