### PR TITLE
[5.x] Fix failed jobs infinite loading

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -63,6 +63,7 @@
                 this.$http.get(Horizon.basePath + '/api/jobs/failed?' + tagQuery + 'starting_at=' + starting)
                     .then(response => {
                         if (!this.$root.autoLoadsNewEntries && refreshing && !response.data.jobs.length) {
+                            this.ready = true;
                             return;
                         }
 


### PR DESCRIPTION
Fixes: https://github.com/laravel/horizon/issues/1570

## Summary
Currently, when `this.$root.autoLoadsNewEntries` is `0`, the failed jobs page can get stuck in the loading state during periodic refreshes. This happens because the `loadJobs()` method returns early without resetting `this.ready`, leaving the UI in the "Loading..." state indefinitely.

References:

https://github.com/laravel/horizon/blob/0a151520baae729168a26249f569ed7f06b14c8e/resources/js/screens/failedJobs/index.vue#L211-L217

https://github.com/laravel/horizon/blob/0a151520baae729168a26249f569ed7f06b14c8e/resources/js/screens/failedJobs/index.vue#L220-L222

## Changes

This PR fixes the issue by setting `this.ready = true` before returning when there are no new jobs to load.
