### PR TITLE
Add queue filter for pending jobs

### DIFF
--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -13,7 +13,9 @@
                 page: 1,
                 perPage: 50,
                 totalPages: 1,
-                jobs: []
+                jobs: [],
+                queues: [],
+                selectedQueue: ''
             };
         },
 
@@ -32,6 +34,10 @@
         mounted() {
             this.updatePageTitle();
 
+            if (this.$route.params.type === 'pending') {
+                this.loadQueues();
+            }
+
             this.loadJobs();
         },
 
@@ -44,6 +50,11 @@
                 this.updatePageTitle();
 
                 this.page = 1;
+                this.selectedQueue = '';
+
+                if (this.$route.params.type === 'pending') {
+                    this.loadQueues();
+                }
 
                 this.loadJobs();
             },
@@ -65,7 +76,13 @@
                     this.ready = false;
                 }
 
-                this.$http.get(Horizon.basePath + '/api/jobs/' + this.$route.params.type + '?starting_at=' + starting + '&limit=' + this.perPage)
+                let url = Horizon.basePath + '/api/jobs/' + this.$route.params.type + '?starting_at=' + starting + '&limit=' + this.perPage;
+
+                if (this.$route.params.type === 'pending' && this.selectedQueue) {
+                    url += '&queue=' + encodeURIComponent(this.selectedQueue);
+                }
+
+                this.$http.get(url)
                     .then(response => {
                         if (!this.$root.autoLoadsNewEntries && refreshing && this.jobs.length && response.data.jobs[0]?.id !== this.jobs[0]?.id) {
                             this.hasNewEntries = true;
@@ -77,6 +94,24 @@
 
                         this.ready = true;
                     });
+            },
+
+            /**
+             * Load the available queues for filtering.
+             */
+            loadQueues() {
+                this.$http.get(Horizon.basePath + '/api/workload')
+                    .then(response => {
+                        this.queues = response.data.map(q => q.name);
+                    });
+            },
+
+            /**
+             * Handle queue filter change.
+             */
+            filterByQueue() {
+                this.page = 1;
+                this.loadJobs();
             },
 
 
@@ -154,6 +189,11 @@
                 <h2 class="h6 m-0" v-if="$route.params.type == 'pending'">Pending Jobs</h2>
                 <h2 class="h6 m-0" v-if="$route.params.type == 'completed'">Completed Jobs</h2>
                 <h2 class="h6 m-0" v-if="$route.params.type == 'silenced'">Silenced Jobs</h2>
+
+                <select v-if="$route.params.type == 'pending'" class="form-select" v-model="selectedQueue" @change="filterByQueue" style="width: auto;">
+                    <option value="">All Queues</option>
+                    <option v-for="queue in queues" :key="queue" :value="queue">{{ queue }}</option>
+                </select>
             </div>
 
             <div v-if="!ready"

--- a/src/Http/Controllers/PendingJobsController.php
+++ b/src/Http/Controllers/PendingJobsController.php
@@ -35,18 +35,70 @@ class PendingJobsController extends Controller
      */
     public function index(Request $request)
     {
+        $queue = $request->query('queue');
+
+        if ($queue) {
+            return $this->paginateByQueue($request, $queue);
+        }
+
         $jobs = $this->jobs
             ->getPending($request->query('starting_at', -1))
-            ->map(function ($job) {
-                $job->payload = json_decode($job->payload);
-
-                return $job;
-            })
+            ->map(fn ($job) => $this->decode($job))
             ->values();
 
         return [
             'jobs' => $jobs,
             'total' => $this->jobs->countPending(),
+        ];
+    }
+
+    /**
+     * Paginate pending jobs filtered by queue.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $queue
+     * @return array
+     */
+    protected function paginateByQueue(Request $request, $queue)
+    {
+        $startingAt = (int) $request->query('starting_at', -1);
+        $limit = 50;
+
+        $filteredJobs = collect();
+        $total = 0;
+        $index = -1;
+        $skipped = 0;
+
+        while (true) {
+            $batch = $this->jobs->getPending($index);
+
+            if ($batch->isEmpty()) {
+                break;
+            }
+
+            $matchingJobs = $batch->filter(fn ($job) => $job->queue === $queue);
+
+            $total += $matchingJobs->count();
+
+            foreach ($matchingJobs as $job) {
+                if ($skipped <= $startingAt) {
+                    $skipped++;
+                    continue;
+                }
+
+                if ($filteredJobs->count() < $limit) {
+                    $job->index = $skipped;
+                    $skipped++;
+                    $filteredJobs->push($job);
+                }
+            }
+
+            $index = $batch->last()->index ?? $index + 50;
+        }
+
+        return [
+            'jobs' => $filteredJobs->map(fn ($job) => $this->decode($job))->values(),
+            'total' => $total,
         ];
     }
 


### PR DESCRIPTION
This pull request adds queue-based filtering functionality to the "Pending Jobs" screen, allowing users to view pending jobs by specific queue. The changes span both the frontend Vue component and the backend controller, introducing new UI elements and API logic to support this feature.

**Frontend: Queue Filtering UI and Logic**

* Added a `select` dropdown to the pending jobs screen for choosing a queue, and updated the data model to track available queues and the selected queue (`resources/js/screens/recentJobs/index.vue`). [[1]](diffhunk://#diff-527be5bd97273c60f84e6fb4fe23f6fc71fc158ccaf4bfada45d004d77e2f342L16-R18) [[2]](diffhunk://#diff-527be5bd97273c60f84e6fb4fe23f6fc71fc158ccaf4bfada45d004d77e2f342R192-R196)
* Implemented logic to load available queues from the backend when viewing pending jobs, and to reload jobs when the selected queue changes (`resources/js/screens/recentJobs/index.vue`). [[1]](diffhunk://#diff-527be5bd97273c60f84e6fb4fe23f6fc71fc158ccaf4bfada45d004d77e2f342R37-R40) [[2]](diffhunk://#diff-527be5bd97273c60f84e6fb4fe23f6fc71fc158ccaf4bfada45d004d77e2f342R53-R57) [[3]](diffhunk://#diff-527be5bd97273c60f84e6fb4fe23f6fc71fc158ccaf4bfada45d004d77e2f342R99-R116)
* Modified job loading to include the selected queue in API requests when filtering is active (`resources/js/screens/recentJobs/index.vue`).

**Backend: Queue Filtering API**

* Updated the pending jobs controller to accept an optional `queue` query parameter; if present, jobs are filtered and paginated by queue (`src/Http/Controllers/PendingJobsController.php`).
* Added a new `paginateByQueue` method to efficiently filter and paginate pending jobs by queue, returning only jobs from the selected queue (`src/Http/Controllers/PendingJobsController.php`).