### PR TITLE
[5.x] Highlight Monitoring sidebar link for job preview pages

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -59,7 +59,7 @@
                         </router-link>
                     </li>
                     <li class="nav-item">
-                        <router-link active-class="active" to="/monitoring" class="nav-link d-flex align-items-center">
+                        <router-link :class="{ active: $route.path.startsWith('/monitoring') || ['jobs','failed'].includes($route.params.type) }" to="/monitoring" class="nav-link d-flex align-items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
                                 <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd" />
                             </svg>


### PR DESCRIPTION
## Description

Currently, the Monitoring sidebar link only highlights for `/monitoring` routes.

When viewing `recent jobs` or `failed jobs` originating from Monitoring (`/jobs/jobs/:jobId` or `/jobs/failed/:jobId`), the link does not highlight, even though these jobs logically belong to Monitoring.

This PR updates the Monitoring `<router-link>` to highlight whenever:

- The path starts with `/monitoring`.
- The current job preview’s `:type` is `jobs` or `failed` (which correspond to Monitoring jobs).

## Why?

The `/jobs/:type/:jobId` route is shared across multiple job types:

- `jobs` → Recent Jobs tab in Monitoring
- `failed` → Failed Jobs tab in Monitoring
- `pending` → Pending Jobs
- `completed` → Completed Jobs
- `silenced` → Silenced Jobs

Only `jobs` and `failed` should highlight Monitoring. Other types highlight their respective sidebar links.

## Routes reference

https://github.com/laravel/horizon/blob/f4e05f9fcf13ad2339f0a8656b433a7e8815ad56/resources/js/routes.js#L25-L52
