### PR TITLE
Add --json option to horizon:work to match queue:work functionality

### DIFF
--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -29,7 +29,7 @@ class WorkCommand extends BaseWorkCommand
                             {--supervisor= : The name of the supervisor the worker belongs to}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}
-                            {--json : Output the result in JSON format}';
+                            {--json : Output the queue worker information as JSON}';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -28,7 +28,8 @@ class WorkCommand extends BaseWorkCommand
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--supervisor= : The name of the supervisor the worker belongs to}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=0 : Number of times to attempt a job before logging it failed}';
+                            {--tries=0 : Number of times to attempt a job before logging it failed}
+                            {--json : Output the result in JSON format}';
 
     /**
      * Indicates whether the command should be shown in the Artisan command list.


### PR DESCRIPTION
Adds support for the --json flag to the horizon:work command, matching the functionality available in Laravel's base queue:work command. This allows workers to output job processing information in JSON format instead of the default CLI format, enabling easier parsing of worker output for monitoring and logging systems.