### PR TITLE
[5.x] Add `Connection` column to Supervisors table in Horizon panel dashboard

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -312,6 +312,7 @@
                 <thead>
                 <tr>
                     <th>Supervisor</th>
+                    <th>Connection</th>
                     <th>Queues</th>
                     <th class="text-end" style="width: 120px;">Processes</th>
                     <th class="text-end" style="width: 180px;">Balancing</th>
@@ -329,6 +330,7 @@
                         </svg>
                         {{ superVisorDisplayName(supervisor.name, worker.name) }}
                     </td>
+                    <td class="text-muted">{{ supervisor.options.connection }}</td>
                     <td class="text-muted">{{ supervisor.options.queue.replace(/,/g, ', ') }}</td>
                     <td class="text-end text-muted">{{ countProcesses(supervisor.processes) }}</td>
                     <td class="text-end text-muted" v-if="supervisor.options.balance">


### PR DESCRIPTION
This pull request adds a `Connection` column to the Supervisors table in the Horizon dashboard.
The column displays the queue connection each supervisor is using, helping users quickly identify which connection a supervisor is managing.

<img width="1243" height="284" alt="image" src="https://github.com/user-attachments/assets/36cf2779-ea65-4987-9967-3e4b27a812cd" />
