### PR TITLE
[5.x] Make "no jobs" messages consistent across job types in Horizon panel

### DIFF
--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -162,7 +162,10 @@
 
             <div v-if="ready && jobs.length == 0"
                  class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
-                <span>There aren't any jobs.</span>
+                <span v-if="$route.params.type == 'pending'">There aren't any pending jobs.</span>
+                <span v-else-if="$route.params.type == 'completed'">There aren't any completed jobs.</span>
+                <span v-else-if="$route.params.type == 'silenced'">There aren't any silenced jobs.</span>
+                <span v-else>There aren't any jobs.</span>
             </div>
 
             <table v-if="ready && jobs.length > 0" class="table table-hover mb-0">


### PR DESCRIPTION
Currently, the Horizon dashboard displays inconsistent messages across different sections:

- Failed Jobs tab: `There aren't any failed jobs`.
- Batches tab: `There aren't any batches`.
- Pending/Completed/Silenced tabs: `There aren't any jobs`. (generic)

This PR updates the jobs screen to show a context-aware message depending on the selected job type, ensuring consistency across the UI.

## Changes

- Pending tab: `There aren't any pending jobs`.
- Completed tab: `There aren't any completed jobs`.
- Silenced tab: `There aren't any silenced jobs`.
