### PR TITLE
[5.x] Update docblock to reflect int|void return type

### DIFF
--- a/src/Console/ContinueSupervisorCommand.php
+++ b/src/Console/ContinueSupervisorCommand.php
@@ -30,7 +30,7 @@ class ContinueSupervisorCommand extends Command
      * Execute the console command.
      *
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
-     * @return void
+     * @return int|void
      */
     public function handle(SupervisorRepository $supervisors)
     {

--- a/src/Console/PauseSupervisorCommand.php
+++ b/src/Console/PauseSupervisorCommand.php
@@ -30,7 +30,7 @@ class PauseSupervisorCommand extends Command
      * Execute the console command.
      *
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
-     * @return void
+     * @return int|void
      */
     public function handle(SupervisorRepository $supervisors)
     {


### PR DESCRIPTION
Continuation of #1613
