### PR TITLE
[5.x] Fail fast when Redis is not installed

### DIFF
--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -36,7 +36,7 @@ class HorizonCommand extends Command
         $client = config('database.redis.client');
 
         if ($client === 'phpredis' && ! extension_loaded('redis')) {
-            return $this->components->error('PHP Redis extension is not installed.');
+            return $this->components->error('The PHP Redis extension is not installed.');
         }
 
         if ($client === 'predis' && ! class_exists(\Predis\Client::class)) {

--- a/src/Console/HorizonCommand.php
+++ b/src/Console/HorizonCommand.php
@@ -33,6 +33,16 @@ class HorizonCommand extends Command
      */
     public function handle(MasterSupervisorRepository $masters)
     {
+        $client = config('database.redis.client');
+
+        if ($client === 'phpredis' && ! extension_loaded('redis')) {
+            return $this->components->error('PHP Redis extension is not installed.');
+        }
+
+        if ($client === 'predis' && ! class_exists(\Predis\Client::class)) {
+            return $this->components->error('Predis client is not installed. Run: composer require predis/predis');
+        }
+
         if ($masters->find(MasterSupervisor::name())) {
             return $this->components->warn('A master supervisor is already running on this machine.');
         }


### PR DESCRIPTION
This PR adds a fail-fast check to the `php artisan horizon` console command to ensure Redis is properly installed and reachable before starting the master supervisor.

Currently, if Redis is not installed (e.g. missing `ext-redis`) or misconfigured, Horizon may start but eventually fail with a runtime error such as:

```bash
Class "Redis" not found
```

This can be confusing and is usually only discovered later via browser inspection or logs.

With this change, Horizon will immediately exit with a clear and actionable error message if Redis is not usable.