### PR TITLE
[5.x] Prevent using the reserved `horizon` Redis connection in `Horizon::use()` method

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -101,9 +101,9 @@ class Horizon
      */
     public static function use($connection)
     {
-        if ($connection === 'horizon' || ! is_null(config("database.redis.horizon"))) {
+        if ($connection === 'horizon' || ! is_null(config('database.redis.horizon'))) {
             throw new InvalidArgumentException(
-                "The Redis connection name [horizon] is reserved for internal use."
+                'The Redis connection name [horizon] is reserved for internal use.'
             );
         }
 

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Horizon
@@ -100,6 +101,12 @@ class Horizon
      */
     public static function use($connection)
     {
+        if ($connection === 'horizon' || ! is_null(config("database.redis.horizon"))) {
+            throw new InvalidArgumentException(
+                "The Redis connection name [horizon] is reserved for internal use."
+            );
+        }
+
         if (! is_null($config = config("database.redis.clusters.{$connection}.0"))) {
             config(["database.redis.{$connection}" => $config]);
         } elseif (is_null($config) && is_null($config = config("database.redis.{$connection}"))) {


### PR DESCRIPTION
## Summary
This PR updates the `Horizon::use()` method to prevent accidental use of the reserved `horizon` Redis connection. If `horizon` is passed as a connection name, or if a conflicting configuration exists, the method now throws an `InvalidArgumentException` during the Laravel app boot process.

## Why?
This change ensures safer configuration and prevents accidental misconfiguration.

<img width="632" height="160" alt="image" src="https://github.com/user-attachments/assets/72d1c33c-2aa7-47f5-83f9-4f040ad29622" />