### PR TITLE
[5.x] Add Enum Support to Horizon Job Tags

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -85,6 +85,13 @@ class Tags
             ->map(fn ($job) => method_exists($job, 'tags') ? $job->tags(static::$event) : [])
             ->collapse()
             ->unique()
+            ->map(function ($tag) {
+                return match (true) {
+                    $tag instanceof \BackedEnum => $tag->value,
+                    $tag instanceof \UnitEnum => $tag->name,
+                    default => $value ?? value($tag),
+                };
+            })
             ->all();
     }
 


### PR DESCRIPTION
Instead of relying on the `enum_value` helper (which isn’t available within Horizon), 
this PR introduces a small inline solution to support Enum-based job tags. 
This keeps the feature self-contained until `enum_value` becomes part of the Horizon’s dependencies.
