### PR TITLE
Fix: Filter inactive supervisors to only include expected ones per master

### DIFF
--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -21,25 +21,37 @@ class MasterSupervisorController extends Controller
 
         $supervisors = collect($supervisors->all())->sortBy('name')->groupBy('master');
 
-        return $masters->each(function ($master, $name) use ($supervisors) {
-            $master->supervisors = ($supervisors->get($name) ?? collect())
-                ->merge(
-                    collect(ProvisioningPlan::get($name)->plan[$master->environment ?? config('horizon.env') ?? config('app.env')] ?? [])
-                        ->map(function ($value, $key) use ($name) {
-                            return (object) [
-                                'name' => $name.':'.$key,
-                                'master' => $name,
-                                'status' => 'inactive',
-                                'processes' => [],
-                                'options' => [
-                                    'queue' => array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : ($value['queue'] ?? ''),
-                                    'balance' => $value['balance'] ?? null,
-                                ],
-                            ];
-                        })
-                )
+        $env = config('horizon.env') ?? config('app.env');
+
+        return $masters->each(function ($master, $name) use ($supervisors, $env) {
+            $expectedNames = collect($master->supervisors);
+
+            $runningSups = $supervisors->get($name) ?? collect();
+
+            $plan = ProvisioningPlan::get($name)->plan[$master->environment ?? $env] ?? [];
+
+            $plannedSups = collect($plan)
+                ->filter(function ($value, $key) use ($name, $expectedNames) {
+                    return $expectedNames->contains($name.':'.$key);
+                })
+                ->map(function ($value, $key) use ($name) {
+                    return (object) [
+                        'name' => $name.':'.$key,
+                        'master' => $name,
+                        'status' => 'inactive',
+                        'processes' => [],
+                        'options' => [
+                            'queue' => array_key_exists('queue', $value) && is_array($value['queue']) ? implode(',', $value['queue']) : ($value['queue'] ?? ''),
+                            'balance' => $value['balance'] ?? null,
+                        ],
+                    ];
+                });
+
+            $master->supervisors = $runningSups
+                ->merge($plannedSups)
                 ->unique('name')
-                ->values();
+                ->values()
+                ->sortBy('name');
         });
     }
 }

--- a/src/Http/Controllers/MasterSupervisorController.php
+++ b/src/Http/Controllers/MasterSupervisorController.php
@@ -31,9 +31,7 @@ class MasterSupervisorController extends Controller
             $plan = ProvisioningPlan::get($name)->plan[$master->environment ?? $env] ?? [];
 
             $plannedSups = collect($plan)
-                ->filter(function ($value, $key) use ($name, $expectedNames) {
-                    return $expectedNames->contains($name.':'.$key);
-                })
+                ->filter(fn ($value, $key) => $expectedNames->contains($name.':'.$key))
                 ->map(function ($value, $key) use ($name) {
                     return (object) [
                         'name' => $name.':'.$key,


### PR DESCRIPTION
**Problem**
In the `MasterSupervisorController@index` method, inactive supervisors from the provisioning plan were being merged into every master's `supervisors` collection without checking if they were actually expected for that specific master. This resulted in bloated responses where masters included inactive supervisors that belong to other masters, leading to incorrect and noisy data in the Horizon dashboard.


**Solution**
 - Extract the expected supervisor names from each master's `supervisors` array.
 - When generating planned (inactive) supervisors from the `ProvisioningPlan`, filter them to only include those whose names match the expected list for the current master.
 - Sort the final `supervisors` collection by name for consistency.
 - This ensures each master only displays its own relevant supervisors (running or inactive), reducing response size and improving accuracy.


**Changes**
 - Added `$expectedNames = collect($master->supervisors);` to capture the master's expected supervisors.
 - Filtered the `plannedSups` collection using `filter(function ($value, $key) use ($name, $expectedNames) { ... })` to check `expectedNames->contains($name . ':' . $key)`.
 - Added `->sortBy('name')` at the end of the merge chain.
 - Minor refactor: Cached the environment variable lookup as `$env` for reuse.


**Testing**
 - Verified with provided sample data: One master now only includes its running supervisors + any matching inactive ones from its plan (no cross-master pollution).
 - Another master correctly shows its full set of supervisors without extras.
 - No impact on running supervisors; only filters planned ones.

