### PR TITLE
[5.x] Prevent using the reserved `horizon` Redis connection

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -162,7 +162,7 @@ class HorizonServiceProvider extends ServiceProvider
 
         $connection = config('horizon.use', 'default');
 
-        if ($connection === 'horizon') {
+        if (! $this->app->configurationIsCached() && ($connection === 'horizon' || config()->has('database.redis.horizon'))) {
             throw new InvalidArgumentException(
                 'The Redis connection name [horizon] is reserved for internal use.'
             );


### PR DESCRIPTION
Continuation of #1615 

The main problem with the previous PR was that if the configurations were cached, the condition kept comparing against the cached config, which caused `InvalidArgumentException`.

With this change:

- We can reuse the previous logic and also check for the presence of incorrect configuration entries in `database.php`:

```php
config()->has('database.redis.horizon')
```

- If any invalid cached configuration exists, we can run `config:clear` to ensure the correct config replaces the incorrect one.

- If someone has an config cached, they can still continue working without any issues, and the application remains backward compatible.
