### PR TITLE
[5.x] Update docblock to reflect int|void return type

### DIFF
--- a/src/Console/SupervisorStatusCommand.php
+++ b/src/Console/SupervisorStatusCommand.php
@@ -30,7 +30,7 @@ class SupervisorStatusCommand extends Command
      * Execute the console command.
      *
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
-     * @return void
+     * @return int|void
      */
     public function handle(SupervisorRepository $supervisors)
     {


### PR DESCRIPTION
This PR updates the `handle()` method docblock to accurately reflect its return type.

Currently, the method can return either:
- `int` → used as an exit code.
- `void` → when execution completes successfully without an explicit return.
