### PR TITLE
Fix empty failed jobs overview that stays loading

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -62,10 +62,6 @@
 
                 this.$http.get(Horizon.basePath + '/api/jobs/failed?' + tagQuery + 'starting_at=' + starting)
                     .then(response => {
-                        if (!this.$root.autoLoadsNewEntries && refreshing && !response.data.jobs.length) {
-                            return;
-                        }
-
                         if (!this.$root.autoLoadsNewEntries && refreshing && this.jobs.length && response.data.jobs[0]?.id !== this.jobs[0]?.id) {
                             this.hasNewEntries = true;
                         } else {


### PR DESCRIPTION
### Problem

When there are no failed jobs in Horizon the overview page keeps showing the Loading indicator.

1. Ensure the are no failed jobs by running `php artisan horizon:forget --all`
2. Open Horizon and enable auto refresh.
3. See that the loading doesn't stop until you disable auto refresh.

### Solution

Adjust the code such that when there are no jobs the `ready` variable is set to true. This way the Loading indicator goes away.

This is the same logic as for the Recent Job overview.