### PR TITLE
[5.x] Convert closures to arrow functions

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -49,9 +49,7 @@ class AutoScaler
             $supervisor, $this->timeToClearPerQueue($supervisor, $pools)
         );
 
-        $workers->each(function ($workers, $queue) use ($supervisor, $pools) {
-            $this->scalePool($supervisor, $pools[$queue], $workers);
-        });
+        $workers->each(fn($workers, $queue) => $this->scalePool($supervisor, $pools[$queue], $workers));
     }
 
     /**

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -49,7 +49,7 @@ class AutoScaler
             $supervisor, $this->timeToClearPerQueue($supervisor, $pools)
         );
 
-        $workers->each(fn($workers, $queue) => $this->scalePool($supervisor, $pools[$queue], $workers));
+        $workers->each(fn ($workers, $queue) => $this->scalePool($supervisor, $pools[$queue], $workers));
     }
 
     /**

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -101,9 +101,7 @@ class PurgeCommand extends Command
         collect($expired)
             ->whenNotEmpty(fn () => $this->components->info('Sending TERM signal to expired processes of ['.$master.']'))
             ->each(function ($processId) use ($master, $signal) {
-                $this->components->task("Process: $processId", function () use ($processId, $signal) {
-                    exec("kill -s {$signal} {$processId}");
-                });
+                $this->components->task("Process: $processId", fn() => exec("kill -s {$signal} {$processId}"));
 
                 $this->processes->forgetOrphans($master, [$processId]);
             })->whenNotEmpty(fn () => $this->output->writeln(''));

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -101,7 +101,7 @@ class PurgeCommand extends Command
         collect($expired)
             ->whenNotEmpty(fn () => $this->components->info('Sending TERM signal to expired processes of ['.$master.']'))
             ->each(function ($processId) use ($master, $signal) {
-                $this->components->task("Process: $processId", fn() => exec("kill -s {$signal} {$processId}"));
+                $this->components->task("Process: $processId", fn () => exec("kill -s {$signal} {$processId}"));
 
                 $this->processes->forgetOrphans($master, [$processId]);
             })->whenNotEmpty(fn () => $this->output->writeln(''));

--- a/src/MasterSupervisorCommands/AddSupervisor.php
+++ b/src/MasterSupervisorCommands/AddSupervisor.php
@@ -21,9 +21,7 @@ class AddSupervisor
         $options = SupervisorOptions::fromArray($options);
 
         $master->supervisors[] = new SupervisorProcess(
-            $options, $this->createProcess($master, $options), function ($type, $line) use ($master) {
-                $master->output($type, $line);
-            }
+            $options, $this->createProcess($master, $options), fn($type, $line) => $master->output($type, $line)
         );
     }
 

--- a/src/MasterSupervisorCommands/AddSupervisor.php
+++ b/src/MasterSupervisorCommands/AddSupervisor.php
@@ -21,7 +21,7 @@ class AddSupervisor
         $options = SupervisorOptions::fromArray($options);
 
         $master->supervisors[] = new SupervisorProcess(
-            $options, $this->createProcess($master, $options), fn($type, $line) => $master->output($type, $line)
+            $options, $this->createProcess($master, $options), fn ($type, $line) => $master->output($type, $line)
         );
     }
 

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -68,9 +68,7 @@ class ProvisioningPlan
      */
     protected function applyDefaultOptions(array $plan, array $defaults = [])
     {
-        return collect($plan)->map(function ($plan) use ($defaults) {
-            return array_replace_recursive($defaults, $plan);
-        })->all();
+        return collect($plan)->map(fn($plan) => array_replace_recursive($defaults, $plan))->all();
     }
 
     /**

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -68,7 +68,7 @@ class ProvisioningPlan
      */
     protected function applyDefaultOptions(array $plan, array $defaults = [])
     {
-        return collect($plan)->map(fn($plan) => array_replace_recursive($defaults, $plan))->all();
+        return collect($plan)->map(fn ($plan) => array_replace_recursive($defaults, $plan))->all();
     }
 
     /**

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -114,9 +114,7 @@ class RedisQueue extends BaseQueue
                 $queue,
                 $delay,
                 function ($payload, $queue, $delay) {
-                    return tap(parent::laterRaw($delay, $payload, $queue), function () use ($payload, $queue) {
-                        $this->event($this->getQueue($queue), new JobPushed($payload));
-                    });
+                    return tap(parent::laterRaw($delay, $payload, $queue), fn() => $this->event($this->getQueue($queue), new JobPushed($payload)));
                 }
             );
         }
@@ -153,9 +151,7 @@ class RedisQueue extends BaseQueue
     #[\Override]
     public function migrateExpiredJobs($from, $to)
     {
-        return tap(parent::migrateExpiredJobs($from, $to), function ($jobs) use ($to) {
-            $this->event($to, new JobsMigrated($jobs === false ? [] : $jobs));
-        });
+        return tap(parent::migrateExpiredJobs($from, $to), fn($jobs) => $this->event($to, new JobsMigrated($jobs === false ? [] : $jobs)));
     }
 
     /**

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -114,7 +114,7 @@ class RedisQueue extends BaseQueue
                 $queue,
                 $delay,
                 function ($payload, $queue, $delay) {
-                    return tap(parent::laterRaw($delay, $payload, $queue), fn() => $this->event($this->getQueue($queue), new JobPushed($payload)));
+                    return tap(parent::laterRaw($delay, $payload, $queue), fn () => $this->event($this->getQueue($queue), new JobPushed($payload)));
                 }
             );
         }
@@ -151,7 +151,7 @@ class RedisQueue extends BaseQueue
     #[\Override]
     public function migrateExpiredJobs($from, $to)
     {
-        return tap(parent::migrateExpiredJobs($from, $to), fn($jobs) => $this->event($to, new JobsMigrated($jobs === false ? [] : $jobs)));
+        return tap(parent::migrateExpiredJobs($from, $to), fn ($jobs) => $this->event($to, new JobsMigrated($jobs === false ? [] : $jobs)));
     }
 
     /**

--- a/src/Repositories/RedisProcessRepository.php
+++ b/src/Repositories/RedisProcessRepository.php
@@ -76,9 +76,7 @@ class RedisProcessRepository implements ProcessRepository
     {
         $expiresAt = CarbonImmutable::now()->getTimestamp() - $seconds;
 
-        return collect($this->allOrphans($master))->filter(function ($recordedAt, $_) use ($expiresAt) {
-            return $expiresAt > $recordedAt;
-        })->keys()->all();
+        return collect($this->allOrphans($master))->filter(fn($recordedAt, $_) => $expiresAt > $recordedAt)->keys()->all();
     }
 
     /**

--- a/src/Repositories/RedisProcessRepository.php
+++ b/src/Repositories/RedisProcessRepository.php
@@ -76,7 +76,7 @@ class RedisProcessRepository implements ProcessRepository
     {
         $expiresAt = CarbonImmutable::now()->getTimestamp() - $seconds;
 
-        return collect($this->allOrphans($master))->filter(fn($recordedAt, $_) => $expiresAt > $recordedAt)->keys()->all();
+        return collect($this->allOrphans($master))->filter(fn ($recordedAt, $_) => $expiresAt > $recordedAt)->keys()->all();
     }
 
     /**

--- a/src/Repositories/RedisTagRepository.php
+++ b/src/Repositories/RedisTagRepository.php
@@ -139,9 +139,7 @@ class RedisTagRepository implements TagRepository
             $tag, $startingAt, $startingAt + $limit - 1
         );
 
-        return collect($tags)->values()->mapWithKeys(function ($tag, $index) use ($startingAt) {
-            return [$index + $startingAt => $tag];
-        })->all();
+        return collect($tags)->values()->mapWithKeys(fn($tag, $index) => [$index + $startingAt => $tag])->all();
     }
 
     /**

--- a/src/Repositories/RedisTagRepository.php
+++ b/src/Repositories/RedisTagRepository.php
@@ -139,7 +139,7 @@ class RedisTagRepository implements TagRepository
             $tag, $startingAt, $startingAt + $limit - 1
         );
 
-        return collect($tags)->values()->mapWithKeys(fn($tag, $index) => [$index + $startingAt => $tag])->all();
+        return collect($tags)->values()->mapWithKeys(fn ($tag, $index) => [$index + $startingAt => $tag])->all();
     }
 
     /**

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -74,7 +74,7 @@ class RedisWorkloadRepository implements WorkloadRepository
 
                 $length = ! Str::contains($queue, ',')
                     ? collect([$queueName => $this->queue->connection($connection)->readyNow($queueName)])
-                    : collect(explode(',', $queueName))->mapWithKeys(fn($queueName) => [$queueName => $this->queue->connection($connection)->readyNow($queueName)]);
+                    : collect(explode(',', $queueName))->mapWithKeys(fn ($queueName) => [$queueName => $this->queue->connection($connection)->readyNow($queueName)]);
 
                 $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses, &$wait) {
                     return [

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -74,9 +74,7 @@ class RedisWorkloadRepository implements WorkloadRepository
 
                 $length = ! Str::contains($queue, ',')
                     ? collect([$queueName => $this->queue->connection($connection)->readyNow($queueName)])
-                    : collect(explode(',', $queueName))->mapWithKeys(function ($queueName) use ($connection) {
-                        return [$queueName => $this->queue->connection($connection)->readyNow($queueName)];
-                    });
+                    : collect(explode(',', $queueName))->mapWithKeys(fn($queueName) => [$queueName => $this->queue->connection($connection)->readyNow($queueName)]);
 
                 $splitQueues = Str::contains($queue, ',') ? $length->map(function ($length, $queueName) use ($connection, $totalProcesses, &$wait) {
                     return [

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -139,7 +139,7 @@ class Supervisor implements Pausable, Restartable, Terminable
             $processes, count($this->processPools)
         );
 
-        $this->balance($this->processPools->mapWithKeys(fn($pool) => [$pool->queue() => floor($processes / count($this->processPools))])->all());
+        $this->balance($this->processPools->mapWithKeys(fn ($pool) => [$pool->queue() => floor($processes / count($this->processPools))])->all());
     }
 
     /**

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -139,9 +139,7 @@ class Supervisor implements Pausable, Restartable, Terminable
             $processes, count($this->processPools)
         );
 
-        $this->balance($this->processPools->mapWithKeys(function ($pool) use ($processes) {
-            return [$pool->queue() => floor($processes / count($this->processPools))];
-        })->all());
+        $this->balance($this->processPools->mapWithKeys(fn($pool) => [$pool->queue() => floor($processes / count($this->processPools))])->all());
     }
 
     /**

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -250,9 +250,7 @@ class SupervisorOptions
      */
     public function withQueue($queue)
     {
-        return tap(clone $this, function ($options) use ($queue) {
-            $options->queue = $queue;
-        });
+        return tap(clone $this, fn($options) => $options->queue = $queue);
     }
 
     /**

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -250,7 +250,7 @@ class SupervisorOptions
      */
     public function withQueue($queue)
     {
-        return tap(clone $this, fn($options) => $options->queue = $queue);
+        return tap(clone $this, fn ($options) => $options->queue = $queue);
     }
 
     /**

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -104,7 +104,7 @@ class WaitTimeCalculator
      */
     protected function totalProcessesFor($allSupervisors, $queue)
     {
-        return $allSupervisors->sum(fn($supervisor) => $supervisor->processes[$queue] ?? 0);
+        return $allSupervisors->sum(fn ($supervisor) => $supervisor->processes[$queue] ?? 0);
     }
 
     /**

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -104,9 +104,7 @@ class WaitTimeCalculator
      */
     protected function totalProcessesFor($allSupervisors, $queue)
     {
-        return $allSupervisors->sum(function ($supervisor) use ($queue) {
-            return $supervisor->processes[$queue] ?? 0;
-        });
+        return $allSupervisors->sum(fn($supervisor) => $supervisor->processes[$queue] ?? 0);
     }
 
     /**


### PR DESCRIPTION
This PR refactors certain sections of the code by converting closures into arrow functions.

### Motivation:
- Cleaner Syntax: Reduces boilerplate by eliminating the need for `use` to pass variables into closures.
- Improved Readability: Arrow functions make the code more concise and easier to read.
