### PR TITLE
Allowed Horizon Status & Supervisors commands to run outside console

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -115,7 +115,6 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\PurgeCommand::class,
                 Console\SupervisorCommand::class,
                 Console\SupervisorStatusCommand::class,
-                
                 Console\TerminateCommand::class,
                 Console\TimeoutCommand::class,
                 Console\WorkCommand::class,
@@ -125,7 +124,7 @@ class HorizonServiceProvider extends ServiceProvider
         $this->commands([
             Console\SnapshotCommand::class,
             Console\StatusCommand::class,
-            Console\SupervisorsCommand::class
+            Console\SupervisorsCommand::class,
         ]);
     }
 

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -113,17 +113,20 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\PauseSupervisorCommand::class,
                 Console\PublishCommand::class,
                 Console\PurgeCommand::class,
-                Console\StatusCommand::class,
                 Console\SupervisorCommand::class,
                 Console\SupervisorStatusCommand::class,
-                Console\SupervisorsCommand::class,
+                
                 Console\TerminateCommand::class,
                 Console\TimeoutCommand::class,
                 Console\WorkCommand::class,
             ]);
         }
 
-        $this->commands([Console\SnapshotCommand::class]);
+        $this->commands([
+            Console\SnapshotCommand::class,
+            Console\StatusCommand::class,
+            Console\SupervisorsCommand::class
+        ]);
     }
 
     /**


### PR DESCRIPTION
This helps if you are checking Horizon status & Supervisors' status using HTTP requests, for example using: https://crondog.io/