### PR TITLE
Fix the pagination of failed jobs list

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -165,7 +165,7 @@
              */
             previous() {
                 this.loadJobs(
-                    (this.page - 2) * this.perPage
+                    (this.page - 2) * this.perPage - 1
                 );
 
                 this.page -= 1;
@@ -179,7 +179,7 @@
              */
             next() {
                 this.loadJobs(
-                    this.page * this.perPage
+                    this.page * this.perPage - 1
                 );
 
                 this.page += 1;


### PR DESCRIPTION
PR #1366 fixed the pagination for recent jobs (pending, completed & silenced). The original PR has a thorough description of the bug, please read that if you need more information.

In short, the 50th job is not displayed because of an off-by-one error.

This PR fixes the same bug for the failed jobs page.