### PR TITLE
[5.x] Add Node.js executable validation before starting file watcher

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -89,7 +89,7 @@ class ListenCommand extends Command
 
         if (! $nodeExecutable) {
             throw new InvalidArgumentException(
-                'Node.js could not be found. Please ensure Node.js is installed and available in your system PATH.',
+                'Node could not be found. Please ensure Node is installed and available in your system PATH.',
             );
         }
 

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -85,8 +85,16 @@ class ListenCommand extends Command
             );
         }
 
+        $nodeExecutable = (new ExecutableFinder)->find('node');
+
+        if (! $nodeExecutable) {
+            throw new InvalidArgumentException(
+                'Node.js could not be found. Please ensure Node.js is installed and available in your system PATH.',
+            );
+        }
+
         $process = new Process([
-            (new ExecutableFinder)->find('node'),
+            $nodeExecutable,
             'file-watcher.cjs',
             json_encode(collect($paths)->map(fn ($path) => base_path($path))->values()->all()),
             $this->option('poll') ? '1' : '',


### PR DESCRIPTION
Fixes https://github.com/laravel/horizon/issues/1694

Validates that Node.js is installed and available in PATH before starting Horizon's file watcher.
