### PR TITLE
[5.x] Prevent negative queue wait times and improve readability in Horizon long wait detection

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -52,8 +52,8 @@ class MonitorWaitTimes
         $results = app(WaitTimeCalculator::class)->calculate();
 
         $long = collect($results)->filter(function ($wait, $queue) {
-            return config("horizon.waits.{$queue}") !== 0
-                    && $wait > (config("horizon.waits.{$queue}") ?? 60);
+            $waitConfig = config("horizon.waits.{$queue}");
+            return (is_null($waitConfig) || $waitConfig > 0) && ($wait > ($waitConfig ?? 60));
         });
 
         // Once we have determined which queues have long wait times we will raise the

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -53,6 +53,7 @@ class MonitorWaitTimes
 
         $long = collect($results)->filter(function ($wait, $queue) {
             $waitConfig = config("horizon.waits.{$queue}");
+
             return (is_null($waitConfig) || $waitConfig > 0) && ($wait > ($waitConfig ?? 60));
         });
 

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -52,6 +52,25 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::assertNotDispatched(LongWaitDetected::class);
     }
 
+    public function test_queue_ignores_negative_long_waits()
+    {
+        config(['horizon.waits' => ['redis:ignore-queue' => -10]]);
+
+        Event::fake();
+
+        $calc = Mockery::mock(WaitTimeCalculator::class);
+        $calc->expects('calculate')->andReturn([
+            'redis:ignore-queue' => 10,
+        ]);
+        $this->app->instance(WaitTimeCalculator::class, $calc);
+
+        $listener = new MonitorWaitTimes(app(MetricsRepository::class));
+
+        $listener->handle();
+
+        Event::assertNotDispatched(LongWaitDetected::class);
+    }
+
     public function test_monitor_wait_times_skips_when_lock_is_not_acquired()
     {
         config(['horizon.waits' => ['redis:default' => 60]]);


### PR DESCRIPTION
Continuation of #1172

## Description

Currently, Horizon checks all queues for long wait times when the waits feature is enabled. Queues with a configured wait time of `0` are ignored, but **negative values were not handled** and could trigger false alerts.

## Benefits

This PR improves the logic by:

- Ignoring negative wait time: only queues with `null` or `positive` wait times are monitored.
- Improving readability
- Maintaining backward compatibility: `0` continues to disable monitoring for that queue, and null falls back to the default `60` seconds.


