### PR TITLE
[5.x] Add `--json` option to `horizon:list` command

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -14,7 +14,8 @@ class ListCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'horizon:list';
+    protected $signature = 'horizon:list 
+                            {--json : Output all of the deployed machines information as JSON}';
 
     /**
      * The console command description.
@@ -33,6 +34,44 @@ class ListCommand extends Command
     {
         $masters = $masters->all();
 
+        $this->option('json')
+            ? $this->displayJson($masters)
+            : $this->displayForCli($masters);
+
+    }
+
+    /**
+     * Render all of the deployed machines information as JSON.
+     *
+     * @param  array  $masters
+     * @return void
+     */
+    protected function displayJson(array $masters)
+    {
+        if (empty($masters)) {
+            return $this->output->writeln('[]');
+        }
+
+        $this->output->writeln(collect($masters)->map(function ($master) {
+            return [
+                'name' => $master->name,
+                'pid' => $master->pid,
+                'supervisors' => $master->supervisors ? collect($master->supervisors)->map(function ($supervisor) {
+                    return explode(':', $supervisor, 2)[1];
+                })->implode(', ') : 'None',
+                'status' => $master->status,
+            ];
+        })->toJson());
+    }
+
+    /**
+     * Render all of the deployed machines information for the CLI.
+     *
+     * @param  array  $masters
+     * @return void
+     */
+    protected function displayForCli(array $masters)
+    {
         if (empty($masters)) {
             return $this->components->info('No machines are running.');
         }

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -37,7 +37,6 @@ class ListCommand extends Command
         $this->option('json')
             ? $this->displayJson($masters)
             : $this->displayForCli($masters);
-
     }
 
     /**


### PR DESCRIPTION
## Description

This PR adds a `--json` option to the `horizon:list` command.

Currently, `horizon:list` only outputs a table in the console, which is great for human readability but not ideal for automated tooling or integrations. With this new flag, the command can now output the migration status in JSON format, making it easier to consume programmatically.

Example output:

```json
[
  {
    "name": "user-abcd",
    "pid": "123",
    "supervisors": "supervisor-1",
    "status": "running"
  }
]
```

## Tests

The `horizon:list` command does not currently have any tests in the Laravel Horizon codebase. If preferred, I can add test coverage for the new `--json` option as part of this PR.