### PR TITLE
[5.x] Prevent using the reserved `horizon` Redis connection name

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
+use InvalidArgumentException;
 use RuntimeException;
 
 class Horizon
@@ -88,6 +89,23 @@ class Horizon
         static::$authUsing = $callback;
 
         return new static;
+    }
+
+    /**
+     * Check if a given Redis connection name is reserved by Horizon.
+     *
+     * @param  string  $connection
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public static function checkReservedConnectionName(string $connection): void
+    {
+        if ($connection === 'horizon' || config()->has('database.redis.horizon')) {
+            throw new InvalidArgumentException(
+                'The Redis connection name [horizon] is reserved for internal use.'
+            );
+        }
     }
 
     /**

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -6,7 +6,6 @@ use Closure;
 use Exception;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
-use InvalidArgumentException;
 use RuntimeException;
 
 class Horizon
@@ -89,23 +88,6 @@ class Horizon
         static::$authUsing = $callback;
 
         return new static;
-    }
-
-    /**
-     * Check if a given Redis connection name is reserved by Horizon.
-     *
-     * @param  string  $connection
-     * @return void
-     *
-     * @throws \Exception
-     */
-    public static function checkReservedConnectionName(string $connection): void
-    {
-        if ($connection === 'horizon' || config()->has('database.redis.horizon')) {
-            throw new InvalidArgumentException(
-                'The Redis connection name [horizon] is reserved for internal use.'
-            );
-        }
     }
 
     /**

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -159,6 +159,8 @@ class HorizonServiceProvider extends ServiceProvider
             __DIR__.'/../config/horizon.php', 'horizon'
         );
 
+        Horizon::checkReservedConnectionName(config('horizon.use', 'default'));
+
         Horizon::use(config('horizon.use', 'default'));
     }
 

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
 use Laravel\Horizon\Connectors\RedisConnector;
 
 class HorizonServiceProvider extends ServiceProvider
@@ -159,9 +160,11 @@ class HorizonServiceProvider extends ServiceProvider
             __DIR__.'/../config/horizon.php', 'horizon'
         );
 
-        Horizon::checkReservedConnectionName(config('horizon.use', 'default'));
+        $horizonRedisConnectionName = config('horizon.use', 'default');
 
-        Horizon::use(config('horizon.use', 'default'));
+        $this->checkIsReservedConnectionName($horizonRedisConnectionName);
+
+        Horizon::use($horizonRedisConnectionName);
     }
 
     /**
@@ -190,5 +193,22 @@ class HorizonServiceProvider extends ServiceProvider
                 return new RedisConnector($this->app['redis']);
             });
         });
+    }
+
+    /**
+     * Check if a given Redis connection name is reserved by Horizon.
+     *
+     * @param  string  $connection
+     * @return void
+     *
+     * @throws \Exception
+     */
+    protected function checkIsReservedConnectionName(string $connection): void
+    {
+        if ($connection === 'horizon' || config()->has('database.redis.horizon')) {
+            throw new InvalidArgumentException(
+                'The Redis connection name [horizon] is reserved for internal use.'
+            );
+        }
     }
 }

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -160,11 +160,15 @@ class HorizonServiceProvider extends ServiceProvider
             __DIR__.'/../config/horizon.php', 'horizon'
         );
 
-        $horizonRedisConnectionName = config('horizon.use', 'default');
+        $connection = config('horizon.use', 'default');
 
-        $this->checkIsReservedConnectionName($horizonRedisConnectionName);
+        if ($connection === 'horizon' || config()->has('database.redis.horizon')) {
+            throw new InvalidArgumentException(
+                'The Redis connection name [horizon] is reserved for internal use.'
+            );
+        }
 
-        Horizon::use($horizonRedisConnectionName);
+        Horizon::use($connection);
     }
 
     /**
@@ -193,22 +197,5 @@ class HorizonServiceProvider extends ServiceProvider
                 return new RedisConnector($this->app['redis']);
             });
         });
-    }
-
-    /**
-     * Check if a given Redis connection name is reserved by Horizon.
-     *
-     * @param  string  $connection
-     * @return void
-     *
-     * @throws \Exception
-     */
-    protected function checkIsReservedConnectionName(string $connection): void
-    {
-        if ($connection === 'horizon' || config()->has('database.redis.horizon')) {
-            throw new InvalidArgumentException(
-                'The Redis connection name [horizon] is reserved for internal use.'
-            );
-        }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds the `checkIsReservedConnectionName` method to prevent accidental use of the reserved `horizon` Redis connection. If `horizon` is passed as a connection name, or if a conflicting configuration exists, the method throws an `InvalidArgumentException` during the Laravel app boot process.

## Why?
This change ensures safer configuration and prevents accidental misconfiguration.

<img width="632" height="160" alt="image" src="https://github.com/user-attachments/assets/72d1c33c-2aa7-47f5-83f9-4f040ad29622" />