### PR TITLE
feat(metrics): Display job performance stats on metrics index

### DIFF
--- a/resources/js/screens/metrics/jobs.vue
+++ b/resources/js/screens/metrics/jobs.vue
@@ -59,6 +59,8 @@
             <thead>
             <tr>
                 <th>Job</th>
+                <th>Throughput</th>
+                <th>Runtime Average</th>
             </tr>
             </thead>
 
@@ -67,9 +69,15 @@
 
             <tr v-for="job in jobs" :key="job">
                 <td>
-                    <router-link class="text-decoration-none" :to="{ name: 'metrics-preview', params: { type: 'jobs', slug: job }}">
-                        {{ job }}
+                    <router-link class="text-decoration-none" :to="{ name: 'metrics-preview', params: { type: 'jobs', slug: job.name }}">
+                        {{ job.name }}
                     </router-link>
+                </td>
+                <td>
+                    {{ job.total_throughput }}
+                </td>
+                <td>
+                    {{ job.average_runtime }}s
                 </td>
             </tr>
             </tbody>

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -31,7 +31,8 @@ class RedisMetricsRepository implements MetricsRepository
     }
 
     /**
-     * Get all of the class names that have metrics measurements.
+     * Get all of the class names that have metrics measurements,
+     * including their average runtime and throughput.
      *
      * @return array
      */
@@ -39,11 +40,40 @@ class RedisMetricsRepository implements MetricsRepository
     {
         $classes = (array) $this->connection()->smembers('measured_jobs');
 
-        return collect($classes)
-            ->map(fn ($class) => preg_match('/job:(.*)$/', $class, $matches) ? $matches[1] : $class)
-            ->sort()
-            ->values()
-            ->all();
+        return collect($classes)->map(function ($class) {
+            $jobName = preg_match('/job:(.*)$/', $class, $matches) ? $matches[1] : $class;
+
+            $snapshots = $this->snapshotsForJob($jobName);
+
+            if (empty($snapshots)) {
+                return null;
+            }
+
+            $totalRuntimeInSeconds = 0;
+            $totalThroughput = 0;
+
+            foreach ($snapshots as $snapshot) {
+                if (isset($snapshot->runtime) && $snapshot->runtime > 0 && isset($snapshot->throughput) && $snapshot->throughput > 0) {
+                    $runtimeInSeconds = $snapshot->runtime / 1000;
+
+                    $totalRuntimeInSeconds += $runtimeInSeconds * $snapshot->throughput;
+                    $totalThroughput += $snapshot->throughput;
+                }
+            }
+
+            if ($totalThroughput > 0) {
+                return [
+                    'name' => $jobName,
+                    'average_runtime' => round($totalRuntimeInSeconds / $totalThroughput, 3),
+                    'total_throughput' => $totalThroughput,
+                ];
+            }
+
+            return null;
+        })->filter()
+        ->sortByDesc('average_runtime')
+        ->values()
+        ->all();
     }
 
     /**

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -58,7 +58,7 @@ class RedisMetricsRepository implements MetricsRepository
             }
 
             if ($totalThroughput > 0) {
-                $averageRuntime = ($totalRuntimeInSeconds / $totalThroughput) * 1000; // Convert back to milliseconds
+                $averageRuntime = round($totalRuntimeInSeconds / $totalThroughput, 3);
             } else {
                 $averageRuntime = 0;
             }

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -282,7 +282,11 @@ class RedisMetricsRepository implements MetricsRepository
      */
     public function snapshot()
     {
-        collect($this->measuredJobs())->each(function ($job) {
+        $jobs = (array) $this->connection()->smembers('measured_jobs');
+
+        collect($jobs)->map(function ($class) {
+            return preg_match('/job:(.*)$/', $class, $matches) ? $matches[1] : $class;
+        })->each(function ($job) {
             $this->storeSnapshotForJob($job);
         });
 

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -45,10 +45,6 @@ class RedisMetricsRepository implements MetricsRepository
 
             $snapshots = $this->snapshotsForJob($jobName);
 
-            if (empty($snapshots)) {
-                return null;
-            }
-
             $totalRuntimeInSeconds = 0;
             $totalThroughput = 0;
 
@@ -62,18 +58,21 @@ class RedisMetricsRepository implements MetricsRepository
             }
 
             if ($totalThroughput > 0) {
-                return [
-                    'name' => $jobName,
-                    'average_runtime' => round($totalRuntimeInSeconds / $totalThroughput, 3),
-                    'total_throughput' => $totalThroughput,
-                ];
+                $averageRuntime = ($totalRuntimeInSeconds / $totalThroughput) * 1000; // Convert back to milliseconds
+            } else {
+                $averageRuntime = 0;
             }
 
-            return null;
-        })->filter()
-        ->sortByDesc('average_runtime')
-        ->values()
-        ->all();
+            return [
+                'name' => $jobName,
+                'average_runtime' => $averageRuntime,
+                'total_throughput' => $totalThroughput,
+            ];
+        })
+            ->filter()
+            ->sortByDesc('average_runtime')
+            ->values()
+            ->all();
     }
 
     /**

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -95,10 +95,12 @@ class MetricsTest extends IntegrationTest
         $this->work();
         $this->work();
 
-        $jobs = resolve(MetricsRepository::class)->measuredJobs();
-        $this->assertCount(2, $jobs);
-        $this->assertContains(Jobs\ConditionallyFailingJob::class, $jobs);
-        $this->assertContains(Jobs\BasicJob::class, $jobs);
+        $metrics = resolve(MetricsRepository::class)->measuredJobs();
+        $this->assertCount(2, $metrics);
+
+        $jobNames = collect($metrics)->pluck('name')->all();
+        $this->assertContains(Jobs\ConditionallyFailingJob::class, $jobNames);
+        $this->assertContains(Jobs\BasicJob::class, $jobNames);
     }
 
     public function test_snapshot_of_metrics_performance_can_be_stored()


### PR DESCRIPTION
This PR enhances the jobs metrics screen (`/horizon/metrics/jobs`) to provide more actionable insights at a glance. Currently, this screen only lists job names, requiring users to click into each job individually to see performance data. This change surfaces key statistics directly in the main table.

### Summary of Changes

* **Backend API (`RedisMetricsRepository`):**
    * The `measuredJobs` method has been refactored to calculate and return a rich collection of data for each job, not just the class name.
    * For each job, it now calculates:
        * A weighted average runtime, using snapshot throughput for greater accuracy.
        * The total number of samples (total throughput).
    * It correctly converts the stored `runtime` from **milliseconds to seconds**.
    * The final collection is sorted by the slowest jobs first, making it easy to identify performance bottlenecks.

* **Frontend (`jobs.vue`):**
    * The jobs table on the metrics index screen has been updated to include two new columns: "Throughput" and "Avg. Runtime (s)".
    * The component now correctly handles the new object-based data structure from the API.

* **Tests (`MetricsTest.php`):**
    * The corresponding feature test has been updated to assert the new, richer data structure returned by the repository.

### Visual Confirmation

<img width="1102" height="401" alt="new_screen" src="https://github.com/user-attachments/assets/bbe36088-a479-4cdc-aec9-39a5e06e00d4" />
