### PR TITLE
[5.x] Display queue paused status in Horizon dashboard

### DIFF
--- a/resources/js/screens/dashboard.vue
+++ b/resources/js/screens/dashboard.vue
@@ -263,6 +263,7 @@
                     <th class="text-end" style="width: 120px;">Jobs</th>
                     <th class="text-end" style="width: 120px;">Processes</th>
                     <th class="text-end" style="width: 180px;">Wait</th>
+                    <th class="text-end" style="width: 120px;">Status</th>
                 </tr>
                 </thead>
 
@@ -275,6 +276,7 @@
                             <td class="text-end text-muted" :class="{ 'fw-bold': queue.split_queues }">{{ queue.length ? queue.length.toLocaleString() : 0 }}</td>
                             <td class="text-end text-muted" :class="{ 'fw-bold': queue.split_queues }">{{ queue.processes ? queue.processes.toLocaleString() : 0 }}</td>
                             <td class="text-end text-muted" :class="{ 'fw-bold': queue.split_queues }">{{ humanTime(queue.wait) }}</td>
+                            <td class="text-end text-muted" :class="{ 'fw-bold': queue.split_queues }">{{ queue.paused ? 'Paused' : 'Running' }}</td>
                         </tr>
 
                         <tr v-for="split_queue in queue.split_queues">
@@ -288,6 +290,7 @@
                             <td class="text-end text-muted">{{ split_queue.length ? split_queue.length.toLocaleString() : 0 }}</td>
                             <td class="text-end text-muted">-</td>
                             <td class="text-end text-muted">{{ humanTime(split_queue.wait) }}</td>
+                            <td class="text-end text-muted">{{ queue.paused ? 'Paused' : 'Running' }}</td>
                         </tr>
                     </template>
                 </tbody>

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon\Repositories;
 
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Laravel\Horizon\Contracts\SupervisorRepository;
@@ -40,12 +41,20 @@ class RedisWorkloadRepository implements WorkloadRepository
     private $supervisors;
 
     /**
+     * The queue manager instance.
+     *
+     * @var \Illuminate\Queue\QueueManager
+     */
+    private $manager;
+
+    /**
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Queue\Factory  $queue
      * @param  \Laravel\Horizon\WaitTimeCalculator  $waitTime
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
+     * @param  \Illuminate\Queue\QueueManager  $manager
      * @return void
      */
     public function __construct(
@@ -53,11 +62,13 @@ class RedisWorkloadRepository implements WorkloadRepository
         WaitTimeCalculator $waitTime,
         MasterSupervisorRepository $masters,
         SupervisorRepository $supervisors,
+        QueueManager $manager,
     ) {
         $this->queue = $queue;
         $this->masters = $masters;
         $this->waitTime = $waitTime;
         $this->supervisors = $supervisors;
+        $this->manager = $manager;
     }
 
     /**
@@ -86,6 +97,7 @@ class RedisWorkloadRepository implements WorkloadRepository
                         'name' => $queueName,
                         'length' => $length,
                         'wait' => $wait += $this->waitTime->calculateTimeToClear($connection, $queueName, $totalProcesses),
+                        'paused' => $this->isPaused($connection, $queueName),
                     ];
                 }) : null;
 
@@ -95,6 +107,7 @@ class RedisWorkloadRepository implements WorkloadRepository
                     'wait' => $waitTime,
                     'processes' => $totalProcesses,
                     'split_queues' => $splitQueues,
+                    'paused' => $this->isPaused($connection, $queueName),
                 ];
             })
             ->values()
@@ -117,5 +130,18 @@ class RedisWorkloadRepository implements WorkloadRepository
 
                 return $final;
             }, []);
+    }
+
+    /**
+     * Determine if a given queue is paused.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @return bool
+     */
+    private function isPaused(string $connection, string $queue): bool
+    {
+        return method_exists($this->manager, 'isPaused')
+            && $this->manager->isPaused($connection, $queue);
     }
 }


### PR DESCRIPTION
## Summary

In commit https://github.com/laravel/framework/pull/57800, Laravel introduced the queue paused feature, allowing queues to be temporarily paused. However, Horizon did not provide a way to visualize this state in its dashboard.

This PR adds the paused status under a `Status` column in the `Current Workload` table, making it easy for users to see which queues are currently paused.

### Backward Compatibility

If Laravel does not include the paused feature, or if Horizon is updated before the Laravel upgrade, the paused status defaults to `false`, ensuring that no errors occur and the dashboard remains fully functional.

## Screenshot

<img width="1237" height="422" alt="image" src="https://github.com/user-attachments/assets/24bc4449-df35-4d69-9888-0137b43e9704" />
