### PR TITLE
[5.x] Revert `#1615`

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use InvalidArgumentException;
 use Laravel\Horizon\Connectors\RedisConnector;
 
 class HorizonServiceProvider extends ServiceProvider

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -160,15 +160,7 @@ class HorizonServiceProvider extends ServiceProvider
             __DIR__.'/../config/horizon.php', 'horizon'
         );
 
-        $connection = config('horizon.use', 'default');
-
-        if ($connection === 'horizon') {
-            throw new InvalidArgumentException(
-                'The Redis connection name [horizon] is reserved for internal use.'
-            );
-        }
-
-        Horizon::use($connection);
+        Horizon::use(config('horizon.use', 'default'));
     }
 
     /**


### PR DESCRIPTION
Based on the community feedback (#1616 and #1617), I think we should revert this change, since the main issue comes from a wrongly cached config that doesn’t follow the documentation and now causes an error.
