### PR TITLE
Allow naming of horizon instances

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -9,9 +9,9 @@ return [
     | Horizon Name
     |--------------------------------------------------------------------------
     |
-    | This name appears in notifications and in the UI of Horizon. This is nice
-    | when running mutliple instances of Horizon within a single application
-    | as it allows you to identify which instance you are current viewing.
+    | This name appears in notifications and in the Horizon UI. Unique names
+    | can be useful while running multiple instances of Horizon within an
+    | application, allowing you to identify the Horizon you're viewing.
     |
     */
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -6,6 +6,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Horizon Name
+    |--------------------------------------------------------------------------
+    |
+    | This name appears in notifications and in the UI of Horizon. This is nice
+    | when running mutliple instances of Horizon within a single application
+    | as it allows you to identify which instance you are current viewing.
+    |
+    */
+
+    'name' => env('HORIZON_NAME'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Horizon Domain
     |--------------------------------------------------------------------------
     |

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -7,7 +7,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="shortcut icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAipJREFUeNrEV8txwjAQtQ2HHCmB3JKbSQOYCoA0gD0pgFBBwpEToQAGKmDglpwgFdg5kZtNB1BBsuusZ4RY2ZZjYGd2jGWh97Q/rUwjpziPT3V4dECboDZoXZoSka5Al5vFNMqzrpkD2IFHn8B1ZAM6BCKbQgQAuAaPWQFgjoinsoipAEcTr0FrRjmyJxLLTAI5wXFXAehBGMPYcDKIIIm5kkAGOJpwAjqHRfYpbkOXvTBBypIwpT+HCvA3Cqi9Rta8EhHOHS1YCy1oWMKHmQIcGQ90wGMfLaZIoEGAoiDGOHmxhFTr5PGZJgncZYszEGC6ogX6nNn/Ay6RGDCfYveYVOFCJuAaumbPiIk1kyUNS2H6SZngyZrMWM+i/JVlXjK4QUVI3pRTpYPlaG6yeyGvm0Jef1ItiArwQBKu8G5bTMEIhKLkU3q65D+HgieE7+MCBHbygMVMOlCK+CnVDOUZ5s00ghCt2T45C+DDD2MBW/O066YFLYGvuXU5C9i6GYaLUzqr+olQtS5aIMwwtW6QfQnv7awNVanolEWgo9nABBb1cNeSmMDyigRWZkqdPrdEkDm3SRYMr7D7odwRXdIK8e7lOuAxh8W5pHtSiOhw8S4A7iX9IErlyC5b/7t+/7Ar4TKiEuyyRuJA5cQ5Wz8gEhgPNyXvfCQPVtgI+SPxAT/vSqiSEbXh70Uvp27GRSMNeJjV2Jp5V6MGpUeuUR0wAemKuwdy8ivAAJcc0R2NFxWtAAAAAElFTkSuQmCC">
 
-    <title>Horizon{{ config('app.name') ? ' - ' . config('app.name') : '' }}</title>
+    <title>Horizon{{ config('horizon.name') ? ' - ' . config('horizon.name') : '' }}</title>
 
     <!-- Style sheets-->
     <link rel="preconnect" href="https://fonts.bunny.net">
@@ -32,7 +32,7 @@
                 </svg>
 
                 <h1 class="h4 mb-0 ms-2">
-                    <strong>Laravel</strong> Horizon{{ config('app.name') ? ' - ' . config('app.name') : '' }}
+                    <strong>Laravel</strong> Horizon{{ config('horizon.name') ? ' - ' . config('horizon.name') : '' }}
                 </h1>
             </router-link>
 

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -20,12 +20,12 @@ class HorizonServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->normalizeConfig();
         $this->registerEvents();
         $this->registerRoutes();
         $this->registerResources();
         $this->offerPublishing();
         $this->registerCommands();
-        $this->normalizeConfig();
     }
 
     /**

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -129,7 +129,12 @@ class HorizonServiceProvider extends ServiceProvider
         ]);
     }
 
-    protected function normalizeConfig(): void
+    /**
+     * Normalize Horizon configuration.
+     *
+     * @return void
+     */
+    protected function normalizeConfig()
     {
         if (! $this->app['config']->get('horizon.name')) {
             $this->app['config']->set('horizon.name', $this->app['config']->get('app.name'));

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -25,6 +25,7 @@ class HorizonServiceProvider extends ServiceProvider
         $this->registerResources();
         $this->offerPublishing();
         $this->registerCommands();
+        $this->normalizeConfig();
     }
 
     /**
@@ -126,6 +127,13 @@ class HorizonServiceProvider extends ServiceProvider
             Console\StatusCommand::class,
             Console\SupervisorsCommand::class,
         ]);
+    }
+
+    protected function normalizeConfig(): void
+    {
+        if (! $this->app['config']->get('horizon.name')) {
+            $this->app['config']->set('horizon.name', $this->app['config']->get('app.name'));
+        }
     }
 
     /**

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -29,6 +29,18 @@ class HorizonServiceProvider extends ServiceProvider
     }
 
     /**
+     * Normalize the Horizon configuration.
+     *
+     * @return void
+     */
+    protected function normalizeConfig()
+    {
+        if (! $this->app['config']->get('horizon.name')) {
+            $this->app['config']->set('horizon.name', $this->app['config']->get('app.name'));
+        }
+    }
+
+    /**
      * Register the Horizon job events.
      *
      * @return void
@@ -127,18 +139,6 @@ class HorizonServiceProvider extends ServiceProvider
             Console\StatusCommand::class,
             Console\SupervisorsCommand::class,
         ]);
-    }
-
-    /**
-     * Normalize Horizon configuration.
-     *
-     * @return void
-     */
-    protected function normalizeConfig()
-    {
-        if (! $this->app['config']->get('horizon.name')) {
-            $this->app['config']->set('horizon.name', $this->app['config']->get('app.name'));
-        }
     }
 
     /**

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -78,7 +78,7 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
     {
         return (new MailMessage)
             ->error()
-            ->subject(config('app.name').': Long Queue Wait Detected')
+            ->subject(config('horizon.name').': Long Queue Wait Detected')
             ->greeting('Oh no! Something needs your attention.')
             ->line(sprintf(
                 'The "%s" queue on the "%s" connection has a wait time of %s seconds.',
@@ -101,7 +101,7 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
 
         $content = sprintf(
             '[%s] The "%s" queue on the "%s" connection has a wait time of %s seconds.',
-            config('app.name'),
+            config('horizon.name'),
             $this->longWaitQueue,
             $this->longWaitConnection,
             $this->seconds
@@ -142,7 +142,7 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
     {
         return (new NexmoMessage)->content(sprintf( // @phpstan-ignore-line
             '[%s] The "%s" queue on the "%s" connection has a wait time of %s seconds.',
-            config('app.name'), $this->longWaitQueue, $this->longWaitConnection, $this->seconds
+            config('horizon.name'), $this->longWaitQueue, $this->longWaitConnection, $this->seconds
         ));
     }
 


### PR DESCRIPTION
We have several horizon instances running in different regions all within a single application.

When we get notifications from Horzion, we are unable to determine which instance of horizon the issue is occurring in.

> **Long Wait Detected**
> [Nightwatch] The "{queue}" queue on the "{connection}" connection has a wait time of {seconds} seconds.

The above notification could be any region and we have no way of knowing.

With this PR, we are able to name our Horizon instances while maintaining a single shared app name.

> **Long Wait Detected**
> [eu-central-1] The "{queue}" queue on the "{connection}" connection has a wait time of {seconds} seconds.

> **Long Wait Detected**
> [us-east-2] The "{queue}" queue on the "{connection}" connection has a wait time of {seconds} seconds.


<img width="717" height="597" alt="Screenshot 2025-10-10 at 11 02 01" src="https://github.com/user-attachments/assets/0a751a7b-55fb-47fa-9d41-edb282c2b153" />

The default prefix also uses the APP_NAME, e.g., but I didn't want to break anything by changing this to respect the new var. It is right there in the config file for people to modify anyway.

```
    'prefix' => env(
        'HORIZON_PREFIX',
        Str::slug(env('APP_NAME', 'laravel'), '_').'_horizon:'
    ),
```