### PR TITLE
[5.x] Add Enum Support to Horizon Job Tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
         "predis/predis": "Required when not using the Redis PHP driver (^1.1|^2.0|^3.0)."
     },
     "autoload": {
+        "files": [
+            "src/functions.php"
+        ],
         "psr-4": {
             "Laravel\\Horizon\\": "src/"
         }

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -85,6 +85,7 @@ class Tags
             ->map(fn ($job) => method_exists($job, 'tags') ? $job->tags(static::$event) : [])
             ->collapse()
             ->unique()
+            ->map(fn ($tag) => enum_value($tag))
             ->all();
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Horizon;
+
+if (! function_exists('enum_value')) {
+    /**
+     * Return a scalar value for the given value that might be an enum.
+     *
+     * @internal
+     *
+     * @template TValue
+     * @template TDefault
+     *
+     * @param  TValue  $value
+     * @param  TDefault|callable(TValue): TDefault  $default
+     * @return ($value is empty ? TDefault : mixed)
+     */
+    function enum_value($value, $default = null)
+    {
+        return match (true) {
+            $value instanceof \BackedEnum => $value->value,
+            $value instanceof \UnitEnum => $value->name,
+
+            default => $value ?? value($default),
+        };
+    }
+}


### PR DESCRIPTION
Resubmittion of #1624

In the previous PR, the tests were failing because the `Illuminate\Support\enum_value()` function was not defined for them. To prevent this, I think the best approach is to include the same function in Horizon’s source code, just as it’s defined in Laravel.

Please let me know if you suggest any other approach so I can make the necessary adjustments.