### PR TITLE
Fix race condition that causes jobs to stay in 'pending' state

### DIFF
--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -10,8 +10,11 @@ trait EventMap
      * @var array
      */
     protected $events = [
-        Events\JobPushed::class => [
+        Events\JobPending::class => [
             Listeners\StoreJob::class,
+        ],
+
+        Events\JobPushed::class => [
             Listeners\StoreMonitoredTags::class,
         ],
 

--- a/src/Events/JobPending.php
+++ b/src/Events/JobPending.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Laravel\Horizon\Events;
+
+class JobPending extends RedisEvent
+{
+    //
+}

--- a/src/Listeners/StoreJob.php
+++ b/src/Listeners/StoreJob.php
@@ -3,7 +3,7 @@
 namespace Laravel\Horizon\Listeners;
 
 use Laravel\Horizon\Contracts\JobRepository;
-use Laravel\Horizon\Events\JobPushed;
+use Laravel\Horizon\Events\JobPending;
 
 class StoreJob
 {
@@ -28,10 +28,10 @@ class StoreJob
     /**
      * Handle the event.
      *
-     * @param  \Laravel\Horizon\Events\JobPushed  $event
+     * @param  \Laravel\Horizon\Events\JobPending  $event
      * @return void
      */
-    public function handle(JobPushed $event)
+    public function handle(JobPending $event)
     {
         $this->jobs->pushed(
             $event->connectionName, $event->queue, $event->payload


### PR DESCRIPTION
This PR fixes a long existing issue where a race condition causes small and fast running jobs to be processed but stay on the 'pending' status. On these jobs the data interestingly shows a completed_at date that is before the created_at date.

### What happens
- In RedisQueue::pushRaw
  - parent::pushRaw is called to push the job on the queue
    - This job is now available to be picked up and processed
  - After the job is pushed, the JobPushed event is fired
    - *meanwhile* the job might have been picked up and been processed already, status = completed
    - The StoreJob is listening to the JobPushed event and updating metadata including "status = pending and created_at = now)
    - The status = completed is now reverted back to pending

### Solution
To fix this issue, this PR introduces the JobPending event that is called before ``parent::pushRaw`` is called and allows the StoreJob listener to update metadata (like status = pending) before the job becomes available to process.

### Impact
Should be very minimal as the JobPushed event is still available with the same data.

Fixes laravel/horizon#1015
Fixes laravel/horizon#1034
Fixes laravel/horizon#1173
Fixes laravel/horizon#1280