### PR TITLE
[5.x] Revert `#1657`

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -238,12 +238,7 @@
                         <a v-if="retry.status == 'failed'" :href="Horizon.basePath + '/failed/'+retry.id">
                             {{ retry.id }}
                         </a>
-                        <a v-if="retry.status == 'completed'" :href="Horizon.basePath + '/jobs/completed/'+retry.id">
-                            {{ retry.id }}
-                        </a>
-                        <a v-if="retry.status == 'reserved' || retry.status == 'pending'" :href="Horizon.basePath + '/jobs/pending/'+retry.id">
-                            {{ retry.id }}
-                        </a>
+                        <span v-else>{{ retry.id }}</span>
                     </td>
 
                     <td class="text-end table-fit text-muted">


### PR DESCRIPTION
This PR reverts #1657

The reason is that completed jobs, based on the Horizon trimming configuration, are automatically deleted after some time. As a result, the link ends up pointing to a job that no longer exists.