### PR TITLE
[5.x] Remove unnecessary `SupervisorLooped` event param

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -37,7 +37,6 @@ class MonitorWaitTimes
     /**
      * Handle the event.
      *
-     * @param  \Laravel\Horizon\Events\SupervisorLooped  $event
      * @return void
      */
     public function handle()


### PR DESCRIPTION
This PR removes an unused `SupervisorLooped` param annotation from the `handle()` method’s docblock in the event listener. 

Continuation of #1172