### PR TITLE
[5.x] Update `ForgetFailedCommand` docblocks

### DIFF
--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -26,7 +26,8 @@ class ForgetFailedCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return int|null
+     * @param  \Laravel\Horizon\Contracts\JobRepository $repository
+     * @return int|null|void
      */
     public function handle(JobRepository $repository)
     {

--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -26,7 +26,7 @@ class ForgetFailedCommand extends Command
     /**
      * Execute the console command.
      *
-     * @param  \Laravel\Horizon\Contracts\JobRepository $repository
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $repository
      * @return int|null|void
      */
     public function handle(JobRepository $repository)


### PR DESCRIPTION
This PR updates the docblocks for the `handle()` method in the `ForgetFailedCommand` to:

- Add the missing `@param` annotation for the injected `\Laravel\Horizon\Contracts\JobRepository` dependency
- Clarifies the possible return types