### PR TITLE
[5.x] Add Enum Support to Horizon Job Tags

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -12,6 +12,8 @@ use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
 
+use function Illuminate\Support\enum_value;
+
 class Tags
 {
     /**
@@ -85,6 +87,7 @@ class Tags
             ->map(fn ($job) => method_exists($job, 'tags') ? $job->tags(static::$event) : [])
             ->collapse()
             ->unique()
+            ->map(fn ($tag) => enum_value($tag))
             ->all();
     }
 


### PR DESCRIPTION
This PR adds enum support to Horizon job tags, allowing to use enums in `tags()` arrays.

### Example:

```php
class ProcessOrder implements ShouldQueue
{
    // ...
    
    public function tags(): array
    {
        return [
            Priority::HIGH,    
            Status::SHIPPED,
            'order:' . $this->order->id
        ];
    }
}
```
