### PR TITLE
[5.x] use normal formatting for method signature

### DIFF
--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -15,8 +15,7 @@ class MasterSupervisorController extends Controller
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
      * @return \Illuminate\Support\Collection
      */
-    public function index(MasterSupervisorRepository $masters,
-                          SupervisorRepository $supervisors)
+    public function index(MasterSupervisorRepository $masters, SupervisorRepository $supervisors)
     {
         $masters = collect($masters->all())->keyBy('name')->sortBy('name');
 


### PR DESCRIPTION
wrong formatting for multiline method signature.  single or multi line would be fine here, but switched it to single since it's simple.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
