### PR TITLE
[5.x] Add `Silenced` Badge to Jobs Lists

### DIFF
--- a/resources/js/screens/failedJobs/index.vue
+++ b/resources/js/screens/failedJobs/index.vue
@@ -257,6 +257,11 @@
                             Retried
                         </small>
 
+                        <small class="ms-1 badge bg-secondary badge-sm"
+                               v-if="job.payload.silenced">
+                            Silenced
+                        </small>
+
                         <br>
 
                         <small class="text-muted">

--- a/resources/js/screens/monitoring/job-row.vue
+++ b/resources/js/screens/monitoring/job-row.vue
@@ -10,6 +10,11 @@
                 Delayed
             </small>
 
+            <small class="ms-1 badge bg-secondary badge-sm"
+                   v-if="job.payload.silenced">
+                Silenced
+            </small>
+
             <br>
 
             <small class="text-muted">

--- a/resources/js/screens/recentJobs/job-row.vue
+++ b/resources/js/screens/recentJobs/job-row.vue
@@ -11,6 +11,11 @@
                 Delayed
             </small>
 
+            <small class="ms-1 badge bg-secondary badge-sm"
+                v-if="job.payload.silenced && $route.params.type=='pending'">
+                Silenced
+            </small>
+
             <br>
 
             <small class="text-muted">


### PR DESCRIPTION
## Summary

This PR adds a `Silenced` badge to job entries displayed in the following Horizon sections:

- Monitoring
- Pending Jobs
- Failed Jobs

The badge is shown in the same style and position as existing badges (e.g., `Delayed`), making silenced jobs easily recognizable at a glance.

## Why?

Horizon already supports silenced jobs via the `silenced` configuration option.  
Silenced jobs do not appear in the *Completed Jobs* list and instead appear in a dedicated *Silenced* page.

However, until such a job actually finishes running (and moves to the Silenced page), there is **no visual indicator** that the job is silenced while it is:

- Pending  
- Being monitored  
- Failed  

This creates a UX gap: developers cannot know that a job is silenced **until after it has executed.**

This PR closes that gap by making the silenced status visible in all job lists where silenced jobs may appear.

## Screenshots

Monitoring:

<img width="1209" height="384" alt="image" src="https://github.com/user-attachments/assets/c76f730a-3e14-4db4-9973-5d019e686add" />

&nbsp;

Pending Jobs:

<img width="1207" height="262" alt="image" src="https://github.com/user-attachments/assets/13df911e-13a5-4b8b-b0b1-53c6b5d75933" />

&nbsp;

Failed Jobs:

<img width="1215" height="410" alt="image" src="https://github.com/user-attachments/assets/2175f15a-b5cd-46f1-982f-166afa45146b" />
