### PR TITLE
Add notification for excessive pending jobs in Horizon

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -89,6 +89,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Queue Pending Jobs Thresholds
+    |--------------------------------------------------------------------------
+    |
+    | This option determines how many pending jobs will trigger an event
+    | across all queues and connections in your application.
+    | Set to null to disable this monitoring entirely.
+    |
+    */
+
+    'pending_jobs_monitor_threshold' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Job Trimming Times
     |--------------------------------------------------------------------------
     |

--- a/src/Contracts/ManyPendingJobsDetectedNotification.php
+++ b/src/Contracts/ManyPendingJobsDetectedNotification.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Horizon\Contracts;
+
+interface ManyPendingJobsDetectedNotification
+{
+    //
+}

--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -53,6 +53,7 @@ trait EventMap
             Listeners\TrimMonitoredJobs::class,
             Listeners\ExpireSupervisors::class,
             Listeners\MonitorMasterSupervisorMemory::class,
+            Listeners\MonitorManyPendingJobs::class,
         ],
 
         Events\SupervisorLooped::class => [
@@ -70,6 +71,10 @@ trait EventMap
         ],
 
         Events\LongWaitDetected::class => [
+            Listeners\SendNotification::class,
+        ],
+
+        Events\ManyPendingJobsDetected::class => [
             Listeners\SendNotification::class,
         ],
     ];

--- a/src/Events/ManyPendingJobsDetected.php
+++ b/src/Events/ManyPendingJobsDetected.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Laravel\Horizon\Events;
+
+use Illuminate\Container\Container;
+use Laravel\Horizon\Contracts\ManyPendingJobsDetectedNotification;
+
+class ManyPendingJobsDetected
+{
+    public function __construct(public int $amountPendingJobs)
+    {
+        //
+    }
+
+    /**
+     * Get a notification representation of the event.
+     */
+    public function toNotification(): ManyPendingJobsDetectedNotification
+    {
+        return Container::getInstance()->make(ManyPendingJobsDetectedNotification::class, [
+            'amountPendingJobs' => $this->amountPendingJobs,
+        ]);
+    }
+}

--- a/src/Listeners/MonitorManyPendingJobs.php
+++ b/src/Listeners/MonitorManyPendingJobs.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Laravel\Horizon\Listeners;
+
+use Carbon\CarbonImmutable;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\Events\ManyPendingJobsDetected;
+use Laravel\Horizon\Lock;
+
+class MonitorManyPendingJobs
+{
+    /**
+     * The time at which we last checked if monitoring was due.
+     */
+    public ?CarbonImmutable $lastMonitored = null;
+
+    public function handle(): void
+    {
+        if (! $this->dueToMonitor()) {
+            return;
+        }
+
+        $amountPendingJobsThreshold = config('horizon.pending_jobs_monitor_threshold');
+
+        if ($amountPendingJobsThreshold === 0 || $amountPendingJobsThreshold === null) {
+            return;
+        }
+
+        $amountPendingJobs = app(JobRepository::class)->countPending();
+
+        if ($amountPendingJobs <= $amountPendingJobsThreshold) {
+            return;
+        }
+
+        event(new ManyPendingJobsDetected($amountPendingJobs));
+    }
+
+    /**
+     * Determine if monitoring is due.
+     */
+    protected function dueToMonitor(): bool
+    {
+        // We will keep track of the amount of time between attempting to acquire the lock to
+        // monitor the amount of pending jobs. We only want a single supervisor to run
+        // the checks on a given interval so that we don't fire too many events.
+        if (! $this->timeToMonitor()) {
+            return false;
+        }
+
+        $lock = app(Lock::class)->get('monitor:many-pending-jobs');
+
+        if (! $lock) {
+            // If we cannot acquire the lock, it means another supervisor is already monitoring.
+            return false;
+        }
+
+        // Next we will update the monitor timestamp and attempt to acquire a lock to check the
+        // amount of pending jobs. We use Redis to do it in order to have the atomic
+        // operation required. This will avoid any deadlocks or race conditions.
+        $this->lastMonitored = CarbonImmutable::now();
+
+        return true;
+    }
+
+    /**
+     * Determine if enough time has elapsed to attempt to monitor.
+     */
+    protected function timeToMonitor(): bool
+    {
+        if ($this->lastMonitored === null) {
+            return true;
+        }
+
+        return CarbonImmutable::now()->gte($this->lastMonitored->addMinute());
+    }
+}

--- a/src/Notifications/ManyPendingJobsDetected.php
+++ b/src/Notifications/ManyPendingJobsDetected.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Laravel\Horizon\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\NexmoMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
+use Illuminate\Notifications\Slack\SlackMessage as ChannelIdSlackMessage;
+use Illuminate\Support\Str;
+use Laravel\Horizon\Contracts\ManyPendingJobsDetectedNotification;
+use Laravel\Horizon\Horizon;
+
+class ManyPendingJobsDetected extends Notification implements ManyPendingJobsDetectedNotification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param  int  $amountPendingJobs
+     * @return void
+     */
+    public function __construct(public int $amountPendingJobs)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return array_filter([
+            Horizon::$slackWebhookUrl ? 'slack' : null,
+            Horizon::$smsNumber ? 'nexmo' : null,
+            Horizon::$email ? 'mail' : null,
+        ]);
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage())
+            ->error()
+            ->subject(config('app.name') . ': Many Pending Jobs Detected')
+            ->greeting('Oh no! Something needs your attention.')
+            ->line(sprintf(
+                'Horizon has %s pending jobs.',
+                $this->amountPendingJobs
+            ));
+    }
+
+    /**
+     * Get the Slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\SlackMessage
+     */
+    public function toSlack($notifiable)
+    {
+        $fromName = 'Laravel Horizon';
+        $title = 'Many Pending Jobs Detected';
+        $text = 'Oh no! Something needs your attention.';
+        $imageUrl = 'https://laravel.com/assets/img/horizon-48px.png';
+
+        $content = sprintf(
+            '[%s] Horizon has %s pending jobs.',
+            config('app.name'),
+            $this->amountPendingJobs
+        );
+
+        if (class_exists('\Illuminate\Notifications\Slack\SlackMessage') &&
+            class_exists('\Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock') &&
+            ! (is_string(Horizon::$slackWebhookUrl) && Str::startsWith(Horizon::$slackWebhookUrl, ['http://', 'https://']))) {
+            return (new ChannelIdSlackMessage())
+                ->username($fromName)
+                ->image($imageUrl)
+                ->text($text)
+                ->headerBlock($title)
+                ->sectionBlock(function (SectionBlock $block) use ($content): void { // @phpstan-ignore-line
+                    $block->text($content);
+                });
+        }
+
+        return (new SlackMessage()) // @phpstan-ignore-line
+            ->from($fromName)
+            ->to(Horizon::$slackChannel)
+            ->image($imageUrl)
+            ->error()
+            ->content($text)
+            ->attachment(function ($attachment) use ($title, $content) {
+                $attachment->title($title)
+                    ->content($content);
+            });
+    }
+
+    /**
+     * Get the Nexmo / SMS representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\NexmoMessage
+     */
+    public function toNexmo($notifiable)
+    {
+        return (new NexmoMessage())->content(sprintf( // @phpstan-ignore-line
+            '[%s] Horizon has %s pending jobs.',
+            config('app.name'), $this->amountPendingJobs
+        ));
+    }
+
+    /**
+     * The unique signature of the notification.
+     *
+     * @return string
+     */
+    public function signature()
+    {
+        return class_basename($this);
+    }
+}

--- a/src/Notifications/ManyPendingJobsDetected.php
+++ b/src/Notifications/ManyPendingJobsDetected.php
@@ -53,7 +53,7 @@ class ManyPendingJobsDetected extends Notification implements ManyPendingJobsDet
     {
         return (new MailMessage())
             ->error()
-            ->subject(config('app.name') . ': Many Pending Jobs Detected')
+            ->subject(config('app.name').': Many Pending Jobs Detected')
             ->greeting('Oh no! Something needs your attention.')
             ->line(sprintf(
                 'Horizon has %s pending jobs.',

--- a/src/ServiceBindings.php
+++ b/src/ServiceBindings.php
@@ -30,5 +30,6 @@ trait ServiceBindings
 
         // Notifications...
         Contracts\LongWaitDetectedNotification::class => Notifications\LongWaitDetected::class,
+        Contracts\ManyPendingJobsDetectedNotification::class => Notifications\ManyPendingJobsDetected::class,
     ];
 }

--- a/tests/Feature/MonitorManyPendingJobsTest.php
+++ b/tests/Feature/MonitorManyPendingJobsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Illuminate\Support\Facades\Event;
+use Laravel\Horizon\Contracts\JobRepository;
+use Laravel\Horizon\Events\ManyPendingJobsDetected;
+use Laravel\Horizon\Listeners\MonitorManyPendingJobs;
+use Laravel\Horizon\Lock;
+use Laravel\Horizon\Tests\IntegrationTest;
+use Mockery;
+
+class MonitorManyPendingJobsTest extends IntegrationTest
+{
+    public function test_many_pending_jobs_dispatches_event()
+    {
+        config(['horizon.pending_jobs_monitor_threshold' => 70]);
+
+        Event::fake();
+
+        $jobRepo = Mockery::mock(JobRepository::class);
+        $jobRepo->shouldReceive('countPending')->andReturn(80);
+        $this->app->instance(JobRepository::class, $jobRepo);
+
+        $listener = new MonitorManyPendingJobs();
+
+        $listener->handle();
+
+        Event::assertDispatched(ManyPendingJobsDetected::class, function ($event) {
+            return $event->amountPendingJobs === 80;
+        });
+    }
+
+    public function test_below_threshold_pending_jobs_does_not_dispatch_event()
+    {
+        config(['horizon.pending_jobs_monitor_threshold' => 70]);
+
+        Event::fake();
+
+        $jobRepo = Mockery::mock(JobRepository::class);
+        $jobRepo->shouldReceive('countPending')->andReturn(65);
+        $this->app->instance(JobRepository::class, $jobRepo);
+
+        $listener = new MonitorManyPendingJobs();
+
+        $listener->handle();
+
+        Event::assertNotDispatched(ManyPendingJobsDetected::class);
+    }
+
+    public function test_threshold_set_to_0_never_dispatches_event()
+    {
+        config(['horizon.pending_jobs_monitor_threshold' => 0]);
+
+        Event::fake();
+
+        $jobRepo = Mockery::mock(JobRepository::class);
+        $jobRepo->expects('countPending')->never();
+        $this->app->instance(JobRepository::class, $jobRepo);
+
+        $listener = new MonitorManyPendingJobs();
+
+        $listener->handle();
+
+        Event::assertNotDispatched(ManyPendingJobsDetected::class);
+    }
+
+    public function test_default_config__never_dispatches_event()
+    {
+        Event::fake();
+
+        $jobRepo = Mockery::mock(JobRepository::class);
+        $jobRepo->expects('countPending')->never();
+        $this->app->instance(JobRepository::class, $jobRepo);
+
+        $listener = new MonitorManyPendingJobs();
+
+        $listener->handle();
+
+        Event::assertNotDispatched(ManyPendingJobsDetected::class);
+    }
+
+    public function test_monitor_skips_when_lock_is_not_acquired()
+    {
+        config(['horizon.pending_jobs_monitor_threshold' => 10]);
+
+        Event::fake();
+
+        $jobRepo = Mockery::mock(JobRepository::class);
+        $jobRepo->shouldReceive('countPending')->andReturn(100);
+        $this->app->instance(JobRepository::class, $jobRepo);
+
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('get')->andReturn(false);
+        $this->app->instance(Lock::class, $lock);
+
+        $listener = new MonitorManyPendingJobs();
+
+        $listener->handle();
+
+        Event::assertNotDispatched(ManyPendingJobsDetected::class);
+    }
+
+    public function test_monitor_skips_when_not_due_to_monitor()
+    {
+        config(['horizon.pending_jobs_monitor_threshold' => 10]);
+
+        Event::fake();
+
+        $jobRepo = Mockery::mock(JobRepository::class);
+        $jobRepo->shouldReceive('countPending')->andReturn(15);
+        $this->app->instance(JobRepository::class, $jobRepo);
+
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('get')->andReturnTrue();
+        $this->app->instance(Lock::class, $lock);
+
+        $listener = new MonitorManyPendingJobs();
+
+        // Set a very recent timestamp, so it's not due yet
+        $listener->lastMonitored = now()->toImmutable();
+
+        $listener->handle();
+
+        Event::assertNotDispatched(ManyPendingJobsDetected::class);
+    }
+}


### PR DESCRIPTION
This PR introduces a new `ManyPendingJobsDetected` event and corresponding notification when the total number of pending jobs exceeds a configurable threshold across all queues and connections. This helps users proactively detect queue congestion before jobs begin to time out or fail.

The feature is disabled by default via `pending_jobs_monitor_threshold => null`. It is designed to be lightweight, using Redis locking and per-minute throttling to prevent unnecessary noise or overhead.

**Benefits to end users:**

Early warning when queues are backing up

Works seamlessly alongside existing LongWaitDetected events

Enables alerting based on queue volume, not just wait time

**Non-breaking change:**
This feature is opt-in and does not modify or interfere with existing Horizon functionality.


This PR already includes the fixed `dueToMonitor` logic as fixed in #1574