### PR TITLE
[5.x] Add job title to failed jobs table in job batch details page

### DIFF
--- a/resources/js/screens/batches/preview.vue
+++ b/resources/js/screens/batches/preview.vue
@@ -165,7 +165,7 @@
 
                 <tr v-for="failedJob in failedJobs">
                     <td>
-                        <router-link :to="{ name: 'failed-jobs-preview', params: { jobId: failedJob.id }}">
+                        <router-link :title="failedJob.name" :to="{ name: 'failed-jobs-preview', params: { jobId: failedJob.id }}">
                             {{ jobBaseName(failedJob.name) }}
                         </router-link>
                     </td>


### PR DESCRIPTION
## Description

This PR adds the job title to the failed jobs table in the Job Batch Details page. 

The job name is matching the style used throughout Horizon, improving consistency with existing title and link displays.

## Screenshot

<img width="1211" height="606" alt="image" src="https://github.com/user-attachments/assets/6dd5be09-a7b1-48ef-8be3-7ca98bfbc47f" />
