### PR TITLE
Fix wildcard pattern matching in file watcher

### DIFF
--- a/bin/file-watcher.cjs
+++ b/bin/file-watcher.cjs
@@ -9,7 +9,7 @@ const chokidarVersion4 = require(chokidarPackagePath).version.startsWith('4.');
 
 const extractWildcardExtension = (path) => {
     // Match patterns like *.php, **/*.blade.php
-    const match = path.match(/\/\*\.((\\w|\\.)+)$/);
+    const match = path.match(/\/\*\.((\w|\.)+)$/);
 
     return match ? match[1] : null;
 };


### PR DESCRIPTION
In https://github.com/laravel/horizon/pull/1689 a new command was introduced to watch for file changes based on the patterns defined in `config('horizon.watch')`.                                                                        
                                                                                                                        
## Problem      
                                                                                                                      
Wildcard patterns don't work correctly. For example, the pattern `'resources/**/*.php'` should only match `.php` files
 in the `resources` directory. However, when a `.js` file is changed, the file watcher is also triggered.

## Cause

Comparing the implementation with [Octane's file watcher](https://github.com/laravel/octane/blob/2.x/bin/file-watcher.cjs) revealed that the regex conversion for glob patterns differs, causing the wildcard matching to be too permissive.

## Fix

This PR aligns the glob-to-regex conversion with Octane's implementation so that wildcard patterns filter files correctly.