### PR TITLE
Fix MonitorWaitTimes to respect one-minute monitoring interval

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -76,11 +76,15 @@ class MonitorWaitTimes
         // We will keep track of the amount of time between attempting to acquire the
         // lock to monitor the wait times. We only want a single supervisor to run
         // the checks on a given interval so that we don't fire too many events.
-        if (! $this->lastMonitored) {
-            $this->lastMonitored = CarbonImmutable::now();
-        }
 
         if (! $this->timeToMonitor()) {
+            return false;
+        }
+
+        $lock = $this->metrics->acquireWaitTimeMonitorLock();
+
+        if (! $lock) {
+            // If we cannot acquire the lock, it means another supervisor is already monitoring.
             return false;
         }
 
@@ -89,7 +93,7 @@ class MonitorWaitTimes
         // operation required. This will avoid any deadlocks or race conditions.
         $this->lastMonitored = CarbonImmutable::now();
 
-        return $this->metrics->acquireWaitTimeMonitorLock();
+        return true;
     }
 
     /**
@@ -99,6 +103,10 @@ class MonitorWaitTimes
      */
     protected function timeToMonitor()
     {
-        return CarbonImmutable::now()->subMinutes(1)->lte($this->lastMonitored);
+        if ($this->lastMonitored === null) {
+            return true;
+        }
+
+        return CarbonImmutable::now()->gte($this->lastMonitored->addMinute());
     }
 }

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -76,7 +76,6 @@ class MonitorWaitTimes
         // We will keep track of the amount of time between attempting to acquire the
         // lock to monitor the wait times. We only want a single supervisor to run
         // the checks on a given interval so that we don't fire too many events.
-
         if (! $this->timeToMonitor()) {
             return false;
         }

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -83,7 +83,6 @@ class MonitorWaitTimes
         $lock = $this->metrics->acquireWaitTimeMonitorLock();
 
         if (! $lock) {
-            // If we cannot acquire the lock, it means another supervisor is already monitoring.
             return false;
         }
 

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
@@ -49,5 +50,72 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener->handle();
 
         Event::assertNotDispatched(LongWaitDetected::class);
+    }
+
+    public function test_monitor_wait_times_skips_when_lock_is_not_acquired()
+    {
+        config(['horizon.waits' => ['redis:default' => 60]]);
+
+        Event::fake();
+
+        $calc = Mockery::mock(WaitTimeCalculator::class);
+        $calc->expects('calculate')->never();
+        $this->app->instance(WaitTimeCalculator::class, $calc);
+
+        $metrics = Mockery::mock(MetricsRepository::class);
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->andReturnFalse();
+        $this->app->instance(MetricsRepository::class, $metrics);
+
+        $listener = new MonitorWaitTimes($metrics);
+
+        $listener->handle();
+
+        Event::assertNotDispatched(LongWaitDetected::class);
+    }
+
+    public function test_monitor_wait_times_skips_when_not_due_to_monitor()
+    {
+        config(['horizon.waits' => ['redis:default' => 60]]);
+
+        Event::fake();
+
+        $calc = Mockery::mock(WaitTimeCalculator::class);
+        $calc->expects('calculate')->never();
+        $this->app->instance(WaitTimeCalculator::class, $calc);
+
+        $metrics = Mockery::mock(MetricsRepository::class);
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->never();
+        $this->app->instance(MetricsRepository::class, $metrics);
+
+        $listener = new MonitorWaitTimes($metrics);
+        $listener->lastMonitored = CarbonImmutable::now(); // Too soon
+
+        $listener->handle();
+
+        Event::assertNotDispatched(LongWaitDetected::class);
+    }
+
+    public function test_monitor_wait_times_executes_once_when_called_twice()
+    {
+        config(['horizon.waits' => ['redis:default' => 60]]);
+
+        Event::fake();
+
+        $calc = Mockery::mock(WaitTimeCalculator::class);
+        $calc->expects('calculate')->once()->andReturn([
+            'redis:default' => 70,
+        ]);
+        $this->app->instance(WaitTimeCalculator::class, $calc);
+
+        $metrics = Mockery::mock(MetricsRepository::class);
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->andReturnTrue();
+        $this->app->instance(MetricsRepository::class, $metrics);
+
+        $listener = new MonitorWaitTimes($metrics);
+        $listener->handle();
+        // Call it again to ensure it doesn't execute twice
+        $listener->handle();
+
+        Event::assertDispatchedTimes(LongWaitDetected::class, 1);
     }
 }

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -95,6 +95,36 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::assertNotDispatched(LongWaitDetected::class);
     }
 
+    public function test_monitor_wait_times_skips_when_not_due_to_monitor_and_executes_after_2_minutes()
+    {
+        config(['horizon.waits' => ['redis:default' => 60]]);
+
+        Event::fake();
+
+        $calc = Mockery::mock(WaitTimeCalculator::class);
+        $calc->expects('calculate')->once()->andReturn([
+            'redis:default' => 70,
+        ]);
+        $this->app->instance(WaitTimeCalculator::class, $calc);
+
+        $metrics = Mockery::mock(MetricsRepository::class);
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->andReturnTrue();
+        $this->app->instance(MetricsRepository::class, $metrics);
+
+        $listener = new MonitorWaitTimes($metrics);
+        $listener->lastMonitored = CarbonImmutable::now(); // Too soon
+
+        $listener->handle();
+
+        Event::assertNotDispatched(LongWaitDetected::class);
+
+        CarbonImmutable::setTestNow(now()->addMinutes(2)); // Simulate time passing
+
+        $listener->handle();
+
+        Event::assertDispatched(LongWaitDetected::class);
+    }
+
     public function test_monitor_wait_times_executes_once_when_called_twice()
     {
         config(['horizon.waits' => ['redis:default' => 60]]);


### PR DESCRIPTION
This PR fixes the interval logic in the MonitorWaitTimes listener to ensure it runs at most once per minute, as intended. The previous time check always returned true, but Redis locking implicitly prevented event spamming. This change corrects the time-based throttle and adds tests to verify proper monitoring behavior.

Benefit to end users:
Improves clarity and correctness of Horizon's internal monitoring. Avoids redundant lock attempts and aligns the logic with its intent.

No breaking changes.
Existing Redis based throttling prevented user-facing issues. This PR only refines internal timing logic and adds tests to prove the workings.

See the failing tests before the fix: https://github.com/laravel/horizon/actions/runs/16727284013