### PR TITLE
[5.x] Add `Collapse` Button to Data Card in Failed Jobs Detail Page

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -194,9 +194,13 @@
         <div class="card overflow-hidden mt-4" v-if="ready">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h2 class="h6 m-0">Data</h2>
+
+                <a data-bs-toggle="collapse" href="#collapseData" role="button">
+                    Collapse
+                </a>
             </div>
 
-            <div class="card-body code-bg text-white">
+            <div class="card-body code-bg text-white collapse show" id="collapseData">
                 <vue-json-pretty :data="prettyPrintJob(job.payload.data)"></vue-json-pretty>
             </div>
         </div>


### PR DESCRIPTION
## Summary

This PR adds a `Collapse` button to the Data card on the Failed Jobs Detail page.

## Why?

The `Collapse` button for the Data card already exists in other parts of Horizon — such as the Completed Jobs Detail, Pending Jobs Detail, Silenced Jobs Detail, and Monitoring pages. However, it was missing from the Failed Jobs Detail page.

This change ensures UI consistency and improves usability when viewing large job payloads.

<img width="975" height="883" alt="image" src="https://github.com/user-attachments/assets/1b433d1a-1cd2-47de-9747-dbca49e04968" />
