### PR TITLE
[5.x] Separate message types in monitoring tags page

### DIFF
--- a/resources/js/screens/monitoring/tag-jobs.vue
+++ b/resources/js/screens/monitoring/tag-jobs.vue
@@ -144,7 +144,8 @@
 
 
         <div v-if="ready && jobs.length == 0" class="d-flex flex-column align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">
-            <span>There aren't any jobs for this tag.</span>
+            <span v-if="type == 'failed'">There aren't any failed jobs for this tag.</span>
+            <span v-else>There aren't any jobs for this tag.</span>
         </div>
 
         <table v-if="ready && jobs.length > 0" class="table table-hover mb-0">


### PR DESCRIPTION
This PR adds a condition to separate the `failed jobs` empty message from the `recent jobs` empty message on the monitoring tags page, ensuring each displays only in the correct context.

Continuation of #1590
