### PR TITLE
[5.x] fix ternary newline indentation

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -126,8 +126,8 @@ class AutoScaler
                       $supervisor->options->autoScaling()) {
                 return [
                     $queue => $timeToClear['size']
-                                ? $supervisor->options->maxProcesses
-                                : $supervisor->options->minProcesses,
+                        ? $supervisor->options->maxProcesses
+                        : $supervisor->options->minProcesses,
                 ];
             }
 

--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -73,8 +73,8 @@ class PurgeCommand extends Command
     public function handle(MasterSupervisorRepository $masters)
     {
         $signal = is_numeric($signal = $this->option('signal'))
-                        ? $signal
-                        : constant($signal);
+            ? $signal
+            : constant($signal);
 
         foreach ($masters->names() as $master) {
             if (Str::startsWith($master, MasterSupervisor::basename())) {

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -112,8 +112,8 @@ class SupervisorCommand extends Command
     protected function supervisorOptions()
     {
         $backoff = $this->hasOption('backoff')
-                    ? $this->option('backoff')
-                    : $this->option('delay');
+            ? $this->option('backoff')
+            : $this->option('delay');
 
         $balance = $this->option('balance');
 

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -171,8 +171,8 @@ class HorizonServiceProvider extends ServiceProvider
     {
         foreach ($this->serviceBindings as $key => $value) {
             is_numeric($key)
-                    ? $this->app->singleton($value)
-                    : $this->app->singleton($key, $value);
+                ? $this->app->singleton($value)
+                : $this->app->singleton($key, $value);
         }
     }
 

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -46,12 +46,12 @@ class FailedJobsController extends Controller
     public function index(Request $request)
     {
         $jobs = ! $request->query('tag')
-                ? $this->paginate($request)
-                : $this->paginateByTag($request, $request->query('tag'));
+            ? $this->paginate($request)
+            : $this->paginateByTag($request, $request->query('tag'));
 
         $total = $request->query('tag')
-                ? $this->tags->count('failed:'.$request->query('tag'))
-                : $this->jobs->countFailed();
+            ? $this->tags->count('failed:'.$request->query('tag'))
+            : $this->jobs->countFailed();
 
         return [
             'jobs' => $jobs,

--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -80,7 +80,7 @@ class RetryFailedJob
         $pushedAt = $payload['pushedAt'] ?? microtime(true);
 
         return $retryUntil
-                        ? CarbonImmutable::now()->addSeconds(ceil($retryUntil - $pushedAt))->getTimestamp()
-                        : null;
+            ? CarbonImmutable::now()->addSeconds(ceil($retryUntil - $pushedAt))->getTimestamp()
+            : null;
     }
 }

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -107,8 +107,8 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     public static function basename()
     {
         return static::$nameResolver
-                        ? call_user_func(static::$nameResolver)
-                        : Str::slug(gethostname());
+            ? call_user_func(static::$nameResolver)
+            : Str::slug(gethostname());
     }
 
     /**

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -176,8 +176,8 @@ class ProcessPool implements Countable
     protected function createProcess()
     {
         $class = config('horizon.fast_termination')
-                    ? BackgroundProcess::class
-                    : Process::class;
+            ? BackgroundProcess::class
+            : Process::class;
 
         return new WorkerProcess($class::fromShellCommandline(
             $this->options->toWorkerCommand(), $this->options->directory

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -514,8 +514,8 @@ class RedisJobRepository implements JobRepository
     {
         return collect($retries)->map(function ($retry) use ($payload, $failed) {
             return $retry['id'] === $payload->id()
-                    ? Arr::set($retry, 'status', $failed ? 'failed' : 'completed')
-                    : $retry;
+                ? Arr::set($retry, 'status', $failed ? 'failed' : 'completed')
+                : $retry;
         })->all();
     }
 

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -333,7 +333,7 @@ class RedisMetricsRepository implements MetricsRepository
     protected function minutesSinceLastSnapshot()
     {
         $lastSnapshotAt = (int) ($this->connection()->get('last_snapshot_at')
-                                    ?: $this->storeSnapshotTimestamp());
+            ?: $this->storeSnapshotTimestamp());
 
         return max(
             (CarbonImmutable::now()->getTimestamp() - $lastSnapshotAt) / 60, 1

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -88,8 +88,8 @@ class Supervisor implements Pausable, Restartable, Terminable
     public function createProcessPools()
     {
         return $this->options->balancing()
-                        ? $this->createProcessPoolPerQueue()
-                        : $this->createSingleProcessPool();
+            ? $this->createProcessPoolPerQueue()
+            : $this->createSingleProcessPool();
     }
 
     /**

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -47,8 +47,8 @@ class Tags
     public static function extractExplicitTags($job)
     {
         return $job instanceof CallQueuedListener
-                    ? static::tagsForListener($job)
-                    : static::explicitTags(static::targetsFor($job));
+            ? static::tagsForListener($job)
+            : static::explicitTags(static::targetsFor($job));
     }
 
     /**
@@ -167,8 +167,8 @@ class Tags
     protected static function extractEvent($job)
     {
         return isset($job->data[0]) && is_object($job->data[0])
-                        ? $job->data[0]
-                        : new stdClass;
+            ? $job->data[0]
+            : new stdClass;
     }
 
     /**

--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -159,8 +159,8 @@ class WorkerProcess
 
         if ($this->restartAgainAt) {
             $this->restartAgainAt = ! $this->process->isRunning()
-                            ? CarbonImmutable::now()->addMinute()
-                            : null;
+                ? CarbonImmutable::now()->addMinute()
+                : null;
 
             if (! $this->process->isRunning()) {
                 event(new UnableToLaunchProcess($this));


### PR DESCRIPTION
just as we now do in `laravel/framework`, we'll indent newline ternary statements once.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
