### PR TITLE
Use Config facade with integer() method for Laravel 11+ (breaks Laravel 9-10 compatibility)

### DIFF
--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\JobPayload;
 use Laravel\Horizon\LuaScripts;
@@ -81,12 +82,12 @@ class RedisJobRepository implements JobRepository
     public function __construct(RedisFactory $redis)
     {
         $this->redis = $redis;
-        $this->recentJobExpires = (int) config('horizon.trim.recent', 60);
-        $this->pendingJobExpires = (int) config('horizon.trim.pending', 60);
-        $this->completedJobExpires = (int) config('horizon.trim.completed', 60);
-        $this->failedJobExpires = (int) config('horizon.trim.failed', 10080);
-        $this->recentFailedJobExpires = (int) config('horizon.trim.recent_failed', $this->failedJobExpires);
-        $this->monitoredJobExpires = (int) config('horizon.trim.monitored', 10080);
+        $this->recentJobExpires = Config::integer('horizon.trim.recent', 60);
+        $this->pendingJobExpires = Config::integer('horizon.trim.pending', 60);
+        $this->completedJobExpires = Config::integer('horizon.trim.completed', 60);
+        $this->failedJobExpires = Config::integer('horizon.trim.failed', 10080);
+        $this->recentFailedJobExpires = Config::integer('horizon.trim.recent_failed', $this->failedJobExpires);
+        $this->monitoredJobExpires = Config::integer('horizon.trim.monitored', 10080);
     }
 
     /**


### PR DESCRIPTION
## Problem
The current implementation in `RedisJobRepository` uses the `config()` helper with explicit integer casting `(int)` for job trimming configuration values. This approach is not the Laravel best practice and can lead to type conversion issues.

## Solution
Replace the `config()` helper calls with the proper `Config` facade using the `integer()` method:

**Before (current):**
```php
$this->recentJobExpires = (int) config('horizon.trim.recent', 60);
$this->pendingJobExpires = (int) config('horizon.trim.pending', 60);
$this->completedJobExpires = (int) config('horizon.trim.completed', 60);
$this->failedJobExpires = (int) config('horizon.trim.failed', 10080);
$this->recentFailedJobExpires = (int) config('horizon.trim.recent_failed', $this->failedJobExpires);
$this->monitoredJobExpires = (int) config('horizon.trim.monitored', 10080);
```

**After (proposed):**
```php
$this->recentJobExpires = Config::integer('horizon.trim.recent', 60);
$this->pendingJobExpires = Config::integer('horizon.trim.pending', 60);
$this->completedJobExpires = Config::integer('horizon.trim.completed', 60);
$this->failedJobExpires = Config::integer('horizon.trim.failed', 10080);
$this->recentFailedJobExpires = Config::integer('horizon.trim.recent_failed', $this->failedJobExpires);
$this->monitoredJobExpires = Config::integer('horizon.trim.monitored', 10080);
```

## ⚠️ Breaking Change
**This PR will break compatibility with Laravel 9 and 10** because the `Config::integer()` method was introduced in Laravel 11.

## Benefits
- **Type Safety**: `Config::integer()` automatically handles type conversion and validation
- **Cleaner Code**: Eliminates the need for explicit `(int)` casting
- **Maintainability**: More readable and follows Laravel conventions

## Compatibility Impact
- ✅ **Laravel 11+**: Fully supported with `Config::integer()`
- ❌ **Laravel 9-10**: Will break - `Config::integer()` method not available
- 🔄 **Migration Required**: Projects on Laravel 9-10 must upgrade to use this code

## Alternative for Laravel 9-10
If you need to maintain Laravel 9-10 compatibility, continue using the current approach:
```php
$this->recentJobExpires = (int) config('horizon.trim.recent', 60);
```

## Technical Details
The `Config::integer()` method is designed specifically for retrieving integer configuration values and handles type conversion internally. This is superior to manually casting the result of the `config()` helper, which can return mixed types and require explicit casting.

## Recommendation
This change is recommended for Laravel 11+ projects as it follows current best practices. For projects that must maintain Laravel 9-10 compatibility, this PR should not be merged.