### PR TITLE
[5.x] Showing horizon job stats in the php artisan horizon:status command

### DIFF
--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon\Console;
 
 use Illuminate\Console\Command;
+use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -46,7 +47,9 @@ class StatusCommand extends Command
         }
 
         $this->components->info('Horizon is running.');
-
+        $jobMetrics = resolve(JobRepository::class);
+        $this->line('Processed Jobs: ' . $jobMetrics->countCompleted());
+        $this->line('Failed Jobs: ' . $jobMetrics->countFailed());
         return 0;
     }
 }


### PR DESCRIPTION
This PR lets the user see the number of processed and failed jobs from the php artisan horizon:status command.

![SuccessMsg](https://github.com/user-attachments/assets/3044aef8-76c1-40b4-a352-65919f95bd97)
