### PR TITLE
[5.x] Mark `horizon:publish` command as deprecated

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -5,6 +5,9 @@ namespace Laravel\Horizon\Console;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+/**
+ * @deprecated This command no longer publishes Horizon assets.
+ */
 #[AsCommand(name: 'horizon:publish')]
 class PublishCommand extends Command
 {


### PR DESCRIPTION
This PR marks the `horizon:publish` command as deprecated because Horizon no longer publishes assets and this command is no longer needed.
