### PR TITLE
Handle non-array Redis HMGET responses during startup

### DIFF
--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -81,6 +81,7 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
                 if (! is_array($record)) {
                     return null;
                 }
+
                 $record = array_values($record);
 
                 return ! $record[0] ? null : (object) [

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -78,6 +78,9 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
 
         return collect($records)
             ->map(function ($record) {
+                if (! is_array($record)) {
+                    return null;
+                }
                 $record = array_values($record);
 
                 return ! $record[0] ? null : (object) [


### PR DESCRIPTION
Added an is_array check to safely handle Redis responses during application startup.

When Redis is starting up or under certain transient conditions (e.g. when the application and Redis start at the same time), HMGET may return false instead of an array. Without this guard, PHP throws a runtime error when the response is processed as an array.

This change prevents unexpected exceptions by gracefully ignoring invalid Redis responses and ensures the application can start reliably even when Redis is not fully ready.


``` bash
[2025-12-25 17:33:41] production.ERROR: array_values(): Argument #1 ($array) must be of type array, false given {"exception":"[object] (TypeError(code: 0): array_values(): Argument #1 ($array) must be of type array, false given at /var/www/vendor/laravel/horizon/src/Repositories/RedisMasterSupervisorRepository.php:81)
[stacktrace]
#0 /var/www/vendor/laravel/horizon/src/Repositories/RedisMasterSupervisorRepository.php(81): array_values()
#1 [internal function]: Laravel\\Horizon\\Repositories\\RedisMasterSupervisorRepository->{closure:Laravel\\Horizon\\Repositories\\RedisMasterSupervisorRepository::get():80}()
#2 /var/www/vendor/laravel/framework/src/Illuminate/Collections/Arr.php(788): array_map()
#3 /var/www/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(819): Illuminate\\Support\\Arr::map()
#4 /var/www/vendor/laravel/horizon/src/Repositories/RedisMasterSupervisorRepository.php(80): Illuminate\\Support\\Collection->map()
#5 /var/www/vendor/laravel/horizon/src/Repositories/RedisMasterSupervisorRepository.php(62): Laravel\\Horizon\\Repositories\\RedisMasterSupervisorRepository->get()
#6 /var/www/vendor/laravel/horizon/src/Console/HorizonCommand.php(36): Laravel\\Horizon\\Repositories\\RedisMasterSupervisorRepository->find()
#7 /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Laravel\\Horizon\\Console\\HorizonCommand->handle()
#8 /var/www/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\\Container\\BoundMethod::{closure:Illuminate\\Container\\BoundMethod::call():35}()
#9 /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(96): Illuminate\\Container\\Util::unwrapIfClosure()
#10 /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\\Container\\BoundMethod::callBoundMethod()
#11 /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php(799): Illuminate\\Container\\BoundMethod::call()
#12 /var/www/vendor/laravel/framework/src/Illuminate/Console/Command.php(211): Illuminate\\Container\\Container->call()
#13 /var/www/vendor/symfony/console/Command/Command.php(341): Illuminate\\Console\\Command->execute()
#14 /var/www/vendor/laravel/framework/src/Illuminate/Console/Command.php(180): Symfony\\Component\\Console\\Command\\Command->run()
#15 /var/www/vendor/symfony/console/Application.php(1102): Illuminate\\Console\\Command->run()
#16 /var/www/vendor/symfony/console/Application.php(356): Symfony\\Component\\Console\\Application->doRunCommand()
#17 /var/www/vendor/symfony/console/Application.php(195): Symfony\\Component\\Console\\Application->doRun()
#18 /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(198): Symfony\\Component\\Console\\Application->run()
#19 /var/www/artisan(35): Illuminate\\Foundation\\Console\\Kernel->handle()
#20 {main}
"} 
```