### PR TITLE
[5.x] Specify npm package name

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -178,7 +178,7 @@ class ListenCommand extends Command
     protected function watcherFailed()
     {
         $this->components->error(
-            'Unable to start file watcher. Please ensure Node.js and the chokidar npm package are installed.',
+            'Unable to start file watcher. Please ensure Node.js and the paulmillr/chokidar npm package are installed.',
         );
 
         $this->output->writeln($this->watcherProcess->getErrorOutput());


### PR DESCRIPTION
Updates the file watcher error message to reference `paulmillr/chokidar` instead of just `chokidar` for clarity. This helps users install the correct package using npm.
