### PR TITLE
[5.x] Add `Runtime` to the job detail page

### DIFF
--- a/resources/js/screens/failedJobs/job.vue
+++ b/resources/js/screens/failedJobs/job.vue
@@ -164,9 +164,14 @@
                     <div class="col-md-2 text-muted">Pushed</div>
                     <div class="col">{{ readableTimestamp(job.payload.pushedAt) }}</div>
                 </div>
-                <div class="row">
+                <div class="row mb-2">
                     <div class="col-md-2 text-muted">Failed</div>
                     <div class="col">{{readableTimestamp(job.failed_at)}}</div>
+                </div>
+                <div class="row">
+                    <div class="col-md-2 text-muted">Runtime</div>
+                    <div class="col" v-if="job.failed_at">{{ String((job.failed_at - job.reserved_at).toFixed(2))+'s' }}</div>
+                    <div class="col" v-else>-</div>
                 </div>
             </div>
         </div>

--- a/resources/js/screens/recentJobs/job.vue
+++ b/resources/js/screens/recentJobs/job.vue
@@ -53,9 +53,15 @@
                     <div class="col">{{delayed}}</div>
                 </div>
 
-                <div class="row">
+                <div class="row mb-2">
                     <div class="col-md-2 text-muted">Completed</div>
                     <div class="col" v-if="job.completed_at">{{readableTimestamp(job.completed_at)}}</div>
+                    <div class="col" v-else>-</div>
+                </div>
+
+                <div class="row" v-if="$route.params.type=='completed' || $route.params.type=='silenced'">
+                    <div class="col-md-2 text-muted">Runtime</div>
+                    <div class="col" v-if="job.completed_at">{{ (job.completed_at - job.reserved_at).toFixed(2)+'s' }}</div>
                     <div class="col" v-else>-</div>
                 </div>
             </div>


### PR DESCRIPTION
## Description

This PR adds the runtime information to the Horizon job detail page.

## Why?

The runtime of `completed`, `silenced`, and `failed` jobs is currently visible only in the jobs index table. However, because the index page refreshes frequently and jobs shift position, the runtime is easy to miss during inspection.

Adding this information to the job detail page:

- provides a more complete and consistent debugging view
- improves performance analysis, especially for slow or long-running jobs

## Screenshots

<img width="1202" height="300" alt="image" src="https://github.com/user-attachments/assets/2b1b55aa-dc0d-45ac-8c66-173f3ac766ad" />

<img width="1201" height="398" alt="image" src="https://github.com/user-attachments/assets/fe51fd7f-d8cb-4673-a98c-1427eeb15e74" />


