### PR TITLE
Scale workers from min instead of max on startup

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -97,7 +97,7 @@ class SupervisorCommand extends Command
         $supervisor->working = ! $this->option('paused');
 
         $supervisor->scale(max(
-            0, $this->option('max-processes') - $supervisor->totalSystemProcessCount()
+            0, $this->option('min-processes') - $supervisor->totalSystemProcessCount()
         ));
 
         $supervisor->monitor();

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -96,8 +96,9 @@ class SupervisorCommand extends Command
 
         $supervisor->working = ! $this->option('paused');
 
+        $balancedWorkerCount = floor(($this->option('min-processes') + $this->option('max-processes')) / 2);
         $supervisor->scale(max(
-            0, $this->option('min-processes') - $supervisor->totalSystemProcessCount()
+            0, $balancedWorkerCount - $supervisor->totalSystemProcessCount()
         ));
 
         $supervisor->monitor();


### PR DESCRIPTION
When Laravel Horizon starts, it currently spawns the maximum number of workers defined by `maxProcesses`, rather than starting with `minProcesses` and scaling up as needed.  

With this change, Horizon will now start with the **minimum** number of workers and scale up dynamically as required. This improvement is especially beneficial for users utilizing **auto compute scaling**, as it eliminates unnecessary scaling, leading to **reduced infrastructure costs**.  

This change addresses issue [#1536](https://github.com/laravel/horizon/issues/1536).  
