### PR TITLE
[5.x] Specify `WorkloadRepository@get()` return type

### DIFF
--- a/src/Contracts/WorkloadRepository.php
+++ b/src/Contracts/WorkloadRepository.php
@@ -7,7 +7,7 @@ interface WorkloadRepository
     /**
      * Get the current workload of each queue.
      *
-     * @return array
+     * @return array<int, array{"name": string, "length": int, "wait": int, "processes": int, "split_queues": null|array<int, {"name": string, "wait": int, "length": int}>}>
      */
     public function get();
 }

--- a/src/Contracts/WorkloadRepository.php
+++ b/src/Contracts/WorkloadRepository.php
@@ -7,7 +7,7 @@ interface WorkloadRepository
     /**
      * Get the current workload of each queue.
      *
-     * @return array<int, array{"name": string, "length": int, "wait": int, "processes": int, "split_queues": null|array<int, {"name": string, "wait": int, "length": int}>}>
+     * @return array<int, array{"name": string, "length": int, "wait": int, "processes": int, "split_queues": null|array<int, array{"name": string, "wait": int, "length": int}>}>
      */
     public function get();
 }

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -60,7 +60,7 @@ class RedisWorkloadRepository implements WorkloadRepository
     /**
      * Get the current workload of each queue.
      *
-     * @return array
+     * @return array<int, array{"name": string, "length": int, "wait": int, "processes": int, "split_queues": null|array<int, array{"name": string, "wait": int, "length": int}>}>
      */
     public function get()
     {


### PR DESCRIPTION
I'm building a library to monitor Horizon metrics via statsd. This clarified return type aids in static analysis.

<details>
<summary>Before and after</summary>
Before:
<img width="960" alt="image" src="https://github.com/user-attachments/assets/634c2d6c-a5a0-46d1-89ed-ce681c222e18" />


After: 
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/9b620294-c95f-41b3-8291-b7d6cf53a38a" />

</details>