### PR TITLE
[5.x] Clarify `monitored` trim precedence over `completed`

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -108,6 +108,8 @@ return [
     | Here you can configure for how long (in minutes) you desire Horizon to
     | persist the recent and failed jobs. Typically, recent jobs are kept
     | for one hour while all failed jobs are stored for an entire week.
+    | For monitored jobs, the monitored trim value takes precedence
+    | over completed, regardless of the completed setting.
     |
     */
 


### PR DESCRIPTION
This PR clarifies that for `monitored` jobs, the `monitored` trim value takes precedence over `completed`.

Developers might not expect `monitored` jobs to affect the trimming of `completed` jobs; however, in practice, `monitored` jobs override `completed`.