### PR TITLE
[5.x] Add `Horizon::isHorizonPath()` to detect Horizon routes

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -225,4 +225,16 @@ class Horizon
 
         return new static;
     }
+
+    /**
+     * Determine if the current path is for Horizon.
+     *
+     * @return bool
+     */
+    public static function isHorizonPath(): bool
+    {
+        $path = trim(config('horizon.path'), '/');
+
+        return request()->is($path) || request()->is($path . '/*');
+    }
 }

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -235,6 +235,6 @@ class Horizon
     {
         $path = trim(config('horizon.path'), '/');
 
-        return request()->is($path) || request()->is($path . '/*');
+        return request()->is($path) || request()->is($path.'/*');
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a new method `Horizon::isHorizonPath()` that allows developers to easily check whether a request is intended for Horizon routes, based on the configured `horizon.path`.

##  Why?

By using `Horizon::isHorizonPath()`, developers can reliably detect Horizon requests before route resolution, making it easier to exclude or customize behavior for Horizon within global middleware, or other request-level logic — ensuring consistent and conflict-free behavior across environments.