### PR TITLE
[5.x] Refactor string capitalization to use global `upperFirst()` helper

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -334,7 +334,7 @@
                     <td class="text-muted">{{ supervisor.options.queue.replace(/,/g, ', ') }}</td>
                     <td class="text-end text-muted">{{ countProcesses(supervisor.processes) }}</td>
                     <td class="text-end text-muted" v-if="supervisor.options.balance">
-                        {{ supervisor.options.balance.charAt(0).toUpperCase() + supervisor.options.balance.slice(1) }}
+                        {{ upperFirst(supervisor.options.balance) }}
                     </td>
                     <td class="text-end text-muted" v-else>
                         Disabled

--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -231,7 +231,7 @@
                             <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
                         </svg>
 
-                        <span class="ms-2">{{ retry.status.charAt(0).toUpperCase() + retry.status.slice(1) }}</span>
+                        <span class="ms-2">{{ upperFirst(retry.status) }}</span>
                     </td>
 
                     <td class="table-fit">


### PR DESCRIPTION
## Description

This pull request refactors repeated string capitalization logic in several Vue templates to use the existing global `upperFirst()` helper method defined in `resources/js/horizon/base.js`.

## Why?

Before this change, some templates manually called:

```js
string.charAt(0).toUpperCase() + string.slice(1)
```

while other parts of the codebase such as the

https://github.com/laravel/horizon/blob/3b2215d4b0eeb65ee1fa49b589d1aba07a75c778/resources/js/screens/failedJobs/index.vue#L154-L158

were already using this helper.

This PR aligns those templates with the existing approach for consistency and maintainability.
