### PR TITLE
[5.x] Add number formatting for large numbers in Horizon monitoring page

### DIFF
--- a/resources/js/screens/monitoring/index.vue
+++ b/resources/js/screens/monitoring/index.vue
@@ -155,7 +155,7 @@
                             {{ tag.tag }}
                         </router-link>
                     </td>
-                    <td class="text-end text-muted">{{ tag.count }}</td>
+                    <td class="text-end text-muted">{{ tag.count ? tag.count.toLocaleString() : 0 }}</td>
                     <td class="text-end">
                         <a href="#" @click="stopMonitoring(tag.tag)" class="control-action" title="Stop Monitoring">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">


### PR DESCRIPTION
This PR improves the readability of numeric values displayed in the Horizon monitoring page by adding proper number formatting.

The Dashboard page already applies this kind of formatting, and this change ensures consistency across both views.

<img width="1179" height="249" alt="image" src="https://github.com/user-attachments/assets/df1a0a55-10fc-40fb-86b1-5ae641d4a6c8" />