### PR TITLE
[5.x] Add `Delayed` column to Pending Jobs table

### DIFF
--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -5,7 +5,7 @@
                 {{ jobBaseName(job.name) }}
             </router-link>
 
-            <small class="ms-1 badge bg-secondary badge-sm"
+            <small class="ms-1 badge bg-secondary badge-sm" :title="`Delayed for ${delayed}`"
                    v-if="delayed && (job.status == 'reserved' || job.status == 'pending')">
                 Delayed
             </small>

--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -5,7 +5,7 @@
                 {{ jobBaseName(job.name) }}
             </router-link>
 
-            <small class="ms-1 badge bg-secondary badge-sm" :title="`Delayed for ${delayed}`"
+            <small class="ms-1 badge bg-secondary badge-sm"
                    v-if="delayed && (job.status == 'reserved' || job.status == 'pending')">
                 Delayed
             </small>

--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -178,7 +178,8 @@
                 <thead>
                     <tr>
                         <th>Job</th>
-                        <th v-if="$route.params.type=='pending'" class="text-end">Queued</th>
+                        <th v-if="$route.params.type=='pending'">Queued</th>
+                        <th v-if="$route.params.type=='pending'" class="text-end">Delayed</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'">Queued</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'">Completed</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'" class="text-end">Runtime</th>

--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -179,7 +179,7 @@
                     <tr>
                         <th>Job</th>
                         <th v-if="$route.params.type=='pending'">Queued</th>
-                        <th v-if="$route.params.type=='pending'" class="text-end">Delayed</th>
+                        <th v-if="$route.params.type=='pending'">Delayed</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'">Queued</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'">Completed</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'" class="text-end">Runtime</th>

--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -6,7 +6,6 @@
             </router-link>
 
             <small class="ms-1 badge bg-secondary badge-sm"
-                :title="`Delayed for ${delayed}`"
                 v-if="delayed && (job.status == 'reserved' || job.status == 'pending')">
                 Delayed
             </small>

--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -26,6 +26,10 @@
             {{ readableTimestamp(job.payload.pushedAt) }}
         </td>
 
+        <td class="table-fit text-muted" v-if="$route.params.type=='pending' && (job.status == 'reserved' || job.status == 'pending')">
+            {{ delayed ? delayed.charAt(0).toUpperCase() + delayed.slice(1) : '-' }}
+        </td>
+
         <td v-if="$route.params.type=='completed' || $route.params.type=='silenced'" class="table-fit text-muted">
             {{ readableTimestamp(job.completed_at) }}
         </td>


### PR DESCRIPTION
This PR adds a new `Delayed` column to the Pending Jobs page in Laravel Horizon.

Previously, delayed jobs were only indicated with a label, and users had to hover over it to see how long the job had been delayed (e.g., `Delayed for 3 minutes`).

Because the Pending Jobs page updates frequently and the hover interaction was inconvenient, the delayed duration is now displayed directly in a dedicated column.

<img width="1181" height="239" alt="image" src="https://github.com/user-attachments/assets/7da925ee-7496-46b8-9ab8-45b6fb2c03de" />

