### PR TITLE
[5.x] Add `$tags` property support

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -82,7 +82,17 @@ class Tags
     protected static function explicitTags(array $jobs)
     {
         return collect($jobs)
-            ->map(fn ($job) => method_exists($job, 'tags') ? $job->tags(static::$event) : [])
+            ->map(function ($job) {
+                if (method_exists($job, 'tags')) {
+                    $tags = $job->tags(static::$event);
+                } elseif (property_exists($job, 'tags')) {
+                    $tags = $job->tags;
+                } else {
+                    $tags = [];
+                }
+
+                return $tags;
+            })
             ->collapse()
             ->unique()
             ->all();

--- a/tests/Feature/Fixtures/FakeJobWithTagsProperty.php
+++ b/tests/Feature/Fixtures/FakeJobWithTagsProperty.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Fixtures;
+
+class FakeJobWithTagsProperty
+{
+    public $tags = ['first', 'second'];
+}

--- a/tests/Feature/RedisPayloadTest.php
+++ b/tests/Feature/RedisPayloadTest.php
@@ -15,6 +15,7 @@ use Laravel\Horizon\Tests\Feature\Fixtures\FakeEventWithModel;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeJobWithEloquentCollection;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeJobWithEloquentModel;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeJobWithTagsMethod;
+use Laravel\Horizon\Tests\Feature\Fixtures\FakeJobWithTagsProperty;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListener;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListenerSilenced;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeListenerWithDynamicTags;
@@ -168,6 +169,14 @@ class RedisPayloadTest extends IntegrationTest
         $JobPayload = new JobPayload(json_encode(['id' => 1]));
 
         $JobPayload->prepare(new FakeJobWithTagsMethod);
+        $this->assertEquals(['first', 'second'], $JobPayload->decoded['tags']);
+    }
+
+    public function test_jobs_can_have_tags_property_to_override_auto_tagging()
+    {
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $JobPayload->prepare(new FakeJobWithTagsProperty);
         $this->assertEquals(['first', 'second'], $JobPayload->decoded['tags']);
     }
 


### PR DESCRIPTION
## Description

This PR adds support for a public `$tags` property in Laravel Horizon.

Currently, Horizon determines tags primarily via the `tags()` method or by inspecting models referenced in the job. With this change, developers can now declare tags using a simple `$tags` property.

## Benefits

- Similar to how `$queue`, `$connection`, `$uniqueFor`, etc., can be defined either as a property or via a method in Laravel.
- Easier declaration of tags.
- Fully backward compatible with `tags()` method.
- Works for both jobs and queued event listeners.

## Usage

```php
class Job implements ShouldQueue
{
    public $tags = ['Critical', 'HighPriority'];

    public function handle()
    {
        //...
    }
}
```