### PR TITLE
Add `horizon:listen` command

### DIFF
--- a/bin/file-watcher.cjs
+++ b/bin/file-watcher.cjs
@@ -1,0 +1,53 @@
+const chokidar = require('chokidar');
+
+const paths = JSON.parse(process.argv[2]);
+const poll = process.argv[3] ? true : false;
+
+// Chokidar removed support for glob in version 4...
+const chokidarPackagePath = require.resolve('chokidar').replace('index.js', 'package.json');
+const chokidarVersion4 = require(chokidarPackagePath).version.startsWith('4.');
+
+const extractWildcardExtension = (path) => {
+    // Match patterns like *.php, **/*.blade.php
+    const match = path.match(/\/\*\.((\\w|\\.)+)$/);
+
+    return match ? match[1] : null;
+};
+
+const getPathBeforeWildcard = (path) => {
+    const match = path.match(/^(.*?)(\*|$)/);
+
+    return match ? match[1] : path;
+};
+
+const extractedPaths = paths.map(path => {
+    return { path: getPathBeforeWildcard(path), extension: extractWildcardExtension(path) };
+});
+
+const watcherPaths = chokidarVersion4 ? extractedPaths.map(ep => ep.path) : paths;
+
+const watcherIgnored = chokidarVersion4 ? (path, stats) => {
+    if (! stats?.isFile()) {
+        return false;
+    }
+
+    const matchedPattern = extractedPaths.find(ep => path.startsWith(ep.path));
+
+    if (! matchedPattern) {
+        return true;
+    }
+
+    return matchedPattern.extension ? ! path.endsWith(`.${matchedPattern.extension}`) : false;
+} : undefined;
+
+const watcher = chokidar.watch(watcherPaths, {
+    ignoreInitial: true,
+    usePolling: poll,
+    ignored: watcherIgnored,
+});
+
+watcher
+    .on('add', () => console.log('File added...'))
+    .on('change', () => console.log('File changed...'))
+    .on('unlink', () => console.log('File deleted...'))
+    .on('unlinkDir', () => console.log('Directory deleted...'));

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -227,4 +227,28 @@ return [
             ],
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Watcher Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The following list of directories and files will be watched when using
+    | the `horizon:listen` command. Whenever any directories or files are
+    | changed, Horizon will automatically restart to apply all changes.
+    |
+    */
+
+    'watch' => [
+        'app',
+        'bootstrap',
+        'config/**/*.php',
+        'database/**/*.php',
+        'public/**/*.php',
+        'resources/**/*.php',
+        'routes',
+        'composer.lock',
+        'composer.json',
+        '.env',
+    ],
 ];

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -25,7 +25,7 @@ class ListenCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Listen for file changes and restart Horizon';
+    protected $description = 'Run Horizon and automatically restart workers on file changes';
 
     /**
      * The Horizon process instance.
@@ -81,7 +81,7 @@ class ListenCommand extends Command
     {
         if (empty($paths = config('horizon.watch'))) {
             throw new InvalidArgumentException(
-                'List of directories/files to watch not found. Please update your "config/horizon.php" configuration file.',
+                'List of directories / files to watch not found. Please update your "config/horizon.php" configuration file.',
             );
         }
 
@@ -162,7 +162,7 @@ class ListenCommand extends Command
      */
     protected function restartHorizon()
     {
-        $this->components->info('Change detected! Restarting Horizon...');
+        $this->components->info('File changed. Restarting Horizon...');
 
         $this->horizonProcess->stop();
         $this->horizonProcess->wait();

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Laravel\Horizon\Console;
+
+use Illuminate\Console\Command;
+use InvalidArgumentException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
+
+#[AsCommand(name: 'horizon:listen')]
+class ListenCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'horizon:listen
+        {--environment= : The environment name}
+        {--poll : Use polling for file watching}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Listen for file changes and restart Horizon';
+
+    /**
+     * The Horizon process instance.
+     *
+     * @var \Symfony\Component\Process\Process|null
+     */
+    protected $horizonProcess;
+
+    /**
+     * The file watcher process instance.
+     *
+     * @var \Symfony\Component\Process\Process|null
+     */
+    protected $watcherProcess;
+
+    /**
+     * Indicates if a termination signal has been received.
+     *
+     * @var int|null
+     */
+    protected $trappedSignal = null;
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->components->info('Starting Horizon and watching for file changes...');
+
+        $this->watcherProcess = $this->startWatcher();
+
+        if ($this->watcherProcess->isTerminated()) {
+            return $this->watcherFailed();
+        }
+
+        if (! $this->startHorizon()) {
+            return Command::FAILURE;
+        }
+
+        $this->listenForChanges();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Start the file watcher process.
+     *
+     * @return \Symfony\Component\Process\Process
+     */
+    protected function startWatcher()
+    {
+        if (empty($paths = config('horizon.watch'))) {
+            throw new InvalidArgumentException(
+                'List of directories/files to watch not found. Please update your "config/horizon.php" configuration file.',
+            );
+        }
+
+        $process = new Process([
+            (new ExecutableFinder)->find('node'),
+            'file-watcher.cjs',
+            json_encode(collect($paths)->map(fn ($path) => base_path($path))->values()->all()),
+            $this->option('poll') ? '1' : '',
+        ], __DIR__.'/../../bin', ['NODE_PATH' => base_path('node_modules')], null, null);
+
+        $process->start();
+
+        sleep(1);
+
+        return $process;
+    }
+
+    /**
+     * Start the Horizon process.
+     *
+     * @return bool
+     */
+    protected function startHorizon()
+    {
+        $command = 'php artisan horizon';
+
+        if ($environment = $this->option('environment')) {
+            $command .= ' --environment='.$environment;
+        }
+
+        $this->horizonProcess = Process::fromShellCommandline($command)
+            ->setTimeout(null);
+
+        $this->trap([SIGINT, SIGTERM, SIGQUIT], function ($signal) {
+            $this->trappedSignal = $signal;
+
+            $this->horizonProcess->stop(signal: $signal);
+            $this->horizonProcess->wait();
+
+            if ($this->watcherProcess) {
+                $this->watcherProcess->stop();
+            }
+        });
+
+        $this->horizonProcess->start();
+
+        usleep(100000);
+
+        return ! $this->horizonProcess->isTerminated();
+    }
+
+    /**
+     * Listen for file changes and restart Horizon when detected.
+     *
+     * @return void
+     */
+    protected function listenForChanges()
+    {
+        while (! $this->trappedSignal) {
+            if ($this->watcherProcess->getIncrementalOutput()) {
+                $this->restartHorizon();
+            }
+
+            $this->output->write($this->horizonProcess->getIncrementalOutput());
+
+            if (! $this->horizonProcess->isRunning()) {
+                break;
+            }
+
+            usleep(500000);
+        }
+    }
+
+    /**
+     * Restart the Horizon process.
+     *
+     * @return void
+     */
+    protected function restartHorizon()
+    {
+        $this->components->info('Change detected! Restarting Horizon...');
+
+        $this->horizonProcess->stop();
+        $this->horizonProcess->wait();
+
+        $this->startHorizon();
+    }
+
+    /**
+     * Handle watcher process failure.
+     *
+     * @return int
+     */
+    protected function watcherFailed()
+    {
+        $this->components->error(
+            'Unable to start file watcher. Please ensure Node.js and the chokidar npm package are installed.',
+        );
+
+        $this->output->writeln($this->watcherProcess->getErrorOutput());
+
+        return Command::FAILURE;
+    }
+}

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -122,6 +122,7 @@ class HorizonServiceProvider extends ServiceProvider
                 Console\HorizonCommand::class,
                 Console\InstallCommand::class,
                 Console\ListCommand::class,
+                Console\ListenCommand::class,
                 Console\PauseCommand::class,
                 Console\PauseSupervisorCommand::class,
                 Console\PublishCommand::class,

--- a/tests/Feature/ListenCommandTest.php
+++ b/tests/Feature/ListenCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use InvalidArgumentException;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class ListenCommandTest extends IntegrationTest
+{
+    public function test_listen_command_requires_watch_configuration()
+    {
+        config(['horizon.watch' => []]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('List of directories/files to watch not found.');
+
+        $this->artisan('horizon:listen');
+    }
+
+    public function test_listen_command_requires_watch_configuration_to_be_set()
+    {
+        config(['horizon.watch' => null]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('List of directories/files to watch not found.');
+
+        $this->artisan('horizon:listen');
+    }
+
+    public function test_listen_command_requires_watch_configuration_key_to_exist()
+    {
+        $config = config('horizon');
+        unset($config['watch']);
+        config(['horizon' => $config]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('List of directories/files to watch not found.');
+
+        $this->artisan('horizon:listen');
+    }
+
+    public function test_listen_command_fails_gracefully_when_node_is_not_available()
+    {
+        config(['horizon.watch' => ['app', 'config']]);
+
+        // Mock the ExecutableFinder to return null (node not found)
+        $this->mock(\Symfony\Component\Process\ExecutableFinder::class, function ($mock) {
+            $mock->shouldReceive('find')->with('node')->andReturn(null);
+        });
+
+        $this->artisan('horizon:listen')
+            ->expectsOutputToContain('Unable to start file watcher')
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Feature/ListenCommandTest.php
+++ b/tests/Feature/ListenCommandTest.php
@@ -12,7 +12,7 @@ class ListenCommandTest extends IntegrationTest
         config(['horizon.watch' => []]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('List of directories/files to watch not found.');
+        $this->expectExceptionMessage('List of directories / files to watch not found.');
 
         $this->artisan('horizon:listen');
     }
@@ -22,7 +22,7 @@ class ListenCommandTest extends IntegrationTest
         config(['horizon.watch' => null]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('List of directories/files to watch not found.');
+        $this->expectExceptionMessage('List of directories / files to watch not found.');
 
         $this->artisan('horizon:listen');
     }
@@ -34,7 +34,7 @@ class ListenCommandTest extends IntegrationTest
         config(['horizon' => $config]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('List of directories/files to watch not found.');
+        $this->expectExceptionMessage('List of directories / files to watch not found.');
 
         $this->artisan('horizon:listen');
     }

--- a/tests/Feature/ListenCommandTest.php
+++ b/tests/Feature/ListenCommandTest.php
@@ -39,17 +39,4 @@ class ListenCommandTest extends IntegrationTest
         $this->artisan('horizon:listen');
     }
 
-    public function test_listen_command_fails_gracefully_when_node_is_not_available()
-    {
-        config(['horizon.watch' => ['app', 'config']]);
-
-        // Mock the ExecutableFinder to return null (node not found)
-        $this->mock(\Symfony\Component\Process\ExecutableFinder::class, function ($mock) {
-            $mock->shouldReceive('find')->with('node')->andReturn(null);
-        });
-
-        $this->artisan('horizon:listen')
-            ->expectsOutputToContain('Unable to start file watcher')
-            ->assertExitCode(1);
-    }
 }

--- a/tests/Feature/ListenCommandTest.php
+++ b/tests/Feature/ListenCommandTest.php
@@ -38,5 +38,4 @@ class ListenCommandTest extends IntegrationTest
 
         $this->artisan('horizon:listen');
     }
-
 }


### PR DESCRIPTION
Introduces a new `horizon:listen` command that watches for file changes and automatically restarts Horizon during development. This mirrors Laravel's built-in `queue:listen` command behavior.

Implementation based on `spatie/laravel-horizon-watcher` and Laravel Octane's file watching approach using Node.js and chokidar.

Usage:
```
npm install --save-dev chokidar
php artisan horizon:listen
php artisan horizon:listen --poll  # For Docker/Vagrant
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
