### PR TITLE
Fix null to Str::contains deprecation

### DIFF
--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -119,7 +119,7 @@ class WaitTimeCalculator
      */
     public function calculateTimeToClear($connection, $queue, $totalProcesses)
     {
-        $timeToClear = ! Str::contains($queue, ',')
+        $timeToClear = ! Str::contains($queue ?? '', ',')
             ? $this->timeToClearFor($connection, $queue)
             : collect(explode(',', $queue))->sum(function ($queueName) use ($connection) {
                 return $this->timeToClearFor($connection, $queueName);


### PR DESCRIPTION
I been getting this in my Sentry 900 times in production

<img width="2538" height="1444" alt="CleanShot 2025-07-13 at 01 40 30@2x" src="https://github.com/user-attachments/assets/d06e04a4-deda-4b0f-95d6-558ae34db943" />

There are 3 to 4 usages of Str::contains in laravel/horizon codebase. Unfortunately Sentry error message doesn't make it easy to pinpoint which is it exactly

But I think it is this 1 because

<img width="2742" height="1256" alt="CleanShot 2025-07-13 at 01 47 02@2x" src="https://github.com/user-attachments/assets/f92db01b-2f69-49eb-b64c-b27578cb7fa6" />






