### PR TITLE
[5.x] Add support for `silenced_tags` configuration in Horizon jobs

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -124,6 +124,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Silenced Tags
+    |--------------------------------------------------------------------------
+    |
+    | Silencing a job by tag will instruct Horizon to not place any job
+    | with the specified tag(s) in the list of completed jobs within
+    | the Horizon dashboard. This setting is useful for filtering out
+    | noisy categories of jobs without specifying individual classes.
+    |
+    */
+
+    'silenced_tags' => [
+        // 'noisy'
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Metrics
     |--------------------------------------------------------------------------
     |

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -122,20 +122,8 @@ return [
         // App\Jobs\ExampleJob::class,
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Silenced Tags
-    |--------------------------------------------------------------------------
-    |
-    | Silencing a job by tag will instruct Horizon to not place any job
-    | with the specified tag(s) in the list of completed jobs within
-    | the Horizon dashboard. This setting is useful for filtering out
-    | noisy categories of jobs without specifying individual classes.
-    |
-    */
-
     'silenced_tags' => [
-        // 'noisy'
+        // 'notifications',
     ],
 
     /*

--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -99,8 +99,8 @@ class JobPayload implements ArrayAccess
     {
         return $this->set([
             'type' => $this->determineType($job),
-            'tags' => $this->determineTags($job),
-            'silenced' => $this->shouldBeSilenced($job),
+            'tags' => $tags = $this->determineTags($job),
+            'silenced' => $this->shouldBeSilenced($job, $tags),
             'pushedAt' => str_replace(',', '.', microtime(true)),
         ]);
     }
@@ -140,9 +140,10 @@ class JobPayload implements ArrayAccess
      * Determine if the underlying job class should be silenced.
      *
      * @param  mixed  $job
+     * @param  array  $tags
      * @return bool
      */
-    protected function shouldBeSilenced($job)
+    protected function shouldBeSilenced($job, array $tags = [])
     {
         if (! $job) {
             return false;
@@ -153,7 +154,8 @@ class JobPayload implements ArrayAccess
         $jobClass = is_string($underlyingJob) ? $underlyingJob : get_class($underlyingJob);
 
         return in_array($jobClass, config('horizon.silenced', [])) ||
-            is_a($jobClass, Silenced::class, true);
+            is_a($jobClass, Silenced::class, true) ||
+            count(array_intersect($tags, config('horizon.silenced_tags', []))) > 0;
     }
 
     /**

--- a/tests/Feature/RedisPayloadTest.php
+++ b/tests/Feature/RedisPayloadTest.php
@@ -200,4 +200,13 @@ class RedisPayloadTest extends IntegrationTest
         $JobPayload->prepare(new SendQueuedMailable($mailableMock));
         $this->assertTrue($JobPayload->isSilenced());
     }
+
+    public function test_it_determines_if_job_is_silenced_correctly_by_tags()
+    {
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        config(['horizon.silenced_tags' => ['first', 'noisy']]);
+        $JobPayload->prepare(new FakeJobWithTagsMethod());
+        $this->assertTrue($JobPayload->isSilenced());
+    }
 }


### PR DESCRIPTION
## Description

This PR introduces a new configuration option `silenced_tags` to Horizon, allowing developers to silence jobs by tag. Previously, only specific job classes or jobs implementing the Silenced interface could be silenced.

## Why?

Silencing by tag is useful for filtering out noisy categories of jobs (like notifications or low-priority background jobs) without listing every job class individually.

## Usage

```php
// config/horizon.php

'silenced' => [
    App\Jobs\ExampleJob::class
],

'silenced_tags' => [
    'notifications',
    'low_priority',
],
```
