### PR TITLE
feat: Add `horizon_stats()` helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
     "autoload": {
         "psr-4": {
             "Laravel\\Horizon\\": "src/"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-if (function_exists('horizon_stats')) {
+if (!function_exists('horizon_stats')) {
     function horizon_stats()
     {
         $dashboard = new \Laravel\Horizon\Http\Controllers\DashboardStatsController();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,9 @@
+<?php
+
+if (function_exists('horizon_stats')) {
+    function horizon_stats()
+    {
+        $dashboard = new \Laravel\Horizon\Http\Controllers\DashboardStatsController();
+        return $dashboard->index();
+    }
+}


### PR DESCRIPTION
**Description:**
This PR introduces a `horizon_stats()` helper function to programmatically retrieve Laravel Horizon's status and statistics. This is useful for displaying Horizon data in custom application dashboards or for other monitoring purposes, especially when `php artisan horizon:status` is not directly usable (e.g., within web requests or when integrating with tools like Totem).
The function internally uses Horizon's `DashboardStatsController` to fetch the data, providing a simple way to access metrics like job counts, process status, and queue performance.
**Example Usage:**
```php
$stats = horizon_stats();
// $stats now holds an array of Horizon statistics.
{
    "failedJobs": 10,
    "jobsPerMinute": 1,
    "status": "running",
    // ... and other stats
}
```
This helper simplifies integrating Horizon monitoring into Laravel applications.