### PR TITLE
[5.x] Add Margin Left to Delayed Label

### DIFF
--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -5,7 +5,7 @@
                 {{ jobBaseName(job.name) }}
             </router-link>
 
-            <small class="badge bg-secondary badge-sm" :title="`Delayed for ${delayed}`"
+            <small class="ms-1 badge bg-secondary badge-sm" :title="`Delayed for ${delayed}`"
                    v-if="delayed && (job.status == 'reserved' || job.status == 'pending')">
                 Delayed
             </small>


### PR DESCRIPTION
This PR adds a left margin to the `Delayed` label in Horizon's Monitoring page, aligning it visually with the same label style used in the Pending page.

### Monitoring:

<img width="1177" height="219" alt="Screenshot 2025-10-30 191348" src="https://github.com/user-attachments/assets/4ffa09c4-4bef-45aa-9d55-3e25c009dd16" />

### Pending Jobs:

<img width="1174" height="237" alt="Screenshot 2025-10-30 191155" src="https://github.com/user-attachments/assets/ea32bbe4-feef-4018-912c-0b8c10c7eb9e" />
