### PR TITLE
[5.x] Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
+.DS_Store
+.phpunit.result.cache
 /.fleet
 /.idea
+/.phpunit.cache
+/phpunit.xml
 /.vscode
 /vendor
-/laravel
-/node_modules
-/phpunit.xml
+composer.phar
 composer.lock
-.phpunit.result.cache
-.phpunit.cache/
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.fleet
+/.idea
+/.vscode
 /vendor
 /laravel
 /node_modules


### PR DESCRIPTION
This replicates the same .gitignore as the [Laravel framework repo](https://github.com/laravel/framework/blob/12.x/.gitignore#L1). 

I noticed I was getting a bunch of invalid changes otherwise: 

<img width="977" height="182" alt="image" src="https://github.com/user-attachments/assets/de67f0a3-9d2a-4609-aadc-d3b55d3c0d23" />


