### PR TITLE
[5.x] Fix link for failed jobs on monitoring page

### DIFF
--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -1,7 +1,11 @@
 <template>
     <tr>
         <td>
-            <router-link :title="job.name" :to="{ name: 'job-preview', params: { jobId: job.id, type: $parent.type }}">
+            <router-link v-if="job.failed_at" :title="job.name" :to="{ name: 'failed-jobs-preview', params: { jobId: job.id }}">
+                {{ jobBaseName(job.name) }}
+            </router-link>
+
+            <router-link v-else :title="job.name" :to="{ name: 'job-preview', params: { jobId: job.id, type: $parent.type }}">
                 {{ jobBaseName(job.name) }}
             </router-link>
 


### PR DESCRIPTION
## Description

When viewing a tag in Laravel Horizon’s monitoring page, the Failed Jobs tab listed the failed jobs correctly, but clicking on a job name incorrectly navigated to the regular job detail page instead of the failed job detail page.

This prevented users from viewing the `exception details` and `context` for that failed job unless they manually navigated through the main Failed Jobs menu.

This PR updates the link generation to correctly point to the failed job detail route, ensuring users can access exception information directly from the tag’s failed jobs list.
