### PR TITLE
fix: guard setAccessible() call for PHP 8.5+

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -118,7 +118,9 @@ class Tags
         foreach ($targets as $target) {
             $models[] = collect((new ReflectionClass($target))->getProperties())
                 ->map(function ($property) use ($target) {
-                    $property->setAccessible(true);
+                    if (PHP_VERSION_ID < 80500) {
+                        $property->setAccessible(true);
+                    }
 
                     $value = static::getValue($property, $target);
 


### PR DESCRIPTION
## Summary

PHP 8.1 made `ReflectionProperty::setAccessible()` a no-op since all properties are accessible via Reflection by default. PHP 8.5 formally deprecated this method, triggering `E_DEPRECATED` warnings.

This change adds a PHP version check to skip the `setAccessible()` call on PHP 8.5+, matching the approach used in `laravel/telescope`.

## Changes

- Guard `setAccessible()` call in `Tags::modelsFor()` with `PHP_VERSION_ID < 80500`

## Related

- Similar fix in Telescope: https://github.com/laravel/telescope/blob/5.x/src/ExtractProperties.php#L22
- PHP 8.5 Deprecation RFC: https://wiki.php.net/rfc/deprecations_php_8_5

## Testing

All existing tests pass.