### PR TITLE
[5.x] Improve Monitor Tag Button Title

### DIFF
--- a/resources/js/screens/monitoring/index.vue
+++ b/resources/js/screens/monitoring/index.vue
@@ -122,7 +122,7 @@
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h2 class="h6 m-0">Monitoring</h2>
 
-                <button @click="openNewTagModal" class="btn btn-primary btn-sm">Monitor Tag</button>
+                <button @click="openNewTagModal" class="btn btn-primary btn-sm">Monitor New Tag</button>
             </div>
 
             <div v-if="!ready" class="d-flex align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">


### PR DESCRIPTION
This PR updates the label of the monitoring button in the Horizon dashboard from `“Monitor Tag”` to `“Monitor New Tag”` to match the modal title and accurately describe the action.

<img width="1047" height="336" alt="Screenshot 2025-10-22 215225" src="https://github.com/user-attachments/assets/10e23daf-8afe-4696-9258-ed6fc1cee8f6" />
