### PR TITLE
Set AutoScaler logic to target process scaling based on queue size wh…

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -106,6 +106,15 @@ class AutoScaler
         $totalJobs = $queues->sum('size');
 
         return $queues->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll, $totalJobs) {
+            if (! $supervisor->options->balancing()) {
+                $targetProcesses = min(
+                    $supervisor->options->maxProcesses,
+                    max($supervisor->options->minProcesses, $timeToClear['size'])
+                );
+
+                return [$queue => $targetProcesses];
+            }
+
             if ($timeToClearAll > 0 &&
                 $supervisor->options->autoScaling()) {
                 $numberOfProcesses = $supervisor->options->autoScaleByNumberOfJobs()
@@ -115,15 +124,6 @@ class AutoScaler
                 return [$queue => $numberOfProcesses *= $supervisor->options->maxProcesses];
             } elseif ($timeToClearAll == 0 &&
                       $supervisor->options->autoScaling()) {
-                if (! $supervisor->options->balancing()) {
-                    $targetProcesses = min(
-                        $supervisor->options->maxProcesses,
-                        max($supervisor->options->minProcesses, $timeToClear['size'])
-                    );
-
-                    return [$queue => $targetProcesses];
-                }
-
                 return [
                     $queue => $timeToClear['size']
                                 ? $supervisor->options->maxProcesses

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -115,6 +115,15 @@ class AutoScaler
                 return [$queue => $numberOfProcesses *= $supervisor->options->maxProcesses];
             } elseif ($timeToClearAll == 0 &&
                       $supervisor->options->autoScaling()) {
+                if (! $supervisor->options->balancing()) {
+                    $targetProcesses = min(
+                        $supervisor->options->maxProcesses,
+                        max($supervisor->options->minProcesses, $timeToClear['size'])
+                    );
+
+                    return [$queue => $targetProcesses];
+                }
+
                 return [
                     $queue => $timeToClear['size']
                                 ? $supervisor->options->maxProcesses

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -266,18 +266,10 @@ class AutoScalerTest extends IntegrationTest
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
             'default' => ['current' => 10, 'size' => 1, 'runtime' => 0],
-        ], ['autoScalingStrategy' => 'size', 'balance' => false]);
+        ], ['balance' => false]);
 
         $scaler->scale($supervisor);
 
         $this->assertSame(9, $supervisor->processPools['default']->totalProcessCount());
-
-        $scaler->scale($supervisor);
-
-        $this->assertSame(8, $supervisor->processPools['default']->totalProcessCount());
-
-        $scaler->scale($supervisor);
-
-        $this->assertSame(7, $supervisor->processPools['default']->totalProcessCount());
     }
 }

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -148,6 +148,9 @@ class AutoScalerTest extends IntegrationTest
         $this->assertSame(2, $supervisor->processPools['second']->totalProcessCount());
     }
 
+    /**
+     * @return array{0: AutoScaler, 1: Supervisor}
+     */
     protected function with_scaling_scenario($maxProcesses, array $pools, array $extraOptions = [])
     {
         // Mock dependencies...
@@ -257,5 +260,24 @@ class AutoScalerTest extends IntegrationTest
 
         $this->assertSame(52, $supervisor->processPools['first']->totalProcessCount());
         $this->assertSame(48, $supervisor->processPools['second']->totalProcessCount());
+    }
+
+    public function test_scaler_works_with_a_single_process_pool_with_no_runtime()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'default' => ['current' => 10, 'size' => 1, 'runtime' => 0],
+        ], ['autoScalingStrategy' => 'size', 'balance' => false]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(9, $supervisor->processPools['default']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(8, $supervisor->processPools['default']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(7, $supervisor->processPools['default']->totalProcessCount());
     }
 }

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -262,7 +262,7 @@ class AutoScalerTest extends IntegrationTest
         $this->assertSame(48, $supervisor->processPools['second']->totalProcessCount());
     }
 
-    public function test_scaler_works_with_a_single_process_pool_with_no_runtime()
+    public function test_scaler_works_with_a_single_process_pool()
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
             'default' => ['current' => 10, 'size' => 1, 'runtime' => 0],
@@ -271,5 +271,21 @@ class AutoScalerTest extends IntegrationTest
         $scaler->scale($supervisor);
 
         $this->assertSame(9, $supervisor->processPools['default']->totalProcessCount());
+
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'default' => ['current' => 10, 'size' => 1, 'runtime' => 1000],
+        ], ['balance' => false]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(9, $supervisor->processPools['default']->totalProcessCount());
+
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'default' => ['current' => 5, 'size' => 11, 'runtime' => 1000],
+        ], ['balance' => false]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(6, $supervisor->processPools['default']->totalProcessCount());
     }
 }


### PR DESCRIPTION
With 'balance' set to false, currently the autoscaler will target maxProcesses when there is >0 jobs in the queue, causing it to almost always ramp upwards.