### PR TITLE
[5.x] Update metrics configuration comment to use assertive language

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -128,7 +128,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you can configure how many snapshots should be kept to display in
-    | the metrics graph. This will get used in combination with Horizon's
+    | the metrics graph. This must be used in combination with Horizon's
     | `horizon:snapshot` schedule to define how long to retain metrics.
     |
     */


### PR DESCRIPTION
Changed the comment in the metrics configuration section to use "must" instead of "will" when referring to the usage of Horizon's `horizon:snapshot` schedule.
This makes the requirement clearer and more directive for developers reading the config.
