### PR TITLE
[5.x] refactor: conditions in monitoring page

### DIFF
--- a/resources/js/screens/monitoring/index.vue
+++ b/resources/js/screens/monitoring/index.vue
@@ -125,7 +125,10 @@
                 <button @click="openNewTagModal" class="btn btn-primary btn-sm">Monitor Tag</button>
             </div>
 
-            <div v-if="!ready" class="d-flex align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
+            <div
+                v-if="!ready"
+                class="d-flex align-items-center justify-content-center card-bg-secondary p-5 bottom-radius"
+            >
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon spin me-2 fill-text-color">
                     <path d="M12 10a2 2 0 0 1-3.41 1.41A2 2 0 0 1 10 8V0a9.97 9.97 0 0 1 10 10h-8zm7.9 1.41A10 10 0 1 1 8.59.1v2.03a8 8 0 1 0 9.29 9.29h2.02zm-4.07 0a6 6 0 1 1-7.25-7.25v2.1a3.99 3.99 0 0 0-1.4 6.57 4 4 0 0 0 6.56-1.42h2.1z"></path>
                 </svg>
@@ -133,39 +136,40 @@
                 <span>Loading...</span>
             </div>
 
-
-            <div v-if="ready && tags.length == 0" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
-                <span>You're not monitoring any tags.</span>
-            </div>
-
-
-            <table v-if="ready && tags.length > 0" class="table table-hover mb-0">
+            <table v-else-if="tags.length !== 0" class="table table-hover mb-0">
                 <thead>
-                <tr>
-                    <th>Tag</th>
-                    <th class="text-end">Jobs</th>
-                    <th class="text-end"></th>
-                </tr>
+                    <tr>
+                        <th>Tag</th>
+                        <th class="text-end">Jobs</th>
+                        <th class="text-end"></th>
+                    </tr>
                 </thead>
 
                 <tbody>
-                <tr v-for="tag in tags">
-                    <td>
-                        <router-link :to="{ name: 'monitoring-jobs', params: { tag:tag.tag }}" href="#">
-                            {{ tag.tag }}
-                        </router-link>
-                    </td>
-                    <td class="text-end text-muted">{{ tag.count }}</td>
-                    <td class="text-end">
-                        <a href="#" @click="stopMonitoring(tag.tag)" class="control-action" title="Stop Monitoring">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
-                            </svg>
-                        </a>
-                    </td>
-                </tr>
+                    <tr v-for="tag in tags">
+                        <td>
+                            <router-link :to="{ name: 'monitoring-jobs', params: { tag:tag.tag }}" href="#">
+                                {{ tag.tag }}
+                            </router-link>
+                        </td>
+                        <td class="text-end text-muted">{{ tag.count }}</td>
+                        <td class="text-end">
+                            <a href="#" @click="stopMonitoring(tag.tag)" class="control-action" title="Stop Monitoring">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+                                </svg>
+                            </a>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
+
+            <div
+                v-else
+                class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius"
+            >
+                <span>You're not monitoring any tags.</span>
+            </div>
         </div>
 
         <div class="modal" id="addTagModel" tabindex="-1" role="dialog" aria-labelledby="alertModalLabel" aria-hidden="true">
@@ -193,6 +197,5 @@
                 </div>
             </div>
         </div>
-
     </div>
 </template>


### PR DESCRIPTION
## 📌 What this PR Does

This PR refactors the conditional rendering logic for displaying monitored tags. The previous implementation used multiple `v-if` blocks to separately handle the loading, empty, and data-present states. This approach was functionally correct but less readable and harder to maintain.

The new version uses a clear and concise `v-if / v-else-if / v-else` structure to handle the UI logic for:

- Loading state
- Empty state (no tags being monitored)
- Data state (monitored tags available)

---

## ✅ Benefits of This Change

- **Improved Readability & Maintainability**  
  The conditional rendering logic is now easier to follow and reason about.

- **Reduced Repetition**  
  Duplicate logic and markup are minimized, making the codebase leaner.

- **Scalable Pattern**  
  This logic can be reused across similar pages to establish a consistent pattern.

---

## 🔍 Additional Context

This issue (disjointed and repetitive state handling) exists across **multiple pages** within Laravel Horizon where similar loading/empty/data states are being handled.

If approved, I’m happy to refactor other instances across the app to follow this same pattern, ensuring consistency and simplifying future maintenance.
