### PR TITLE
[5.x] Guard `RedisStore::scan()` results against boolean failures

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -396,9 +396,15 @@ class RedisMetricsRepository implements MetricsRepository
             $cursor = null;
 
             do {
-                [$cursor, $keys] = $this->connection()->scan(
+                $scanResult = $this->connection()->scan(
                     $cursor ?? 0, ['match' => config('horizon.prefix').$pattern]
                 );
+
+                if (! is_array($scanResult)) {
+                    break;
+                }
+
+                [$cursor, $keys] = $scanResult;
 
                 foreach ($keys ?? [] as $key) {
                     $this->forget(Str::after($key, config('horizon.prefix')));


### PR DESCRIPTION
Fixes #1690

Guard the `scan()` unpacks so PHP 8.5 can no longer blow up when Redis returns false.

This is consistent with the fix applied in https://github.com/laravel/framework/pull/57911.