### PR TITLE
Fixed deprecation warning  `Creation of dynamic property Laravel\Horizon\SupervisorOptions::$retryAfter`

### DIFF
--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -166,6 +166,13 @@ class SupervisorOptions
     public $rest;
 
     /**
+     * The number of seconds to wait before retrying a job that encountered an uncaught exception.
+     *
+     * @var int
+     */
+    public $retryAfter;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name


### PR DESCRIPTION
### Problem
I was finding in the logs deprecations warnings which are causing a mess in my log files
```
[2025-04-16 09:21:53] local.WARNING: Creation of dynamic property Laravel\Horizon\SupervisorOptions::$retryAfter is deprecated in /app/vendor/laravel/horizon/src/SupervisorOptions.php on line 353  
[2025-04-16 09:52:40] local.WARNING: Creation of dynamic property Laravel\Horizon\SupervisorOptions::$retryAfter is deprecated in /app/vendor/laravel/horizon/src/SupervisorOptions.php on line 353  
[2025-04-16 09:52:40] local.WARNING: Creation of dynamic property Laravel\Horizon\SupervisorOptions::$retryAfter is deprecated in /app/vendor/laravel/horizon/src/SupervisorOptions.php on line 353  
```

### Solution
I added new `SupervisorOptions` property called `$retryAfter`. I didn't find any uses of `retryAfter`, `retry_after` and `retry-after` property in repo, so I just added a property without adding it to `toArray` on constructor methods

### Benefits
Clearer log files!

### Impact
None