### PR TITLE
[5.x] Add `Horizon::name()` method

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -7,7 +7,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="shortcut icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAipJREFUeNrEV8txwjAQtQ2HHCmB3JKbSQOYCoA0gD0pgFBBwpEToQAGKmDglpwgFdg5kZtNB1BBsuusZ4RY2ZZjYGd2jGWh97Q/rUwjpziPT3V4dECboDZoXZoSka5Al5vFNMqzrpkD2IFHn8B1ZAM6BCKbQgQAuAaPWQFgjoinsoipAEcTr0FrRjmyJxLLTAI5wXFXAehBGMPYcDKIIIm5kkAGOJpwAjqHRfYpbkOXvTBBypIwpT+HCvA3Cqi9Rta8EhHOHS1YCy1oWMKHmQIcGQ90wGMfLaZIoEGAoiDGOHmxhFTr5PGZJgncZYszEGC6ogX6nNn/Ay6RGDCfYveYVOFCJuAaumbPiIk1kyUNS2H6SZngyZrMWM+i/JVlXjK4QUVI3pRTpYPlaG6yeyGvm0Jef1ItiArwQBKu8G5bTMEIhKLkU3q65D+HgieE7+MCBHbygMVMOlCK+CnVDOUZ5s00ghCt2T45C+DDD2MBW/O066YFLYGvuXU5C9i6GYaLUzqr+olQtS5aIMwwtW6QfQnv7awNVanolEWgo9nABBb1cNeSmMDyigRWZkqdPrdEkDm3SRYMr7D7odwRXdIK8e7lOuAxh8W5pHtSiOhw8S4A7iX9IErlyC5b/7t+/7Ar4TKiEuyyRuJA5cQ5Wz8gEhgPNyXvfCQPVtgI+SPxAT/vSqiSEbXh70Uvp27GRSMNeJjV2Jp5V6MGpUeuUR0wAemKuwdy8ivAAJcc0R2NFxWtAAAAAElFTkSuQmCC">
 
-    <title>Horizon{{ config('horizon.name') ? ' - ' . config('horizon.name') : '' }}</title>
+    <title>Horizon{{ Laravel\Horizon\Horizon::name() ? ' - ' . Laravel\Horizon\Horizon::name() : '' }}</title>
 
     <!-- Style sheets-->
     <link rel="preconnect" href="https://fonts.bunny.net">
@@ -32,7 +32,7 @@
                 </svg>
 
                 <h1 class="h4 mb-0 ms-2">
-                    <strong>Laravel</strong> Horizon{{ config('horizon.name') ? ' - ' . config('horizon.name') : '' }}
+                    <strong>Laravel</strong> Horizon{{ Laravel\Horizon\Horizon::name() ? ' - ' . Laravel\Horizon\Horizon::name() : '' }}
                 </h1>
             </router-link>
 

--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -65,6 +65,16 @@ class Horizon
     ];
 
     /**
+     * Get the current Horizon instance name.
+     *
+     * @return string|null
+     */
+    public static function name(): ?string
+    {
+        return config('horizon.name');
+    }
+
+    /**
      * Determine if the given request can access the Horizon dashboard.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Notifications/LongWaitDetected.php
+++ b/src/Notifications/LongWaitDetected.php
@@ -78,7 +78,7 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
     {
         return (new MailMessage)
             ->error()
-            ->subject(config('horizon.name').': Long Queue Wait Detected')
+            ->subject(Horizon::name().': Long Queue Wait Detected')
             ->greeting('Oh no! Something needs your attention.')
             ->line(sprintf(
                 'The "%s" queue on the "%s" connection has a wait time of %s seconds.',
@@ -101,7 +101,7 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
 
         $content = sprintf(
             '[%s] The "%s" queue on the "%s" connection has a wait time of %s seconds.',
-            config('horizon.name'),
+            Horizon::name(),
             $this->longWaitQueue,
             $this->longWaitConnection,
             $this->seconds
@@ -142,7 +142,7 @@ class LongWaitDetected extends Notification implements LongWaitDetectedNotificat
     {
         return (new NexmoMessage)->content(sprintf( // @phpstan-ignore-line
             '[%s] The "%s" queue on the "%s" connection has a wait time of %s seconds.',
-            config('horizon.name'), $this->longWaitQueue, $this->longWaitConnection, $this->seconds
+            Horizon::name(), $this->longWaitQueue, $this->longWaitConnection, $this->seconds
         ));
     }
 

--- a/tests/Feature/HorizonNameTest.php
+++ b/tests/Feature/HorizonNameTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Laravel\Horizon\Horizon;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class HorizonNameTest extends IntegrationTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('horizon.name', null);
+    }
+
+    public function test_it_returns_the_horizon_name_from_config()
+    {
+        config()->set('horizon.name', 'my-horizon');
+
+        $this->assertSame('my-horizon', Horizon::name());
+    }
+
+    public function test_it_returns_null_if_horizon_name_not_set()
+    {
+        config()->set('horizon.name', null);
+
+        $this->assertNull(Horizon::name());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `Horizon::name()` method to retrieve the configured Horizon instance name from config.

## Motivation

Provides a convenient way to programmatically access the Horizon instance name for:
- Custom monitoring dashboards
- Multi-instance deployments
- Logging and metrics that need instance identification