### PR TITLE
[5.x] Update 'Job' column label to 'Status' in Recent Jobs table

### DIFF
--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -177,7 +177,7 @@
             <table v-if="ready && jobs.length > 0" class="table table-hover mb-0">
                 <thead>
                     <tr>
-                        <th>Job</th>
+                        <th>Status</th>
                         <th v-if="$route.params.type=='pending'" class="text-end">Queued</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'">Queued</th>
                         <th v-if="$route.params.type=='completed' || $route.params.type=='silenced'">Completed</th>


### PR DESCRIPTION
This PR updates the column label in the Horizon Recent Jobs table for clarity.

- The 'Job' column is renamed to 'Status' to better reflect the data being displayed.
- No backend or functional changes are made.
- This is purely a UI/UX improvement.
