### PR TITLE
[5.x] Add `ParsesQueue` trait

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -5,10 +5,13 @@ namespace Laravel\Horizon\Listeners;
 use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\ParsesQueue;
 use Laravel\Horizon\WaitTimeCalculator;
 
 class MonitorWaitTimes
 {
+    use ParsesQueue;
+
     /**
      * The metrics repository implementation.
      *
@@ -59,7 +62,7 @@ class MonitorWaitTimes
         // events for each of the queues. We'll need to separate the connection and
         // queue names into their own strings before we will fire off the events.
         $long->each(function ($wait, $queue) {
-            [$connection, $queue] = explode(':', $queue, 2);
+            [$connection, $queue] = $this->parseQueue($queue);
 
             event(new LongWaitDetected($connection, $queue, $wait));
         });

--- a/src/ParsesQueue.php
+++ b/src/ParsesQueue.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Horizon;
+
+trait ParsesQueue
+{
+    /**
+     * Parse the queue argument into connection and queue name.
+     *
+     * @param  string  $queue
+     * @return array{string, string}
+     */
+    protected function parseQueue($queue)
+    {
+        [$connection, $queue] = array_pad(explode(':', $queue, 2), -2, null);
+
+        return [
+            $connection ?? config('queue.default'),
+            $queue ?: 'default',
+        ];
+    }
+}

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -7,10 +7,13 @@ use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Contracts\WorkloadRepository;
+use Laravel\Horizon\ParsesQueue;
 use Laravel\Horizon\WaitTimeCalculator;
 
 class RedisWorkloadRepository implements WorkloadRepository
 {
+    use ParsesQueue;
+
     /**
      * The queue factory implementation.
      *
@@ -71,7 +74,7 @@ class RedisWorkloadRepository implements WorkloadRepository
 
         return collect($this->waitTime->calculate())
             ->map(function ($waitTime, $queue) use ($processes) {
-                [$connection, $queueName] = explode(':', $queue, 2);
+                [$connection, $queueName] = $this->parseQueue($queue);
 
                 $totalProcesses = $processes[$queue] ?? 0;
 

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -9,6 +9,8 @@ use Laravel\Horizon\Contracts\SupervisorRepository;
 
 class WaitTimeCalculator
 {
+    use ParsesQueue;
+
     /**
      * The queue factory implementation.
      *
@@ -74,7 +76,7 @@ class WaitTimeCalculator
         return $queues->mapWithKeys(function ($queue) use ($supervisors) {
             $totalProcesses = $this->totalProcessesFor($supervisors, $queue);
 
-            [$connection, $queueName] = explode(':', $queue, 2);
+            [$connection, $queueName] = $this->parseQueue($queue);
 
             return [$queue => $this->calculateTimeToClear($connection, $queueName, $totalProcesses)];
         })


### PR DESCRIPTION
This PR introduces a small internal `ParsesQueue` trait for Horizon that mirrors Laravel’s queue parsing behavior without introducing a hard dependency on Laravel 12 (https://github.com/laravel/framework/pull/57863).

All internal `explode(':', ...)` usages related to queue parsing have been replaced with this method to ensure consistent and robust behavior, including safe handling of missing connection or queue names (falling back to `config('queue.default')` and `default`).