### PR TITLE
[6.x] listeners promoted properties

### DIFF
--- a/src/Listeners/ForgetJobTimer.php
+++ b/src/Listeners/ForgetJobTimer.php
@@ -7,21 +7,14 @@ use Laravel\Horizon\Stopwatch;
 class ForgetJobTimer
 {
     /**
-     * The stopwatch instance.
-     *
-     * @var \Laravel\Horizon\Stopwatch
-     */
-    public $watch;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Stopwatch  $watch
+     * @param  \Laravel\Horizon\Stopwatch  $watch  The stopwatch instance.
      * @return void
      */
-    public function __construct(Stopwatch $watch)
-    {
-        $this->watch = $watch;
+    public function __construct(
+        public Stopwatch $watch,
+    ) {
     }
 
     /**

--- a/src/Listeners/MarkJobAsComplete.php
+++ b/src/Listeners/MarkJobAsComplete.php
@@ -9,30 +9,16 @@ use Laravel\Horizon\Events\JobDeleted;
 class MarkJobAsComplete
 {
     /**
-     * The job repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\JobRepository
-     */
-    public $jobs;
-
-    /**
-     * The tag repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\TagRepository
-     */
-    public $tags;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs  The job repository implementation.
+     * @param  \Laravel\Horizon\Contracts\TagRepository  $tags  The tag repository implementation.
      * @return void
      */
-    public function __construct(JobRepository $jobs, TagRepository $tags)
-    {
-        $this->jobs = $jobs;
-        $this->tags = $tags;
+    public function __construct(
+        public JobRepository $jobs,
+        public TagRepository $tags,
+    ) {
     }
 
     /**

--- a/src/Listeners/MarkJobAsFailed.php
+++ b/src/Listeners/MarkJobAsFailed.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobFailed;
 class MarkJobAsFailed
 {
     /**
-     * The job repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\JobRepository
-     */
-    public $jobs;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs  The job repository implementation.
      * @return void
      */
-    public function __construct(JobRepository $jobs)
-    {
-        $this->jobs = $jobs;
+    public function __construct(
+        public JobRepository $jobs,
+    ) {
     }
 
     /**

--- a/src/Listeners/MarkJobAsReleased.php
+++ b/src/Listeners/MarkJobAsReleased.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobReleased;
 class MarkJobAsReleased
 {
     /**
-     * The job repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\JobRepository
-     */
-    public $jobs;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs  The job repository implementation.
      * @return void
      */
-    public function __construct(JobRepository $jobs)
-    {
-        $this->jobs = $jobs;
+    public function __construct(
+        public JobRepository $jobs,
+    ) {
     }
 
     /**

--- a/src/Listeners/MarkJobAsReserved.php
+++ b/src/Listeners/MarkJobAsReserved.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobReserved;
 class MarkJobAsReserved
 {
     /**
-     * The job repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\JobRepository
-     */
-    public $jobs;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs  The job repository implementation.
      * @return void
      */
-    public function __construct(JobRepository $jobs)
-    {
-        $this->jobs = $jobs;
+    public function __construct(
+        public JobRepository $jobs,
+    ) {
     }
 
     /**

--- a/src/Listeners/MarkJobsAsMigrated.php
+++ b/src/Listeners/MarkJobsAsMigrated.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobsMigrated;
 class MarkJobsAsMigrated
 {
     /**
-     * The job repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\JobRepository
-     */
-    public $jobs;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs  The job repository implementation.
      * @return void
      */
-    public function __construct(JobRepository $jobs)
-    {
-        $this->jobs = $jobs;
+    public function __construct(
+        public JobRepository $jobs,
+    ) {
     }
 
     /**

--- a/src/Listeners/MarshalFailedEvent.php
+++ b/src/Listeners/MarshalFailedEvent.php
@@ -10,21 +10,14 @@ use Laravel\Horizon\Events\JobFailed;
 class MarshalFailedEvent
 {
     /**
-     * The event dispatcher implementation.
-     *
-     * @var \Illuminate\Contracts\Events\Dispatcher
-     */
-    public $events;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events  The event dispatcher implementation.
      * @return void
      */
-    public function __construct(Dispatcher $events)
-    {
-        $this->events = $events;
+    public function __construct(
+        public Dispatcher $events,
+    ) {
     }
 
     /**

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -10,13 +10,6 @@ use Laravel\Horizon\WaitTimeCalculator;
 class MonitorWaitTimes
 {
     /**
-     * The metrics repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\MetricsRepository
-     */
-    public $metrics;
-
-    /**
      * The time at which we last checked if monitoring was due.
      *
      * @var \Carbon\CarbonImmutable
@@ -26,12 +19,12 @@ class MonitorWaitTimes
     /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
+     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics  The metrics repository implementation.
      * @return void
      */
-    public function __construct(MetricsRepository $metrics)
-    {
-        $this->metrics = $metrics;
+    public function __construct(
+        public MetricsRepository $metrics,
+    ) {
     }
 
     /**

--- a/src/Listeners/StartTimingJob.php
+++ b/src/Listeners/StartTimingJob.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Stopwatch;
 class StartTimingJob
 {
     /**
-     * The stopwatch instance.
-     *
-     * @var \Laravel\Horizon\Stopwatch
-     */
-    public $watch;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Stopwatch  $watch
+     * @param  \Laravel\Horizon\Stopwatch  $watch  The stopwatch instance.
      * @return void
      */
-    public function __construct(Stopwatch $watch)
-    {
-        $this->watch = $watch;
+    public function __construct(
+        public Stopwatch $watch,
+    ) {
     }
 
     /**

--- a/src/Listeners/StoreJob.php
+++ b/src/Listeners/StoreJob.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobPushed;
 class StoreJob
 {
     /**
-     * The job repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\JobRepository
-     */
-    public $jobs;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs  The job repository implementation.
      * @return void
      */
-    public function __construct(JobRepository $jobs)
-    {
-        $this->jobs = $jobs;
+    public function __construct(
+        public JobRepository $jobs,
+    ) {
     }
 
     /**

--- a/src/Listeners/StoreMonitoredTags.php
+++ b/src/Listeners/StoreMonitoredTags.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobPushed;
 class StoreMonitoredTags
 {
     /**
-     * The tag repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\TagRepository
-     */
-    public $tags;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
+     * @param  \Laravel\Horizon\Contracts\TagRepository  $tags  The tag repository implementation.
      * @return void
      */
-    public function __construct(TagRepository $tags)
-    {
-        $this->tags = $tags;
+    public function __construct(
+        public TagRepository $tags,
+    ) {
     }
 
     /**

--- a/src/Listeners/StoreTagsForFailedJob.php
+++ b/src/Listeners/StoreTagsForFailedJob.php
@@ -8,21 +8,14 @@ use Laravel\Horizon\Events\JobFailed;
 class StoreTagsForFailedJob
 {
     /**
-     * The tag repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\TagRepository
-     */
-    public $tags;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
+     * @param  \Laravel\Horizon\Contracts\TagRepository  $tags  The tag repository implementation.
      * @return void
      */
-    public function __construct(TagRepository $tags)
-    {
-        $this->tags = $tags;
+    public function __construct(
+        public TagRepository $tags,
+    ) {
     }
 
     /**

--- a/src/Listeners/UpdateJobMetrics.php
+++ b/src/Listeners/UpdateJobMetrics.php
@@ -9,30 +9,16 @@ use Laravel\Horizon\Stopwatch;
 class UpdateJobMetrics
 {
     /**
-     * The metrics repository implementation.
-     *
-     * @var \Laravel\Horizon\Contracts\MetricsRepository
-     */
-    public $metrics;
-
-    /**
-     * The stopwatch instance.
-     *
-     * @var \Laravel\Horizon\Stopwatch
-     */
-    public $watch;
-
-    /**
      * Create a new listener instance.
      *
-     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
-     * @param  \Laravel\Horizon\Stopwatch  $watch
+     * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics  The metrics repository implementation.
+     * @param  \Laravel\Horizon\Stopwatch  $watch  The stopwatch instance.
      * @return void
      */
-    public function __construct(MetricsRepository $metrics, Stopwatch $watch)
-    {
-        $this->watch = $watch;
-        $this->metrics = $metrics;
+    public function __construct(
+        public MetricsRepository $metrics,
+        public Stopwatch $watch,
+    ) {
     }
 
     /**


### PR DESCRIPTION
the reason this is sent to `master` is because even though the constructor parameters are type hinted, the properties themselves were not.

- move the property comment to the constructor

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
