### PR TITLE
[5.x] Horizon proxy_path configuration description.

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -32,6 +32,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Horizon Proxy Path
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to define a proxy prefix when serving Horizon
+    | from behind a reverse proxy or within a subdirectory of your domain.
+    |
+    | For example, if Horizon should be accessible from "/myapp/horizon",
+    | you may set the environment variable:
+    |
+    |   HORIZON_PROXY_PATH=/myapp
+    |
+    | By default, this value is null and Horizon will be served directly
+    | from the path defined in the "path" configuration option.
+    |
+    */
+    'proxy_path' => env('HORIZON_PROXY_PATH', ''),
+
+    /*
+    |--------------------------------------------------------------------------
     | Horizon Redis Connection
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Improves the description of the `proxy_path` option in the Horizon configuration file, adding clarity about its use behind reverse proxies or when served from a subdirectory.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
