### PR TITLE
Fix type casting for Carbon 3 compatibility in RedisJobRepository

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -81,12 +81,12 @@ class RedisJobRepository implements JobRepository
     public function __construct(RedisFactory $redis)
     {
         $this->redis = $redis;
-        $this->recentJobExpires = config('horizon.trim.recent', 60);
-        $this->pendingJobExpires = config('horizon.trim.pending', 60);
-        $this->completedJobExpires = config('horizon.trim.completed', 60);
-        $this->failedJobExpires = config('horizon.trim.failed', 10080);
-        $this->recentFailedJobExpires = config('horizon.trim.recent_failed', $this->failedJobExpires);
-        $this->monitoredJobExpires = config('horizon.trim.monitored', 10080);
+        $this->recentJobExpires = (int) config('horizon.trim.recent', 60);
+        $this->pendingJobExpires = (int) config('horizon.trim.pending', 60);
+        $this->completedJobExpires = (int) config('horizon.trim.completed', 60);
+        $this->failedJobExpires = (int) config('horizon.trim.failed', 10080);
+        $this->recentFailedJobExpires = (int) config('horizon.trim.recent_failed', $this->failedJobExpires);
+        $this->monitoredJobExpires = (int) config('horizon.trim.monitored', 10080);
     }
 
     /**


### PR DESCRIPTION
###   Carbon 3 Compatibility Fix for RedisJobRepository

  Laravel Horizon uses Carbon's addMinutes() and subMinutes() methods throughout the RedisJobRepository class for job expiration and cleanup operations. These methods are called with configuration values retrieved via Laravel's config() helper.

  The Problem:
  Carbon 3 introduced stricter type checking and no longer accepts string values for time manipulation methods like addMinutes() and subMinutes(). The config() helper can return string values (especially when reading from environment variables), which causes type errors in Carbon 3.

#### The Solution:
  This patch adds explicit integer casting (int) to all configuration values in the RedisJobRepository constructor:
  - horizon.trim.recent
  - horizon.trim.pending
  - horizon.trim.completed
  - horizon.trim.failed
  - horizon.trim.recent_failed
  - horizon.trim.monitored

#### Testing Examples:

Without this fix, the following common Laravel job operations would fail with Carbon 3:

```php
  // Basic job dispatch - fails during job tracking/expiration
  TestJob::dispatch();

  // Delayed job dispatch - fails when setting pending job expiration
  TestJob::dispatch()->delay(now()->addMinutes(5));

  // Job with specific queue - fails during queue management
  TestJob::dispatch()->onQueue('emails');

  // Failed job handling - fails during failed job expiration tracking
  TestJob::dispatch()->onQueue('processing');
```

Error Example (before fix):
  TypeError: Carbon\CarbonImmutable::addMinutes(): Argument #1 ($value) must be of type int, string given

Without the integer casting, Carbon 3 will throw type errors when these configuration values are strings, breaking job expiration, cleanup, and monitoring
  functionality in Laravel Horizon.

This change maintains backward compatibility while ensuring Laravel Horizon works correctly with both Carbon 2 and Carbon 3, supporting Laravel 11's requirements.