### PR TITLE
[5.x] Improve more tags display in Horizon jobs list

### DIFF
--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -16,7 +16,7 @@
                 Queue: {{job.queue}}
 
                 <span v-if="job.payload.tags.length">
-                    | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.slice(0,3).join(', ') : '' }}<span v-if="job.payload.tags.length > 3"> ({{ job.payload.tags.length - 3 }} more)</span>
+                    | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.slice(0,3).join(', ') : '' }}<span class="text-secondary" v-if="job.payload.tags.length > 3"> +{{ job.payload.tags.length - 3 }} more</span>
                 </span>
             </small>
         </td>

--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -17,7 +17,7 @@
                 Queue: {{job.queue}}
 
                 <span v-if="job.payload.tags && job.payload.tags.length" class="text-break">
-                    | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.slice(0,3).join(', ') : '' }}<span v-if="job.payload.tags.length > 3"> ({{ job.payload.tags.length - 3 }} more)</span>
+                    | Tags: {{ job.payload.tags && job.payload.tags.length ? job.payload.tags.slice(0,3).join(', ') : '' }}<span class="text-secondary" v-if="job.payload.tags.length > 3"> +{{ job.payload.tags.length - 3 }} more</span>
                 </span>
             </small>
         </td>


### PR DESCRIPTION
This PR enhances the Laravel Horizon dashboard by improving the display of job tags. Specifically, it updates the way additional tags are shown by replacing `(1 more)` with `+1 more` and applying the `text-secondary` styling for better visual distinction.

Before:

<img width="1183" height="78" alt="image" src="https://github.com/user-attachments/assets/72a77b61-ecb0-44f3-aeb4-d21c0a4188e4" />

After:

<img width="1175" height="148" alt="image" src="https://github.com/user-attachments/assets/4db79238-dede-40e6-be8d-664431245ad0" />
