### PR TITLE
Show attempts on completed jobs detail

### DIFF
--- a/resources/js/screens/recentJobs/job.vue
+++ b/resources/js/screens/recentJobs/job.vue
@@ -35,6 +35,12 @@
                 </div>
 
                 <div class="row mb-2">
+                    <div class="col-md-2 text-muted">Attempts</div>
+                    <div class="col" v-if="job.payload.attempts">{{job.payload.attempts}}</div>
+                    <div class="col" v-else>-</div>
+                </div>
+
+                <div class="row mb-2">
                     <div class="col-md-2 text-muted">Pushed</div>
                     <div class="col">{{ readableTimestamp(job.payload.pushedAt) }}</div>
                 </div>
@@ -83,7 +89,6 @@
                     Collapse
                 </a>
             </div>
-
             <div class="card-body code-bg text-white collapse show" id="collapseTags">
                 <vue-json-pretty :data="job.payload.tags"></vue-json-pretty>
             </div>


### PR DESCRIPTION
Hello, this PR  shows the attempts on the completed job detail.

<img width="1502" height="363" alt="image" src="https://github.com/user-attachments/assets/bdbda312-b4cd-4524-882e-5571d66ad881" />

<img width="1505" height="375" alt="image" src="https://github.com/user-attachments/assets/00718711-8b6f-46c1-be79-f828a85e4c6c" />

This would be helpful to spot jobs that eventually succeed but required multiple retries, which is useful when diagnosing transient failures. For example, a job showing 3 attempts could indicate API timeouts or race conditions that deserve further investigation.