### PR TITLE
add support for pushing to multiple connections with different redis …

### DIFF
--- a/src/Listeners/StoreMonitoredTags.php
+++ b/src/Listeners/StoreMonitoredTags.php
@@ -33,10 +33,10 @@ class StoreMonitoredTags
      */
     public function handle(JobPushed $event)
     {
-        $monitoring = $this->tags->monitored($event->payload->tags());
+        $monitoring = $this->tags->monitored($event->payload->tags(), $event->connectionName);
 
         if (! empty($monitoring)) {
-            $this->tags->add($event->payload->id(), $monitoring);
+            $this->tags->add($event->payload->id(), $monitoring, $event->connectionName);
         }
     }
 }

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -335,7 +335,7 @@ class RedisJobRepository implements JobRepository
      */
     public function pushed($connection, $queue, JobPayload $payload)
     {
-        $this->connection()->pipeline(function ($pipe) use ($connection, $queue, $payload) {
+        $this->connection($connection)->pipeline(function ($pipe) use ($connection, $queue, $payload) {
             $this->storeJobReference($pipe, 'recent_jobs', $payload);
             $this->storeJobReference($pipe, 'pending_jobs', $payload);
 
@@ -739,10 +739,19 @@ class RedisJobRepository implements JobRepository
     /**
      * Get the Redis connection instance.
      *
+     * @param  string|null  $connection
      * @return \Illuminate\Redis\Connections\Connection
      */
-    protected function connection()
+    protected function connection($connection = null)
     {
-        return $this->redis->connection('horizon');
+        if ($connection && config()->has('queue.connections.'.$connection)) {
+            $connection = config('queue.connections.'.$connection.'.connection');
+        }
+
+        if ($connection && ! config()->has('database.redis.'.$connection)) {
+            $connection = null;
+        }
+
+        return $this->redis->connection($connection ?? 'horizon');
     }
 }

--- a/src/Repositories/RedisTagRepository.php
+++ b/src/Repositories/RedisTagRepository.php
@@ -28,22 +28,24 @@ class RedisTagRepository implements TagRepository
     /**
      * Get the currently monitored tags.
      *
+     * @param  string|null  $connectionName
      * @return array
      */
-    public function monitoring()
+    public function monitoring($connectionName = null)
     {
-        return (array) $this->connection()->smembers('monitoring');
+        return (array) $this->connection($connectionName)->smembers('monitoring');
     }
 
     /**
      * Return the tags which are being monitored.
      *
      * @param  array  $tags
+     * @param  string|null  $connectionName
      * @return array
      */
-    public function monitored(array $tags)
+    public function monitored(array $tags, $connectionName = null)
     {
-        return array_intersect($tags, $this->monitoring());
+        return array_intersect($tags, $this->monitoring($connectionName));
     }
 
     /**
@@ -73,11 +75,12 @@ class RedisTagRepository implements TagRepository
      *
      * @param  string  $id
      * @param  array  $tags
+     * @param  string|null  $connection
      * @return void
      */
-    public function add($id, array $tags)
+    public function add($id, array $tags, ?string $connection = null)
     {
-        $this->connection()->pipeline(function ($pipe) use ($id, $tags) {
+        $this->connection($connection)->pipeline(function ($pipe) use ($id, $tags) {
             foreach ($tags as $tag) {
                 $pipe->zadd($tag, str_replace(',', '.', microtime(true)), $id);
             }
@@ -176,10 +179,19 @@ class RedisTagRepository implements TagRepository
     /**
      * Get the Redis connection instance.
      *
+     * @param  string|null  $connection
      * @return \Illuminate\Redis\Connections\Connection
      */
-    protected function connection()
+    protected function connection($connection = null)
     {
-        return $this->redis->connection('horizon');
+        if ($connection && config()->has('queue.connections.'.$connection)) {
+            $connection = config('queue.connections.'.$connection.'.connection');
+        }
+
+        if ($connection && ! config()->has('database.redis.'.$connection)) {
+            $connection = null;
+        }
+
+        return $this->redis->connection($connection ?? 'horizon');
     }
 }

--- a/tests/Feature/MonitoringTest.php
+++ b/tests/Feature/MonitoringTest.php
@@ -78,4 +78,41 @@ class MonitoringTest extends IntegrationTest
         dispatch(new StopMonitoringTag('first'));
         $this->assertSame(0, $this->monitoredJobs('first'));
     }
+
+    public function test_store_monitored_tags_uses_connection_from_job_pushed_event()
+    {
+        // Add second Redis connection pointing to same instance
+        config(['database.redis.redis2' => config('database.redis.default')]);
+
+        // Set up a second queue connection using the new Redis connection
+        config(['queue.connections.queue_connection' => [
+            'driver' => 'redis',
+            'connection' => 'redis2',
+            'queue' => 'default',
+        ]]);
+
+        // Force rebuild Redis connections
+        $this->app->forgetInstance('redis');
+        $this->app->forgetInstance('redis.connection');
+
+        $mockRepository = $this->createMock(TagRepository::class);
+
+        $mockRepository->method('monitored')
+            ->willReturnCallback(function ($tags, $connection) {
+                // Verify connection parameter is passed
+                $this->assertEquals('queue_connection', $connection);
+
+                return in_array('first', $tags) ? ['first'] : [];
+            });
+
+        $mockRepository->expects($this->once())
+            ->method('add')
+            ->with($this->anything(), ['first'], 'queue_connection');
+
+        $mockRepository->method('monitor');
+
+        $this->app->instance(TagRepository::class, $mockRepository);
+
+        Queue::connection('queue_connection')->push(new Jobs\BasicJob);
+    }
 }

--- a/tests/Feature/RedisJobRepositoryTest.php
+++ b/tests/Feature/RedisJobRepositoryTest.php
@@ -3,8 +3,10 @@
 namespace Laravel\Horizon\Tests\Feature;
 
 use Exception;
+use Illuminate\Contracts\Redis\Factory;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\JobPayload;
+use Laravel\Horizon\Repositories\RedisJobRepository;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Throwable;
 
@@ -105,5 +107,29 @@ class RedisJobRepositoryTest extends IntegrationTest
 
         $this->assertSame(0, $result);
         $this->assertSame('1', $repository->getRecent()[0]->id);
+    }
+
+    public function test_it_uses_specified_connection_when_connection_is_configured()
+    {
+        // Mock the config to have a 'custom' redis connection
+        config(['database.redis.custom_redis' => ['host' => 'localhost']]);
+        config(['queue.connections.custom' => ['connection' => 'custom_redis']]);
+
+        $payload = new JobPayload(json_encode(['id' => 1, 'displayName' => 'foo']));
+
+        // Mock the Redis factory to verify which connection is called
+        $redisFactory = $this->createMock(Factory::class);
+
+        // just a mock, the real deal would use the custom connection
+        $redisConnection = $this->app->make('redis')->connection('horizon');
+
+        // Expect that 'custom' connection is used when it exists in config
+        $redisFactory->expects($this->once())
+            ->method('connection')
+            ->with('custom_redis')
+            ->willReturn($redisConnection);
+
+        $repository = new RedisJobRepository($redisFactory);
+        $repository->pushed('custom', 'default', $payload);
     }
 }

--- a/tests/Feature/SupervisorTest.php
+++ b/tests/Feature/SupervisorTest.php
@@ -52,6 +52,8 @@ class SupervisorTest extends IntegrationTest
     /** @requires extension redis */
     public function test_supervisor_can_start_worker_process_with_given_options()
     {
+        config(['queue.connections.redis.connection' => null]);
+
         Queue::push(new Jobs\BasicJob);
         $this->assertSame(1, $this->recentJobs());
 
@@ -264,6 +266,8 @@ class SupervisorTest extends IntegrationTest
     /** @requires extension redis */
     public function test_processes_can_be_paused_and_continued()
     {
+        config(['queue.connections.redis.connection' => null]);
+
         $options = $this->supervisorOptions();
         $options->sleep = 0;
         $this->supervisor = $supervisor = new Supervisor($options);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -134,5 +134,6 @@ abstract class IntegrationTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('queue.default', 'redis');
+        $app['config']->set('queue.connections.redis.connection', 'horizon');
     }
 }


### PR DESCRIPTION
## Fix job monitoring across multiple Horizon instances with different Redis connections

 ### Problem

In setups with multiple Horizon instances using the same codebase but different queue connections (each pointing to different Redis instances), jobs dispatched to different connections are incorrectly tracked. 
When a job is pushed to a connection, it appears as pending on the wrong Horizon dashboard because job monitoring data is always stored in the Redis connection it was pushed from, rather than the Redis connection of the queue connection the job was pushed to. This causes other Horizon instances monitoring different connections to be unable to show the completed or failed jobs for jobs that were dispatched to their connections.

 ### Solution

This PR fixes the issue by ensuring that job monitoring data (tags, job references) is stored in the correct Redis instance based on the connection the job was pushed to.

 ### Changes

  - **Enhanced Tag Repository**: Modified `RedisTagRepository` to accept connection parameter and resolve the correct Redis connection for storing monitored tags
  - **Updated Job Repository**: Modified `RedisJobRepository::pushed()` to use the job's target connection for storing job references
  - **Fixed Event Handling**: Updated `StoreMonitoredTags` listener to pass the target connection name when storing monitored job tags
  - **Connection Resolution**: Added logic to resolve Redis connections from queue connection configuration with fallback to default

  ### Result

  Jobs are now properly tracked on the correct Horizon instance based on their target connection, allowing each instance to accurately display job statuses for jobs dispatched to their respective Redis instances.

## Why The Test Configuration Changes Don't Interfere With Logic Testing

  The test configuration lines (`config(['queue.connections.redis.connection' => null])`) address a test environment limitation where the `getEnvironmentSetUp()` configuration isn't inherited by spawned worker processes.

  **The Issue**: The `getEnvironmentSetUp()` method sets `queue.connections.redis.connection = 'horizon'` for the test process, but spawned worker processes don't inherit this configuration and use Laravel's default setup instead.

  **The Fix**: Setting the connection to `null` in the specific tests disables the multi-connection logic entirely, forcing both the test process and worker processes to use the same fallback behavior (default 'horizon'
  connection).

  **Logic Preserved**: The core multi-connection functionality remains fully intact and tested in dedicated multi-connection tests. These configuration changes only ensure test environment consistency in supervisor tests that
  spawn separate PHP processes - in production, all processes naturally share the same application configuration.