### PR TITLE
[5.x] Hide `Load New Entries` button when auto loading is enabled

### DIFF
--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -31,6 +31,12 @@
 
                 this.loadBatches();
             },
+
+            '$root.autoLoadsNewEntries'(autoLoadsNewEntries) {
+                if (autoLoadsNewEntries && this.hasNewEntries) {
+                    this.hasNewEntries = false;
+                }
+            }
         },
 
 
@@ -146,7 +152,7 @@
                 </thead>
 
                 <tbody>
-                <tr v-if="hasNewEntries" key="newEntries" class="dontanimate">
+                <tr v-if="hasNewEntries && !this.$root.autoLoadsNewEntries" key="newEntries" class="dontanimate">
                     <td colspan="100" class="text-center card-bg-secondary py-2">
                         <small><a href="#" v-on:click.prevent="loadNewEntries" v-if="!loadingNewEntries">Load New Entries</a></small>
 

--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -45,6 +45,12 @@
                     this.loadJobs();
                     this.refreshJobsPeriodically();
                 }, 500);
+            },
+
+            '$root.autoLoadsNewEntries'(autoLoadsNewEntries) {
+                if (autoLoadsNewEntries && this.hasNewEntries) {
+                    this.hasNewEntries = false;
+                }
             }
         },
 
@@ -233,7 +239,7 @@
                 </thead>
 
                 <tbody>
-                <tr v-if="hasNewEntries" key="newEntries" class="dontanimate">
+                <tr v-if="hasNewEntries && !this.$root.autoLoadsNewEntries" key="newEntries" class="dontanimate">
                     <td colspan="100" class="text-center card-bg-secondary py-2">
                         <small><a href="#" v-on:click.prevent="loadNewEntries" v-if="!loadingNewEntries">Load New Entries</a></small>
 

--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -46,6 +46,12 @@
                 this.page = 1;
 
                 this.loadJobs(this.$route.params.tag);
+            },
+
+            '$root.autoLoadsNewEntries'(autoLoadsNewEntries) {
+                if (autoLoadsNewEntries && this.hasNewEntries) {
+                    this.hasNewEntries = false;
+                }
             }
         },
 
@@ -159,7 +165,7 @@
             </thead>
 
             <tbody>
-            <tr v-if="hasNewEntries" key="newEntries" class="dontanimate">
+            <tr v-if="hasNewEntries && !this.$root.autoLoadsNewEntries" key="newEntries" class="dontanimate">
                 <td colspan="100" class="text-center card-bg-secondary py-2">
                     <small><a href="#" v-on:click.prevent="loadNewEntries" v-if="!loadingNewEntries">Load New Entries</a></small>
 

--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -46,6 +46,12 @@
                 this.page = 1;
 
                 this.loadJobs();
+            },
+
+            '$root.autoLoadsNewEntries'(autoLoadsNewEntries) {
+                if (autoLoadsNewEntries && this.hasNewEntries) {
+                    this.hasNewEntries = false;
+                }
             }
         },
 
@@ -180,7 +186,7 @@
                 </thead>
 
                 <tbody>
-                    <tr v-if="hasNewEntries" key="newEntries" class="dontanimate">
+                    <tr v-if="hasNewEntries && !this.$root.autoLoadsNewEntries" key="newEntries" class="dontanimate">
                         <td colspan="100" class="text-center card-bg-secondary py-1">
                             <small><a href="#" v-on:click.prevent="loadNewEntries" v-if="!loadingNewEntries">Load New Entries</a></small>
 


### PR DESCRIPTION
## Summary

This PR fixes a UI inconsistency across multiple sections of the Horizon dashboard where the `Load New Entries` button remains visible even after the user enables automatic job loading (`autoLoadsNewEntries`).

## Problem

Current behavior:

1. Auto-loading is off (`autoLoadsNewEntries = false`).
2. New jobs arrive → `Load New Entries` button appears.
3. User enables auto-loading (`autoLoadsNewEntries = true`).
4. The button remains visible until the next manual refresh or reload.

This creates confusion since new entries are already being loaded automatically:

<img width="1217" height="398" alt="Screenshot 2025-10-28 212848" src="https://github.com/user-attachments/assets/8e6059aa-851e-496c-9257-9ed4cdf806dd" />

## Fix

- Added a watcher for `$root.autoLoadsNewEntries` in the jobs list components.
- When `autoLoadsNewEntries` is toggled on, the component now clears the `hasNewEntries` flag, immediately hiding the `Load New Entries` button.

## Why?

This is a small but meaningful UX improvement that improves visual consistency and eliminates stale UI states across all job and monitoring views.

## Affected Sections

- Monitoring
- Batches
- Pending Jobs
- Completed Jobs
- Silenced Jobs
- Failed Jobs
