### PR TITLE
[5.x] Fix `calculateTimeToClear` return type

### DIFF
--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -120,7 +120,7 @@ class WaitTimeCalculator
      * @param  string  $connection
      * @param  string  $queue
      * @param  int  $totalProcesses
-     * @return int
+     * @return float
      */
     public function calculateTimeToClear($connection, $queue, $totalProcesses)
     {


### PR DESCRIPTION
This PR fixes a return type inconsistency in `calculateTimeToClear()`.
Although the method is documented to return an `int`, it was implicitly returning a `float` because `round()` always returns float in PHP.

https://www.php.net/manual/en/function.round.php
