### PR TITLE
[5.x] Make Job IDs Clickable in the `Recent Retries` Table

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -238,7 +238,12 @@
                         <a v-if="retry.status == 'failed'" :href="Horizon.basePath + '/failed/'+retry.id">
                             {{ retry.id }}
                         </a>
-                        <span v-else>{{ retry.id }}</span>
+                        <a v-if="retry.status == 'completed'" :href="Horizon.basePath + '/jobs/completed/'+retry.id">
+                            {{ retry.id }}
+                        </a>
+                        <a v-if="retry.status == 'reserved' || retry.status == 'pending'" :href="Horizon.basePath + '/jobs/pending/'+retry.id">
+                            {{ retry.id }}
+                        </a>
                     </td>
 
                     <td class="text-end table-fit text-muted">


### PR DESCRIPTION
## Description

This pull request updates the `Recent Retries` table in Laravel Horizon so that all job IDs—including `pending` and `completed` jobs—are rendered as clickable links to their corresponding Job Details page.

Previously, only `failed` jobs had their job IDs linked. This created an inconsistent experience and made it harder to quickly inspect the jobs that were retried.

## Before

<img width="1177" height="204" alt="Screenshot 2025-11-06 192447" src="https://github.com/user-attachments/assets/36c6f091-4f2b-4afd-99c9-407fd0689650" />

<img width="1179" height="198" alt="Screenshot 2025-11-06 192604" src="https://github.com/user-attachments/assets/675c3ca0-3973-40ff-8bda-814da2d7b2f6" />


## After

<img width="1181" height="201" alt="Screenshot 2025-11-06 193005" src="https://github.com/user-attachments/assets/f76cbb7d-139d-4be6-be6b-1e3d73eaa0a6" />

<img width="1173" height="200" alt="Screenshot 2025-11-06 193033" src="https://github.com/user-attachments/assets/7c62984d-37e5-43c0-901f-2d9770cb6955" />

