### PR TITLE
[5.x] Improve docblocks for nullable parameters

### DIFF
--- a/src/Contracts/JobRepository.php
+++ b/src/Contracts/JobRepository.php
@@ -31,7 +31,7 @@ interface JobRepository
     /**
      * Get a chunk of recent jobs.
      *
-     * @param  string  $afterIndex
+     * @param  string|null  $afterIndex
      * @return \Illuminate\Support\Collection
      */
     public function getRecent($afterIndex = null);
@@ -39,7 +39,7 @@ interface JobRepository
     /**
      * Get a chunk of failed jobs.
      *
-     * @param  string  $afterIndex
+     * @param  string|null  $afterIndex
      * @return \Illuminate\Support\Collection
      */
     public function getFailed($afterIndex = null);
@@ -47,7 +47,7 @@ interface JobRepository
     /**
      * Get a chunk of pending jobs.
      *
-     * @param  string  $afterIndex
+     * @param  string|null  $afterIndex
      * @return \Illuminate\Support\Collection
      */
     public function getPending($afterIndex = null);
@@ -55,7 +55,7 @@ interface JobRepository
     /**
      * Get a chunk of completed jobs.
      *
-     * @param  string  $afterIndex
+     * @param  string|null  $afterIndex
      * @return \Illuminate\Support\Collection
      */
     public function getCompleted($afterIndex = null);
@@ -63,7 +63,7 @@ interface JobRepository
     /**
      * Get a chunk of silenced jobs.
      *
-     * @param  string  $afterIndex
+     * @param  string|null  $afterIndex
      * @return \Illuminate\Support\Collection
      */
     public function getSilenced($afterIndex = null);

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -202,7 +202,7 @@ class Horizon
      * Specify the webhook URL and channel to which Slack notifications should be routed.
      *
      * @param  string  $url
-     * @param  string  $channel
+     * @param  string|null  $channel
      * @return static
      */
     public static function routeSlackNotificationsTo($url, $channel = null)

--- a/src/MasterSupervisor.php
+++ b/src/MasterSupervisor.php
@@ -66,7 +66,7 @@ class MasterSupervisor implements Pausable, Restartable, Terminable
     /**
      * Create a new master supervisor instance.
      *
-     * @param  string  $environment
+     * @param  string|null  $environment
      * @return void
      */
     public function __construct(?string $environment = null)

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -59,7 +59,7 @@ class RedisQueue extends BaseQueue
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @param  array  $options
      * @return mixed
      */
@@ -99,7 +99,7 @@ class RedisQueue extends BaseQueue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string  $job
      * @param  mixed  $data
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return mixed
      */
     #[\Override]
@@ -129,7 +129,7 @@ class RedisQueue extends BaseQueue
     /**
      * Pop the next job off of the queue.
      *
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @param  int  $index
      * @return \Illuminate\Contracts\Queue\Job|null
      */

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -177,7 +177,7 @@ class SupervisorOptions
      *
      * @param  string  $name
      * @param  string  $connection
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @param  string  $workersName
      * @param  string  $balance
      * @param  int  $backoff


### PR DESCRIPTION
This PR updates docblocks for parameters with a default value of `null` that are currently documented as non-nullable.
- Follows the existing convention used elsewhere in the Horizon source code.
- Applies the changes consistently across the codebase.