### PR TITLE
[5.x] Allow to specify job namespace in horizon:clear command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /phpunit.xml
 composer.lock
 .phpunit.result.cache
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 /phpunit.xml
 composer.lock
 .phpunit.result.cache
-.idea

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -23,6 +23,7 @@ class ClearCommand extends Command
     protected $signature = 'horizon:clear
                             {connection? : The name of the queue connection}
                             {--queue= : The name of the queue to clear}
+                            {--job= : The namespace of the job to clear}
                             {--force : Force the operation to run when in production}';
 
     /**
@@ -52,8 +53,25 @@ class ClearCommand extends Command
         $connection = $this->argument('connection')
             ?: Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
 
+        $queue = $this->getQueue($connection);
+        $job = $this->getJob();
+
+        if ($job) {
+            if (method_exists($jobRepository, 'purgeSpecificJob')) {
+                $jobRepository->purgeSpecificJob($queue, $job);
+            }
+
+            if (method_exists(RedisQueue::class, 'clearSpecificJob')) {
+                $count = $manager->connection($connection)->clearSpecificJob($queue, $job);
+            }
+
+            $this->components->info('Cleared ' . $count . ' jobs from the [' . $queue . '] queue.');
+
+            return 0;
+        }
+
         if (method_exists($jobRepository, 'purge')) {
-            $jobRepository->purge($queue = $this->getQueue($connection));
+            $jobRepository->purge($queue);
         }
 
         $count = $manager->connection($connection)->clear($queue);
@@ -75,5 +93,15 @@ class ClearCommand extends Command
             "queue.connections.{$connection}.queue",
             'default'
         );
+    }
+
+    /**
+     * Get the job namespace to clear.
+     *
+     * @return string
+     */
+    protected function getJob()
+    {
+        return $this->option('job');
     }
 }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -65,7 +65,7 @@ class ClearCommand extends Command
                 $count = $manager->connection($connection)->clearSpecificJob($queue, $job);
             }
 
-            $this->components->info('Cleared '.$count.' jobs from the ['.$queue.'] queue.');
+            $this->components->info('Cleared ' . $count . ' jobs from the [' . $queue . '] queue.');
 
             return 0;
         }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -65,7 +65,7 @@ class ClearCommand extends Command
                 $count = $manager->connection($connection)->clearSpecificJob($queue, $job);
             }
 
-            $this->components->info('Cleared ' . $count . ' jobs from the [' . $queue . '] queue.');
+            $this->components->info('Cleared '.$count.' jobs from the ['.$queue.'] queue.');
 
             return 0;
         }

--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -17,9 +17,9 @@ class LuaScripts
     {
         return <<<'LUA'
             redis.call('hsetnx', KEYS[1], 'throughput', 0)
-            
+
             redis.call('sadd', KEYS[2], KEYS[1])
-            
+
             local hash = redis.call('hmget', KEYS[1], 'throughput', 'runtime')
 
             local throughput = hash[1] + 1
@@ -48,10 +48,10 @@ LUA;
     public static function purge()
     {
         return <<<'LUA'
-            
+
             local count = 0
             local cursor = 0
-            
+
             repeat
                 -- Iterate over the recent jobs sorted set
                 local scanner = redis.call('zscan', KEYS[1], cursor)
@@ -69,11 +69,151 @@ LUA;
                         redis.call('zrem', KEYS[2], jobid)
                         redis.call('del', hashkey)
                         count = count + 1
-                    end           
+                    end
                 end
             until cursor == '0'
 
             return count
 LUA;
+    }
+
+    /**
+     * Get the Lua script for purging specific recent and pending job off of the queue.
+     *
+     * KEYS[1] - The name of the recent jobs sorted set
+     * KEYS[2] - The name of the pending jobs sorted set
+     * ARGV[1] - The prefix of the Horizon keys
+     * ARGV[2] - The name of the queue to purge
+     * ARGV[3] - The namespace of the job to purge
+     *
+     * @return string
+     */
+    public static function purgeSpecificJob()
+    {
+        return <<<'LUA'
+
+        local count = 0
+        local cursor = 0
+
+        repeat
+            local scanner = redis.call('zscan', KEYS[1], cursor)
+            cursor = scanner[1]
+
+            for i = 1, #scanner[2], 2 do
+                local jobId = scanner[2][i]
+                local hashKey = ARGV[1] .. jobId
+                local job = redis.call('hmget', hashKey, 'status', 'queue', 'name')
+
+                local statusMatch = (job[1] == 'reserved' or job[1] == 'pending')
+                local queueMatch = (job[2] == ARGV[2])
+                local nameMatch = (job[3] == ARGV[3])
+
+                if statusMatch and queueMatch and nameMatch then
+                    redis.call('zrem', KEYS[1], jobId)
+                    redis.call('zrem', KEYS[2], jobId)
+                    redis.call('del', hashKey)
+                    count = count + 1
+                end
+            end
+        until cursor == '0'
+
+        return count
+
+        LUA;
+    }
+
+    /**
+     * Get the Lua script for clear specific job off of the primary queue.
+     *
+     * KEYS[1] - The name of the primary queue
+     * ARGV[1] - The namespace of the job to clear
+     *
+     * @return string
+     */
+    public static function clearSpecificJobFromPrimaryQueue()
+    {
+        return <<<'LUA'
+            local items = redis.call('lrange', KEYS[1], 0, -1)
+            local count = 0
+
+            for _, item in ipairs(items) do
+                local ok, data = pcall(cjson.decode, item)
+
+                if ok and data.displayName == ARGV[1] then
+                    redis.call('lrem', KEYS[1], 0, item)
+                    count = count + 1
+                end
+            end
+
+            return count
+        LUA;
+    }
+
+    /**
+     * Get the Lua script for clear specific job off of the delayed queue.
+     *
+     * KEYS[1] - The name of the delayed queue
+     * ARGV[1] - The namespace of the job to clear
+     *
+     * @return string
+     */
+    public static function clearSpecificJobFromDelayedQueue()
+    {
+        return <<<'LUA'
+            local items = redis.call('zrange', KEYS[1], 0, -1)
+            local count = 0
+
+            for _, item in ipairs(items) do
+                local ok, data = pcall(cjson.decode, item)
+
+                if ok and data.displayName == ARGV[1] then
+                    redis.call('zrem', KEYS[1], item)
+                    count = count + 1
+                end
+            end
+
+            return count
+        LUA;
+    }
+
+    /**
+     * Get the Lua script for clear specific job off of the reserved queue.
+     *
+     * KEYS[1] - The name of the reserved queue
+     * ARGV[1] - The namespace of the job to clear
+     *
+     * @return string
+     */
+    public static function clearSpecificJobFromReservedQueue()
+    {
+        return <<<'LUA'
+            local items = redis.call('zrange', KEYS[1], 0, -1)
+            local count = 0
+
+            for _, item in ipairs(items) do
+                local ok, data = pcall(cjson.decode, item)
+
+                if ok and data.displayName == ARGV[1] then
+                    redis.call('zrem', KEYS[1], item)
+                    count = count + 1
+                end
+            end
+
+            return count
+        LUA;
+    }
+
+    /**
+     * Get the Lua script for clear specific job off of the notify queue.
+     *
+     * KEYS[1] - The name of the notify queue
+     *
+     * @return string
+     */
+    public static function clearNotifyQueue()
+    {
+        return <<<'LUA'
+            redis.call('del', KEYS[1])
+        LUA;
     }
 }

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -206,4 +206,22 @@ class RedisQueue extends BaseQueue
             );
         }
     }
+
+    /**
+     * Delete specific job from the queue.
+     *
+     * @param string $queue
+     * @param string $job
+     * @return int
+     */
+    public function clearSpecificJob($queue, $job)
+    {
+        $connection = $this->getConnection();
+        $queue = $this->getQueue($queue);
+
+        return $connection->eval(LuaScripts::clearSpecificJobFromPrimaryQueue(), 1, $queue, $job)
+             + $connection->eval(LuaScripts::clearSpecificJobFromDelayedQueue(), 1, $queue.':delayed', $job)
+             + $connection->eval(LuaScripts::clearSpecificJobFromReservedQueue(), 1, $queue.':reserved', $job)
+             + $connection->eval(LuaScripts::clearNotifyQueue(), 1, $queue.':notify');
+    }
 }

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -210,8 +210,8 @@ class RedisQueue extends BaseQueue
     /**
      * Delete specific job from the queue.
      *
-     * @param string $queue
-     * @param string $job
+     * @param  string $queue
+     * @param  string $job
      * @return int
      */
     public function clearSpecificJob($queue, $job)

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -210,8 +210,8 @@ class RedisQueue extends BaseQueue
     /**
      * Delete specific job from the queue.
      *
-     * @param  string $queue
-     * @param  string $job
+     * @param  string  $queue
+     * @param  string  $job
      * @return int
      */
     public function clearSpecificJob($queue, $job)

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -210,8 +210,8 @@ class RedisQueue extends BaseQueue
     /**
      * Delete specific job from the queue.
      *
-     * @param  string $queue
-     * @param  string $job
+     * @param string $queue
+     * @param string $job
      * @return int
      */
     public function clearSpecificJob($queue, $job)

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -739,8 +739,8 @@ class RedisJobRepository implements JobRepository
     /**
      * Delete specific pending and reserved job for a queue.
      *
-     * @param string $queue
-     * @param string $job
+     * @param  string $queue
+     * @param  string $job
      * @return int
      */
     public function purgeSpecificJob($queue, $job)

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -737,6 +737,26 @@ class RedisJobRepository implements JobRepository
     }
 
     /**
+     * Delete specific pending and reserved job for a queue.
+     *
+     * @param string $queue
+     * @param string $job
+     * @return int
+     */
+    public function purgeSpecificJob($queue, $job)
+    {
+        return $this->connection()->eval(
+            LuaScripts::purgeSpecificJob(),
+            2,
+            'recent_jobs',
+            'pending_jobs',
+            config('horizon.prefix'),
+            $queue,
+            $job
+        );
+    }
+
+    /**
      * Get the Redis connection instance.
      *
      * @return \Illuminate\Redis\Connections\Connection

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -739,8 +739,8 @@ class RedisJobRepository implements JobRepository
     /**
      * Delete specific pending and reserved job for a queue.
      *
-     * @param  string $queue
-     * @param  string $job
+     * @param string $queue
+     * @param string $job
      * @return int
      */
     public function purgeSpecificJob($queue, $job)

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -739,8 +739,8 @@ class RedisJobRepository implements JobRepository
     /**
      * Delete specific pending and reserved job for a queue.
      *
-     * @param  string $queue
-     * @param  string $job
+     * @param  string  $queue
+     * @param  string  $job
      * @return int
      */
     public function purgeSpecificJob($queue, $job)

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -81,6 +81,35 @@ class RedisJobRepositoryTest extends IntegrationTest
         $this->assertCount(2, $repository->getJobs([1, 2, 3, 4, 5]));
     }
 
+    public function test_it_removes_recent_jobs_when_queue_is_purged_with_specific_job_name()
+    {
+        $repository = $this->app->make(JobRepository::class);
+
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 1, 'displayName' => 'first'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 2, 'displayName' => 'second'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 3, 'displayName' => 'third'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 4, 'displayName' => 'fourth'])));
+        $repository->pushed('horizon', 'email-processing', new JobPayload(json_encode(['id' => 5, 'displayName' => 'fifth'])));
+
+        $repository->completed(new JobPayload(json_encode(['id' => 1, 'displayName' => 'first'])));
+        $repository->completed(new JobPayload(json_encode(['id' => 2, 'displayName' => 'second'])));
+
+        $this->assertEquals(0, $repository->purgeSpecificJob('email-processing', 'first'));
+        $this->assertEquals(0, $repository->purgeSpecificJob('email-processing', 'second'));
+        $this->assertEquals(1, $repository->purgeSpecificJob('email-processing', 'third'));
+        $this->assertEquals(1, $repository->purgeSpecificJob('email-processing', 'fourth'));
+        $this->assertEquals(1, $repository->purgeSpecificJob('email-processing', 'fifth'));
+
+        $this->assertEquals(2, $repository->countRecent());
+        $this->assertEquals(0, $repository->countPending());
+        $this->assertEquals(2, $repository->countCompleted());
+
+        $recent = collect($repository->getRecent());
+        $this->assertNotNull($recent->firstWhere('id', 1));
+        $this->assertNotNull($recent->firstWhere('id', 2));
+        $this->assertCount(2, $repository->getJobs([1, 2, 3, 4, 5]));
+    }
+
     public function test_it_will_delete_a_failed_job()
     {
         $repository = $this->app->make(JobRepository::class);


### PR DESCRIPTION
This pull request updates the `horizon:clear` command to allow specifying the job namespace as an argument.

Example usage:
`php artisan horizon:clear --queue=emails --job=App\\Jobs\\TestJob`

Why is it useful?
This enhancement provides more granular control when clearing jobs from specific queue. By allowing the `--job` option, developers can target and clear jobs of a particular class within a given queue, without affecting other jobs.