### PR TITLE
fix: cluster redis eval return false

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -154,7 +154,7 @@ class RedisQueue extends BaseQueue
     public function migrateExpiredJobs($from, $to)
     {
         return tap(parent::migrateExpiredJobs($from, $to), function ($jobs) use ($to) {
-            $this->event($to, new JobsMigrated($jobs));
+            $this->event($to, new JobsMigrated($jobs === false ? [] : $jobs));
         });
     }
 


### PR DESCRIPTION
when queue name is **default** in cluster redis, **eval** will return  (queue name must "{xxxx}")
```
ERR 'EVAL' command keys must in same slot
```
`parent::migrateExpiredJobs` will return false,
 `JobPayload::id()` is error Trying to access array offset on value of type null

at https://github.com/laravel/horizon/issues/924