### PR TITLE
Fix: Unable to clear a queue with a lot of data

### DIFF
--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -50,30 +50,28 @@ LUA;
         return <<<'LUA'
             
             local count = 0
-            local cursor = 0
-            
-            repeat
-                -- Iterate over the recent jobs sorted set
-                local scanner = redis.call('zscan', KEYS[1], cursor)
-                cursor = scanner[1]
+            local cursor = ARGV[3]
 
-                for i = 1, #scanner[2], 2 do
-                    local jobid = scanner[2][i]
-                    local hashkey = ARGV[1] .. jobid
-                    local job = redis.call('hmget', hashkey, 'status', 'queue')
+            -- Iterate over the recent jobs sorted set
+            local scanner = redis.call('zscan', KEYS[1], cursor)
+            cursor = scanner[1]
 
-                    -- Delete the pending/reserved jobs, that match the queue
-                    -- name, from the sorted sets as well as the job hash
-                    if((job[1] == 'reserved' or job[1] == 'pending') and job[2] == ARGV[2]) then
-                        redis.call('zrem', KEYS[1], jobid)
-                        redis.call('zrem', KEYS[2], jobid)
-                        redis.call('del', hashkey)
-                        count = count + 1
-                    end           
+            for i = 1, #scanner[2], 2 do
+                local jobid = scanner[2][i]
+                local hashkey = ARGV[1] .. jobid
+                local job = redis.call('hmget', hashkey, 'status', 'queue')
+
+                -- Delete the pending/reserved jobs, that match the queue
+                -- name, from the sorted sets as well as the job hash
+                if((job[1] == 'reserved' or job[1] == 'pending') and job[2] == ARGV[2]) then
+                    redis.call('zrem', KEYS[1], jobid)
+                    redis.call('zrem', KEYS[2], jobid)
+                    redis.call('del', hashkey)
+                    count = count + 1
                 end
-            until cursor == '0'
+            end
 
-            return count
+            return {count, cursor}
 LUA;
     }
 }

--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -48,7 +48,6 @@ LUA;
     public static function purge()
     {
         return <<<'LUA'
-            
             local count = 0
             local cursor = ARGV[3]
 
@@ -61,8 +60,7 @@ LUA;
                 local hashkey = ARGV[1] .. jobid
                 local job = redis.call('hmget', hashkey, 'status', 'queue')
 
-                -- Delete the pending/reserved jobs, that match the queue
-                -- name, from the sorted sets as well as the job hash
+                -- Delete the pending / reserved jobs in the given queue
                 if((job[1] == 'reserved' or job[1] == 'pending') and job[2] == ARGV[2]) then
                     redis.call('zrem', KEYS[1], jobid)
                     redis.call('zrem', KEYS[2], jobid)

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -728,14 +728,25 @@ class RedisJobRepository implements JobRepository
      */
     public function purge($queue)
     {
-        return $this->connection()->eval(
-            LuaScripts::purge(),
-            2,
-            'recent_jobs',
-            'pending_jobs',
-            config('horizon.prefix'),
-            $queue
-        );
+        $count = 0;
+        $cursor = 0;
+
+        do {
+            $result = $this->connection()->eval(
+                LuaScripts::purge(),
+                2,
+                'recent_jobs',
+                'pending_jobs',
+                config('horizon.prefix'),
+                $queue,
+                $cursor
+            );
+
+            $count += $result[0];
+            $cursor = $result[1];
+        } while ($cursor !== '0');
+
+        return $count;
     }
 
     /**


### PR DESCRIPTION
### Fixed #1663
### Description

This PR fixes a `SCRIPT KILL` error (or timeout) that occurs when running `php artisan horizon:clear` on a queue with a very large number of jobs (e.g., > 200k).

The existing [purge](cci:1://file:///d:/wamp64/www/package-development/package-testing/packages/laravel/horizon/src/LuaScripts.php:37:4-75:5) Lua script iterates over the entire `recent_jobs` sorted set in a single atomic execution. On large datasets, this exceeds the Redis/Memurai script execution time limit, causing the script to be killed by the server or timeout.

**Changes:**
- Modified `LuaScripts::purge` to run a single `zscan` iteration (chunked) instead of iterating until completion. It now accepts a `cursor` argument and returns `[deleted_count, next_cursor]`.
- Updated `RedisJobRepository::purge` to loop through the Lua script calls until the cursor returns to `0`.

This approach breaks the massive atomic operation into smaller, manageable chunks, ensuring the Lua script stays within execution time limits regardless of the queue size.

### Benefit to End Users

Users managing high-volume queues often need to clear them during maintenance or debugging. Currently, this command fails catastrophically on large queues. This fix ensures `horizon:clear` works reliably even with millions of jobs, preventing manual Redis intervention or "SCRIPT KILL" errors.

### Breaking Changes

None. The public API of `RedisJobRepository::purge` remains the same (returns total deleted count), but the internal execution is now chunked.

### Testing

**reproduction:**
1. Seeded 500,000 jobs to a queue.
2. Ran `php artisan horizon:clear`.
3. **Before fix:** Failed with `Predis\Response\ServerException: ERR Script killed by user with SCRIPT KILL`.
4. **After fix:** Successfully cleared all 500,000 jobs without error.