### PR TITLE
Make $user = null the default in viewHorizon gate closure for better DX

### DIFF
--- a/stubs/HorizonServiceProvider.stub
+++ b/stubs/HorizonServiceProvider.stub
@@ -28,7 +28,7 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
     protected function gate(): void
     {
         Gate::define('viewHorizon', function ($user = null) {
-            return in_array($user->email, [
+            return in_array(optional($user)->email, [
                 //
             ]);
         });

--- a/stubs/HorizonServiceProvider.stub
+++ b/stubs/HorizonServiceProvider.stub
@@ -27,7 +27,7 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewHorizon', function ($user) {
+        Gate::define('viewHorizon', function ($user = null) {
             return in_array($user->email, [
                 //
             ]);


### PR DESCRIPTION
In the [Laravel Horizon documentation](https://laravel.com/docs/horizon#alternative-authentication-strategies), it's suggested that developers manually set the `$user` parameter in the `viewHorizon` gate closure to `null` when using alternative authentication strategies (e.g. cookie-based, IP-based access).

```php
Gate::define('viewHorizon', function (User $user = null) {
    return request()->cookie('horizon') === 'horizon';
});
```
While this workaround is documented, it would be more intuitive and developer-friendly to make $user = null the default behavior. When the auth middleware is not present, Laravel will not execute the developer-defined viewHorizon gate at all if the closure requires a User instance. Instead, Laravel silently falls back to an internal no-op closure, which can be confusing. The gate appears to be registered, but none of the intended logic is actually executed — and no error is thrown.

Making $user optional by default would ensure the gate logic is always reached and evaluated, even when no authenticated user is available. This improves clarity, reduces potential security misconfigurations, and enhances the developer experience for alternative authentication setups.