### PR TITLE
[5.x] Rename table column for clarity

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -209,7 +209,7 @@
             <table class="table table-hover mb-0">
                 <thead>
                 <tr>
-                    <th>Job</th>
+                    <th>Status</th>
                     <th>ID</th>
                     <th class="text-end">Retry Time</th>
                 </tr>


### PR DESCRIPTION
This PR updates the column name from `Job` to `Status` in the Horizon Recent Retries table to more accurately reflect the data being displayed.

Before:

<img width="1174" height="151" alt="image" src="https://github.com/user-attachments/assets/542efa73-9d8d-44d2-84ca-9ccebd19318e" />

After:

<img width="1178" height="151" alt="image" src="https://github.com/user-attachments/assets/16106197-1c82-497e-945d-897d9f19da89" />
