### PR TITLE
[5.x] Refactor: remove `@return void` from `__construct()`

### DIFF
--- a/src/Console/PurgeCommand.php
+++ b/src/Console/PurgeCommand.php
@@ -50,7 +50,6 @@ class PurgeCommand extends Command
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
      * @param  \Laravel\Horizon\Contracts\ProcessRepository  $processes
      * @param  \Laravel\Horizon\ProcessInspector  $inspector
-     * @return void
      */
     public function __construct(
         SupervisorRepository $supervisors,

--- a/src/Events/JobDeleted.php
+++ b/src/Events/JobDeleted.php
@@ -16,7 +16,6 @@ class JobDeleted extends RedisEvent
      *
      * @param  \Illuminate\Queue\Jobs\Job  $job
      * @param  string  $payload
-     * @return void
      */
     public function __construct($job, $payload)
     {

--- a/src/Events/JobFailed.php
+++ b/src/Events/JobFailed.php
@@ -24,7 +24,6 @@ class JobFailed extends RedisEvent
      * @param  \Exception  $exception
      * @param  \Illuminate\Queue\Jobs\Job  $job
      * @param  string  $payload
-     * @return void
      */
     public function __construct($exception, $job, $payload)
     {

--- a/src/Events/JobsMigrated.php
+++ b/src/Events/JobsMigrated.php
@@ -31,7 +31,6 @@ class JobsMigrated
      * Create a new event instance.
      *
      * @param  array  $payloads
-     * @return void
      */
     public function __construct($payloads)
     {

--- a/src/Events/LongWaitDetected.php
+++ b/src/Events/LongWaitDetected.php
@@ -34,7 +34,6 @@ class LongWaitDetected
      * @param  string  $connection
      * @param  string  $queue
      * @param  int  $seconds
-     * @return void
      */
     public function __construct($connection, $queue, $seconds)
     {

--- a/src/Events/MasterSupervisorDeployed.php
+++ b/src/Events/MasterSupervisorDeployed.php
@@ -15,7 +15,6 @@ class MasterSupervisorDeployed
      * Create a new event instance.
      *
      * @param  string  $master
-     * @return void
      */
     public function __construct($master)
     {

--- a/src/Events/MasterSupervisorLooped.php
+++ b/src/Events/MasterSupervisorLooped.php
@@ -17,7 +17,6 @@ class MasterSupervisorLooped
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\MasterSupervisor  $master
-     * @return void
      */
     public function __construct(MasterSupervisor $master)
     {

--- a/src/Events/MasterSupervisorOutOfMemory.php
+++ b/src/Events/MasterSupervisorOutOfMemory.php
@@ -17,7 +17,6 @@ class MasterSupervisorOutOfMemory
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\MasterSupervisor  $master
-     * @return void
      */
     public function __construct(MasterSupervisor $master)
     {

--- a/src/Events/MasterSupervisorReviving.php
+++ b/src/Events/MasterSupervisorReviving.php
@@ -15,7 +15,6 @@ class MasterSupervisorReviving
      * Create a new event instance.
      *
      * @param  string  $master
-     * @return void
      */
     public function __construct($master)
     {

--- a/src/Events/RedisEvent.php
+++ b/src/Events/RedisEvent.php
@@ -31,7 +31,6 @@ class RedisEvent
      * Create a new event instance.
      *
      * @param  string  $payload
-     * @return void
      */
     public function __construct($payload)
     {

--- a/src/Events/SupervisorLooped.php
+++ b/src/Events/SupervisorLooped.php
@@ -17,7 +17,6 @@ class SupervisorLooped
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\Supervisor  $supervisor
-     * @return void
      */
     public function __construct(Supervisor $supervisor)
     {

--- a/src/Events/SupervisorOutOfMemory.php
+++ b/src/Events/SupervisorOutOfMemory.php
@@ -24,7 +24,6 @@ class SupervisorOutOfMemory
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\Supervisor  $supervisor
-     * @return void
      */
     public function __construct(Supervisor $supervisor)
     {

--- a/src/Events/SupervisorProcessRestarting.php
+++ b/src/Events/SupervisorProcessRestarting.php
@@ -17,7 +17,6 @@ class SupervisorProcessRestarting
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\SupervisorProcess  $process
-     * @return void
      */
     public function __construct(SupervisorProcess $process)
     {

--- a/src/Events/UnableToLaunchProcess.php
+++ b/src/Events/UnableToLaunchProcess.php
@@ -17,7 +17,6 @@ class UnableToLaunchProcess
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\WorkerProcess  $process
-     * @return void
      */
     public function __construct(WorkerProcess $process)
     {

--- a/src/Events/WorkerProcessRestarting.php
+++ b/src/Events/WorkerProcessRestarting.php
@@ -17,7 +17,6 @@ class WorkerProcessRestarting
      * Create a new event instance.
      *
      * @param  \Laravel\Horizon\WorkerProcess  $process
-     * @return void
      */
     public function __construct(WorkerProcess $process)
     {

--- a/src/Http/Controllers/BatchesController.php
+++ b/src/Http/Controllers/BatchesController.php
@@ -21,7 +21,6 @@ class BatchesController extends Controller
      * Create a new controller instance.
      *
      * @param  \Illuminate\Bus\BatchRepository  $batches
-     * @return void
      */
     public function __construct(BatchRepository $batches)
     {

--- a/src/Http/Controllers/CompletedJobsController.php
+++ b/src/Http/Controllers/CompletedJobsController.php
@@ -18,7 +18,6 @@ class CompletedJobsController extends Controller
      * Create a new controller instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -9,8 +9,6 @@ class Controller extends BaseController
 {
     /**
      * Create a new controller instance.
-     *
-     * @return void
      */
     public function __construct()
     {

--- a/src/Http/Controllers/FailedJobsController.php
+++ b/src/Http/Controllers/FailedJobsController.php
@@ -27,7 +27,6 @@ class FailedJobsController extends Controller
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
      * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
-     * @return void
      */
     public function __construct(JobRepository $jobs, TagRepository $tags)
     {

--- a/src/Http/Controllers/JobMetricsController.php
+++ b/src/Http/Controllers/JobMetricsController.php
@@ -17,7 +17,6 @@ class JobMetricsController extends Controller
      * Create a new controller instance.
      *
      * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
-     * @return void
      */
     public function __construct(MetricsRepository $metrics)
     {

--- a/src/Http/Controllers/JobsController.php
+++ b/src/Http/Controllers/JobsController.php
@@ -17,7 +17,6 @@ class JobsController extends Controller
      * Create a new controller instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Http/Controllers/MonitoringController.php
+++ b/src/Http/Controllers/MonitoringController.php
@@ -29,7 +29,6 @@ class MonitoringController extends Controller
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
      * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
-     * @return void
      */
     public function __construct(JobRepository $jobs, TagRepository $tags)
     {

--- a/src/Http/Controllers/PendingJobsController.php
+++ b/src/Http/Controllers/PendingJobsController.php
@@ -18,7 +18,6 @@ class PendingJobsController extends Controller
      * Create a new controller instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Http/Controllers/QueueMetricsController.php
+++ b/src/Http/Controllers/QueueMetricsController.php
@@ -17,7 +17,6 @@ class QueueMetricsController extends Controller
      * Create a new controller instance.
      *
      * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
-     * @return void
      */
     public function __construct(MetricsRepository $metrics)
     {

--- a/src/Http/Controllers/SilencedJobsController.php
+++ b/src/Http/Controllers/SilencedJobsController.php
@@ -18,7 +18,6 @@ class SilencedJobsController extends Controller
      * Create a new controller instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Jobs/MonitorTag.php
+++ b/src/Jobs/MonitorTag.php
@@ -10,7 +10,6 @@ class MonitorTag
      * Create a new job instance.
      *
      * @param  string  $tag  The tag to monitor.
-     * @return void
      */
     public function __construct(
         public $tag,

--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -13,7 +13,6 @@ class RetryFailedJob
      * Create a new job instance.
      *
      * @param  string  $id  The job ID.
-     * @return void
      */
     public function __construct(
         public $id,

--- a/src/Jobs/StopMonitoringTag.php
+++ b/src/Jobs/StopMonitoringTag.php
@@ -11,7 +11,6 @@ class StopMonitoringTag
      * Create a new job instance.
      *
      * @param  string  $tag  The tag to stop monitoring.
-     * @return void
      */
     public function __construct(
         public $tag,

--- a/src/Listeners/ForgetJobTimer.php
+++ b/src/Listeners/ForgetJobTimer.php
@@ -17,7 +17,6 @@ class ForgetJobTimer
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Stopwatch  $watch
-     * @return void
      */
     public function __construct(Stopwatch $watch)
     {

--- a/src/Listeners/MarkJobAsComplete.php
+++ b/src/Listeners/MarkJobAsComplete.php
@@ -27,7 +27,6 @@ class MarkJobAsComplete
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
      * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
-     * @return void
      */
     public function __construct(JobRepository $jobs, TagRepository $tags)
     {

--- a/src/Listeners/MarkJobAsFailed.php
+++ b/src/Listeners/MarkJobAsFailed.php
@@ -18,7 +18,6 @@ class MarkJobAsFailed
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Listeners/MarkJobAsReleased.php
+++ b/src/Listeners/MarkJobAsReleased.php
@@ -18,7 +18,6 @@ class MarkJobAsReleased
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Listeners/MarkJobAsReserved.php
+++ b/src/Listeners/MarkJobAsReserved.php
@@ -18,7 +18,6 @@ class MarkJobAsReserved
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Listeners/MarkJobsAsMigrated.php
+++ b/src/Listeners/MarkJobsAsMigrated.php
@@ -18,7 +18,6 @@ class MarkJobsAsMigrated
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Listeners/MarshalFailedEvent.php
+++ b/src/Listeners/MarshalFailedEvent.php
@@ -20,7 +20,6 @@ class MarshalFailedEvent
      * Create a new listener instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     * @return void
      */
     public function __construct(Dispatcher $events)
     {

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -27,7 +27,6 @@ class MonitorWaitTimes
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
-     * @return void
      */
     public function __construct(MetricsRepository $metrics)
     {

--- a/src/Listeners/StartTimingJob.php
+++ b/src/Listeners/StartTimingJob.php
@@ -18,7 +18,6 @@ class StartTimingJob
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Stopwatch  $watch
-     * @return void
      */
     public function __construct(Stopwatch $watch)
     {

--- a/src/Listeners/StoreJob.php
+++ b/src/Listeners/StoreJob.php
@@ -18,7 +18,6 @@ class StoreJob
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\JobRepository  $jobs
-     * @return void
      */
     public function __construct(JobRepository $jobs)
     {

--- a/src/Listeners/StoreMonitoredTags.php
+++ b/src/Listeners/StoreMonitoredTags.php
@@ -18,7 +18,6 @@ class StoreMonitoredTags
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
-     * @return void
      */
     public function __construct(TagRepository $tags)
     {

--- a/src/Listeners/StoreTagsForFailedJob.php
+++ b/src/Listeners/StoreTagsForFailedJob.php
@@ -18,7 +18,6 @@ class StoreTagsForFailedJob
      * Create a new listener instance.
      *
      * @param  \Laravel\Horizon\Contracts\TagRepository  $tags
-     * @return void
      */
     public function __construct(TagRepository $tags)
     {

--- a/src/Listeners/UpdateJobMetrics.php
+++ b/src/Listeners/UpdateJobMetrics.php
@@ -27,7 +27,6 @@ class UpdateJobMetrics
      *
      * @param  \Laravel\Horizon\Contracts\MetricsRepository  $metrics
      * @param  \Laravel\Horizon\Stopwatch  $watch
-     * @return void
      */
     public function __construct(MetricsRepository $metrics, Stopwatch $watch)
     {

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -44,7 +44,6 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
      * @param  string  $connection
      * @param  string  $queue
      * @param  int  $seconds
-     * @return void
      */
     public function __construct($connection, $queue, $seconds)
     {

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -76,7 +76,6 @@ class RedisJobRepository implements JobRepository
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RedisFactory $redis)
     {

--- a/src/Repositories/RedisMasterSupervisorRepository.php
+++ b/src/Repositories/RedisMasterSupervisorRepository.php
@@ -22,7 +22,6 @@ class RedisMasterSupervisorRepository implements MasterSupervisorRepository
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RedisFactory $redis)
     {

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -23,7 +23,6 @@ class RedisMetricsRepository implements MetricsRepository
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RedisFactory $redis)
     {

--- a/src/Repositories/RedisProcessRepository.php
+++ b/src/Repositories/RedisProcessRepository.php
@@ -19,7 +19,6 @@ class RedisProcessRepository implements ProcessRepository
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RedisFactory $redis)
     {

--- a/src/Repositories/RedisSupervisorRepository.php
+++ b/src/Repositories/RedisSupervisorRepository.php
@@ -21,7 +21,6 @@ class RedisSupervisorRepository implements SupervisorRepository
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RedisFactory $redis)
     {

--- a/src/Repositories/RedisTagRepository.php
+++ b/src/Repositories/RedisTagRepository.php
@@ -18,7 +18,6 @@ class RedisTagRepository implements TagRepository
      * Create a new repository instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
-     * @return void
      */
     public function __construct(RedisFactory $redis)
     {

--- a/src/Repositories/RedisWorkloadRepository.php
+++ b/src/Repositories/RedisWorkloadRepository.php
@@ -46,7 +46,6 @@ class RedisWorkloadRepository implements WorkloadRepository
      * @param  \Laravel\Horizon\WaitTimeCalculator  $waitTime
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @param  \Laravel\Horizon\Contracts\SupervisorRepository  $supervisors
-     * @return void
      */
     public function __construct(
         QueueFactory $queue,


### PR DESCRIPTION
This PR removes unnecessary `@return void` annotations from `__construct` method docblocks throughout the codebase. Constructors in PHP cannot return any value. Adding `@return void` to constructor docblocks is redundant and provides no additional type information.