### PR TITLE
[5.x] Fix incorrect `@return` tag in Supervisor property docblock

### DIFF
--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -22,7 +22,7 @@ class Supervisor implements Pausable, Restartable, Terminable
     /**
      * The name of this supervisor instance.
      *
-     * @return string
+     * @var string
      */
     public $name;
 


### PR DESCRIPTION
Fixes an incorrect PHPDoc tag on the `Supervisor::$name` property to align with PHPDoc standards and improve static analysis accuracy.

**Before:**
```php
/**
 * The name of this supervisor instance.
 *
 * @return string
 */
public $name;
```

**After:**
```php
/**
 * The name of this supervisor instance.
 *
 * @var string
 */
public $name;
```
The `@return` tag is only valid for methods, while properties should use `@var`. 
This is a documentation-only change with no impact on functionality.