### PR TITLE
[5.x] Add `Connection` parameter to job details page

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -125,6 +125,10 @@
                     <div class="col">{{job.id}}</div>
                 </div>
                 <div class="row mb-2">
+                    <div class="col-md-2 text-muted">Connection</div>
+                    <div class="col">{{job.connection}}</div>
+                </div>
+                <div class="row mb-2">
                     <div class="col-md-2 text-muted">Queue</div>
                     <div class="col">{{job.queue}}</div>
                 </div>

--- a/resources/js/screens/recentJobs/job.vue
+++ b/resources/js/screens/recentJobs/job.vue
@@ -25,6 +25,11 @@
                 </div>
 
                 <div class="row mb-2">
+                    <div class="col-md-2 text-muted">Connection</div>
+                    <div class="col">{{job.connection}}</div>
+                </div>
+
+                <div class="row mb-2">
                     <div class="col-md-2 text-muted">Queue</div>
                     <div class="col">{{job.queue}}</div>
                 </div>


### PR DESCRIPTION
This PR adds `Connection` parameter to the Job Details page in Laravel Horizon panel.
The parameter is now visible for jobs across all relevant sections, including:

- Monitoring
- Pending Jobs
- Completed Jobs
- Silenced Jobs
- Failed Jobs

<img width="1185" height="251" alt="image" src="https://github.com/user-attachments/assets/f99a017a-03bc-45ab-8165-e8af2e127f71" />
