### PR TITLE
[5.x] Store memory used when dispatching `SupervisorOutOfMemory`

### DIFF
--- a/src/Events/SupervisorOutOfMemory.php
+++ b/src/Events/SupervisorOutOfMemory.php
@@ -18,7 +18,7 @@ class SupervisorOutOfMemory
      *
      * @var float|int
      */
-    protected $memoryUsage;
+    public $memoryUsage;
 
     /**
      * Create a new event instance.
@@ -32,9 +32,19 @@ class SupervisorOutOfMemory
     }
 
     /**
+     * Get the memory usage that triggered the event.
+     *
+     * @return int|float
+     */
+    public function getMemoryUsage()
+    {
+        return $this->memoryUsage ?? $this->supervisor->memoryUsage();
+    }
+
+    /**
      * Set the memory usage that was recorded when the event was dispatched.
      *
-     * @param float|int $memoryUsage
+     * @param  int|float $memoryUsage
      * @return $this
      */
     public function setMemoryUsage($memoryUsage)
@@ -42,15 +52,5 @@ class SupervisorOutOfMemory
         $this->memoryUsage = $memoryUsage;
 
         return $this;
-    }
-
-    /**
-     * Get the memory usage that triggered the event.
-     *
-     * @return float|int
-     */
-    public function getMemoryUsage()
-    {
-        return $this->memoryUsage ?? $this->supervisor->memoryUsage();
     }
 }

--- a/src/Events/SupervisorOutOfMemory.php
+++ b/src/Events/SupervisorOutOfMemory.php
@@ -14,6 +14,13 @@ class SupervisorOutOfMemory
     public $supervisor;
 
     /**
+     * The memory usage that exceeded the allowable limit.
+     *
+     * @var float|int
+     */
+    protected $memoryUsage;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\Supervisor  $supervisor
@@ -22,5 +29,28 @@ class SupervisorOutOfMemory
     public function __construct(Supervisor $supervisor)
     {
         $this->supervisor = $supervisor;
+    }
+
+    /**
+     * Set the memory usage that was recorded when the event was dispatched.
+     *
+     * @param float|int $memoryUsage
+     * @return $this
+     */
+    public function setMemoryUsage($memoryUsage)
+    {
+        $this->memoryUsage = $memoryUsage;
+
+        return $this;
+    }
+
+    /**
+     * Get the memory usage that triggered the event.
+     *
+     * @return float|int
+     */
+    public function getMemoryUsage()
+    {
+        return $this->memoryUsage ?? $this->supervisor->memoryUsage();
     }
 }

--- a/src/Events/SupervisorOutOfMemory.php
+++ b/src/Events/SupervisorOutOfMemory.php
@@ -16,7 +16,7 @@ class SupervisorOutOfMemory
     /**
      * The memory usage that exceeded the allowable limit.
      *
-     * @var float|int
+     * @var int|float
      */
     public $memoryUsage;
 

--- a/src/Listeners/MonitorSupervisorMemory.php
+++ b/src/Listeners/MonitorSupervisorMemory.php
@@ -17,8 +17,8 @@ class MonitorSupervisorMemory
     {
         $supervisor = $event->supervisor;
 
-        if ($supervisor->memoryUsage() > $supervisor->options->memory) {
-            event(new SupervisorOutOfMemory($supervisor));
+        if (($memoryUsage = $supervisor->memoryUsage()) > $supervisor->options->memory) {
+            event((new SupervisorOutOfMemory($supervisor))->setMemoryUsage($memoryUsage));
 
             $supervisor->terminate(12);
         }


### PR DESCRIPTION
There could be some discrepancy between a supervisor's memory at the time the event is dispatched and when a user calls `Supervisor::memoryUsage()`.

```php
Event::listen(
    SupervisorOutOfMemory::class,
    function(SupervisorOutOfMemory $event) {
        Log::warning(
            "Supervisor {$event->supervisor->name} has exceeded memory limits. Current memory: " . $event->supervisor->memoryUsage()
        );
});
```

Instead, we can do this and have the memory that triggered the OOM event.

```php
Event::listen(
    SupervisorOutOfMemory::class,
    function(SupervisorOutOfMemory $event) {
        Log::warning(
            "Supervisor {$event->supervisor->name} has exceeded memory limits. Current memory: " . $event->getMemoryUsage()
        );
});
```

---
This could be added to the constructor of the event. Feels like this is potentially a breaking change?

Can follow up to add this to `MasterSupervisorOutOfMemory` as well.