### PR TITLE
Add Valkey support to Laravel Horizon

### DIFF
--- a/.github/workflows/tests-valkey.yml
+++ b/.github/workflows/tests-valkey.yml
@@ -1,0 +1,57 @@
+name: tests-valkey
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+
+    services:
+      valkey:
+        image: valkey/valkey:7-alpine
+        ports:
+          - 6379:6379
+        options: --health-cmd="valkey-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3, 8.4]
+        laravel: [10, 11, 12]
+        driver: ['predis', 'phpredis']
+        exclude:
+          - php: 8.4
+            laravel: 10
+
+    name: Valkey - PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.driver }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, ${{ matrix.driver == 'phpredis' && 'redis' || '' }}, zip
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"
+
+      - name: Configure Redis client
+        run: |
+          echo "REDIS_CLIENT=${{ matrix.driver }}" >> $GITHUB_ENV
+
+      - name: Execute tests
+        run: vendor/bin/phpunit ${{ matrix.laravel >= 10 && '--display-deprecations --fail-on-deprecation' || '' }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Horizon provides a beautiful dashboard and code-driven configuration for your La
 
 All of your worker configuration is stored in a single, simple configuration file, allowing your configuration to stay in source control where your entire team can collaborate.
 
+### Redis and Valkey Support
+
+Horizon supports both Redis and Valkey as backend storage systems. You can use any of the following drivers:
+- `ext-redis` - The Redis PHP extension
+- `ext-valkey` - The Valkey PHP extension
+- `predis/predis` - A pure PHP Redis/Valkey client
+
 <p align="center">
 <img src="https://laravel.com/img/docs/horizon-example.png">
 </p>

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "suggest": {
         "ext-redis": "Required to use the Redis PHP driver.",
-        "predis/predis": "Required when not using the Redis PHP driver (^1.1|^2.0)."
+        "ext-valkey": "Required to use the Valkey PHP driver (Redis-compatible).",
+        "predis/predis": "Required when not using the Redis/Valkey PHP driver (^1.1|^2.0)."
     },
     "autoload": {
         "psr-4": {

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -39,6 +39,9 @@ return [
     | meta information required for it to function. It includes the list
     | of supervisors, failed jobs, job metrics, and other information.
     |
+    | Horizon supports both Redis and Valkey as the backend storage. You can
+    | use either ext-redis, ext-valkey, or predis/predis as the PHP driver.
+    |
     */
 
     'use' => 'default',


### PR DESCRIPTION
- Add ext-valkey to composer.json suggestions
- Update Predis suggestion to mention Valkey compatibility
- Add Valkey documentation to config/horizon.php
- Create dedicated Valkey test workflow for GitHub Actions
- Update README to document Valkey support
- Test both predis and phpredis drivers with Valkey

Valkey is a Redis-compatible data store that works seamlessly with Horizon through Laravel's Redis abstraction layer.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
