### PR TITLE
[5.x] Improve `ForgetFailedCommand` docblocks

### DIFF
--- a/src/Console/ForgetFailedCommand.php
+++ b/src/Console/ForgetFailedCommand.php
@@ -26,6 +26,7 @@ class ForgetFailedCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Laravel\Horizon\Contracts\JobRepository  $repository
      * @return int|null
      */
     public function handle(JobRepository $repository)


### PR DESCRIPTION
This PR updates a docblock to improve clarity and maintain consistency with other Horizon source files.

For reference, similar annotations can be found in:

https://github.com/laravel/horizon/blob/3a3145345221df6a0eaacc478c22040d1252a065/src/Jobs/RetryFailedJob.php#L27-L30
https://github.com/laravel/horizon/blob/3a3145345221df6a0eaacc478c22040d1252a065/src/Jobs/StopMonitoringTag.php#L24-L28


Thank you for reviewing.