### PR TITLE
[5.x] Add support for batch searching

### DIFF
--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -38,6 +38,7 @@
                 this.searchTimeout = setTimeout(() => {
                     this.page = 1;
                     this.previousFirstId = null;
+
                     this.loadBatches();
                     this.updateQueryParams();
                 }, 500);
@@ -154,10 +155,10 @@
             updateQueryParams(beforeId) {
                 var query = {};
 
+                if (this.searchQuery) query.query = this.searchQuery;
                 if (this.page > 1) query.page = this.page;
                 if (beforeId) query.before_id = beforeId;
                 if (this.previousFirstId && this.page > 1) query.previous_first_id = this.previousFirstId;
-                if (this.searchQuery) query.query = this.searchQuery;
 
                 this.$router.replace({ query }).catch(() => {});
             },

--- a/resources/js/screens/batches/index.vue
+++ b/resources/js/screens/batches/index.vue
@@ -8,9 +8,11 @@
                 ready: false,
                 loadingNewEntries: false,
                 hasNewEntries: false,
-                page: 1,
-                previousFirstId: null,
+                page: parseInt(this.$route.query.page) || 1,
+                previousFirstId: this.$route.query.previous_first_id || null,
                 batches: [],
+                searchQuery: this.$route.query.query || '',
+                searchTimeout: null,
             };
         },
 
@@ -19,6 +21,8 @@
          */
         mounted() {
             document.title = "Horizon - Batches";
+
+            this.loadBatches(this.$route.query.before_id || '');
         },
 
 
@@ -26,10 +30,17 @@
          * Watch these properties for changes.
          */
         watch: {
-            '$route'() {
-                this.page = 1;
+            searchQuery(newVal, oldVal) {
+                if (!oldVal) return;
 
-                this.loadBatches();
+                clearTimeout(this.searchTimeout);
+
+                this.searchTimeout = setTimeout(() => {
+                    this.page = 1;
+                    this.previousFirstId = null;
+                    this.loadBatches();
+                    this.updateQueryParams();
+                }, 500);
             },
 
             '$root.autoLoadsNewEntries'(autoLoadsNewEntries) {
@@ -49,7 +60,9 @@
                     this.ready = false;
                 }
 
-                this.$http.get(Horizon.basePath + '/api/batches?before_id=' + beforeId)
+                var searchQuery = this.searchQuery ? 'query=' + encodeURIComponent(this.searchQuery) + '&' : '';
+
+                this.$http.get(Horizon.basePath + '/api/batches?' + searchQuery + 'before_id=' + beforeId)
                     .then(response => {
                         if (!this.$root.autoLoadsNewEntries && refreshing && !response.data.batches.length) {
                             this.ready = true;
@@ -70,9 +83,14 @@
             loadNewEntries() {
                 this.batches = [];
 
-                this.loadBatches(0, false);
+                this.page = 1;
+                this.previousFirstId = null;
+
+                this.loadBatches('', false);
 
                 this.hasNewEntries = false;
+
+                this.updateQueryParams();
             },
 
 
@@ -82,6 +100,8 @@
             refreshBatchesPeriodically() {
                 if (this.page != 1) return;
 
+                if (this.searchQuery) return;
+
                 this.loadBatches('', true);
             },
 
@@ -90,13 +110,15 @@
              * Load the batches for the previous page.
              */
             previous() {
-                this.loadBatches(
-                    this.page == 2 ? '' : this.previousFirstId
-                );
+                var beforeId = this.page == 2 ? '' : this.previousFirstId;
+
+                this.loadBatches(beforeId);
 
                 this.page -= 1;
 
                 this.hasNewEntries = false;
+
+                this.updateQueryParams(beforeId);
             },
 
 
@@ -106,14 +128,39 @@
             next() {
                 this.previousFirstId = this.batches[0]?.id + '0';
 
-                this.loadBatches(
-                    this.batches.slice(-1)[0]?.id
-                );
+                var beforeId = this.batches.slice(-1)[0]?.id;
+
+                this.loadBatches(beforeId);
 
                 this.page += 1;
 
                 this.hasNewEntries = false;
-            }
+
+                this.updateQueryParams(beforeId);
+            },
+
+
+            /**
+             * Clear the search query and reset the table state.
+             */
+            clearSearch() {
+                this.searchQuery = '';
+            },
+
+
+            /**
+             * Sync pagination and search state to URL query params.
+             */
+            updateQueryParams(beforeId) {
+                var query = {};
+
+                if (this.page > 1) query.page = this.page;
+                if (beforeId) query.before_id = beforeId;
+                if (this.previousFirstId && this.page > 1) query.previous_first_id = this.previousFirstId;
+                if (this.searchQuery) query.query = this.searchQuery;
+
+                this.$router.replace({ query }).catch(() => {});
+            },
         }
     }
 </script>
@@ -125,6 +172,22 @@
         <div class="card overflow-hidden">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <h2 class="h6 m-0">Batches</h2>
+
+                <div class="form-control-with-icon">
+                    <div class="icon-wrapper">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon">
+                            <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd" />
+                        </svg>
+                    </div>
+
+                    <input type="text" class="form-control w-100" :style="searchQuery ? 'padding-right: 2rem' : ''" v-model="searchQuery" placeholder="Search Batches">
+
+                    <a v-if="searchQuery" href="#" @click.prevent="clearSearch" class="clear-search">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon">
+                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+                        </svg>
+                    </a>
+                </div>
             </div>
 
             <div v-if="!ready" class="d-flex align-items-center justify-content-center card-bg-secondary p-5 bottom-radius">

--- a/resources/sass/base.scss
+++ b/resources/sass/base.scss
@@ -110,6 +110,24 @@ svg.icon {
                 font-size: 0.875rem;
                 border-radius: 9999px;
             }
+
+            .clear-search {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                position: absolute;
+                top: 0;
+                right: 0.5rem;
+                bottom: 0;
+
+                .icon {
+                    fill: $text-muted;
+                }
+
+                &:hover .icon {
+                    fill: $body-color;
+                }
+            }
         }
     }
 

--- a/src/Http/Controllers/BatchesController.php
+++ b/src/Http/Controllers/BatchesController.php
@@ -5,13 +5,14 @@ namespace Laravel\Horizon\Http\Controllers;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Laravel\Horizon\Contracts\JobRepository;
 use Laravel\Horizon\Jobs\RetryFailedJob;
 
 class BatchesController extends Controller
 {
     /**
-     * The job repository implementation.
+     * The batch repository implementation.
      *
      * @var \Illuminate\Bus\BatchRepository
      */
@@ -39,7 +40,9 @@ class BatchesController extends Controller
     public function index(Request $request)
     {
         try {
-            $batches = $this->batches->get(50, $request->query('before_id') ?: null);
+            $batches = $request->query('query')
+                ? $this->searchBatches($request)
+                : $this->batches->get(50, $request->query('before_id'));
         } catch (QueryException $e) {
             $batches = [];
         }
@@ -61,13 +64,42 @@ class BatchesController extends Controller
 
         if ($batch) {
             $failedJobs = app(JobRepository::class)
-                            ->getJobs($batch->failedJobIds);
+                ->getJobs($batch->failedJobIds);
         }
 
         return [
             'batch' => $batch,
             'failedJobs' => $failedJobs ?? null,
         ];
+    }
+
+    /**
+     * Search the batches by name or ID.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    private function searchBatches(Request $request)
+    {
+        $query = str_replace(['%', '_'], ['\%', '\_'], $request->query('query'));
+        $table = config('queue.batching.table', 'job_batches');
+        $connection = config('queue.batching.database');
+
+        return DB::connection($connection)
+            ->table($table)
+            ->where(function ($q) use ($query) {
+                $q->where('name', 'like', "%{$query}%")
+                    ->orWhere('id', 'like', "%{$query}%");
+            })
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->limit(50)
+            ->when($request->query('before_id'), fn ($q, $beforeId) => $q->where('id', '<', $beforeId))
+            ->pluck('id')
+            ->map(fn ($id) => $this->batches->find($id))
+            ->filter()
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Http/Controllers/BatchesController.php
+++ b/src/Http/Controllers/BatchesController.php
@@ -82,16 +82,13 @@ class BatchesController extends Controller
     private function searchBatches(Request $request)
     {
         $query = str_replace(['%', '_'], ['\%', '\_'], $request->query('query'));
-        $table = config('queue.batching.table', 'job_batches');
-        $connection = config('queue.batching.database');
 
-        return DB::connection($connection)
-            ->table($table)
+        return DB::connection(config('queue.batching.database'))
+            ->table(config('queue.batching.table', 'job_batches'))
             ->where(function ($q) use ($query) {
                 $q->where('name', 'like', "%{$query}%")
                     ->orWhere('id', 'like', "%{$query}%");
             })
-            ->orderByDesc('created_at')
             ->orderByDesc('id')
             ->limit(50)
             ->when($request->query('before_id'), fn ($q, $beforeId) => $q->where('id', '<', $beforeId))

--- a/tests/Controller/BatchesControllerTest.php
+++ b/tests/Controller/BatchesControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Controller;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Horizon\Tests\ControllerTest;
+
+class BatchesControllerTest extends ControllerTest
+{
+    public function test_batches_can_be_searched_by_name()
+    {
+        $this->setupBatchTable();
+        $this->seedBatches();
+
+        $response = $this->actingAs(new Fakes\User)
+            ->get('/horizon/api/batches?query=Import');
+
+        $response->assertOk();
+
+        $batches = $response->original['batches'];
+
+        $this->assertCount(1, $batches);
+        $this->assertSame('Import Users', $batches[0]->name);
+    }
+
+    public function test_batches_can_be_searched_by_id()
+    {
+        $this->setupBatchTable();
+        $this->seedBatches();
+
+        $response = $this->actingAs(new Fakes\User)
+            ->get('/horizon/api/batches?query=batch-2');
+
+        $response->assertOk();
+
+        $batches = $response->original['batches'];
+
+        $this->assertCount(1, $batches);
+        $this->assertSame('Send Emails', $batches[0]->name);
+    }
+
+    public function test_search_escapes_like_wildcards()
+    {
+        $this->setupBatchTable();
+        $this->seedBatches();
+
+        $response = $this->actingAs(new Fakes\User)
+            ->get('/horizon/api/batches?query=%25');
+
+        $response->assertOk();
+
+        $this->assertEmpty($response->original['batches']);
+    }
+
+    public function test_search_supports_cursor_pagination()
+    {
+        $this->setupBatchTable();
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->insertBatch("batch-{$i}", 'Import Chunk '.$i);
+        }
+
+        $response = $this->actingAs(new Fakes\User)
+            ->get('/horizon/api/batches?query=Import&before_id=batch-3');
+
+        $response->assertOk();
+
+        $batches = $response->original['batches'];
+
+        $this->assertCount(2, $batches);
+        $this->assertSame('batch-2', $batches[0]->id);
+        $this->assertSame('batch-1', $batches[1]->id);
+    }
+
+    private function setupBatchTable()
+    {
+        $this->app['config']->set('queue.batching.database', 'testing');
+        $this->app['config']->set('queue.batching.table', 'job_batches');
+        $this->app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        Schema::connection('testing')->create('job_batches', static function ($table) {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->integer('total_jobs');
+            $table->integer('pending_jobs');
+            $table->integer('failed_jobs');
+            $table->longText('failed_job_ids');
+            $table->mediumText('options')->nullable();
+            $table->integer('cancelled_at')->nullable();
+            $table->integer('created_at');
+            $table->integer('finished_at')->nullable();
+        });
+    }
+
+    private function seedBatches()
+    {
+        $this->insertBatch('batch-1', 'Import Users');
+        $this->insertBatch('batch-2', 'Send Emails');
+        $this->insertBatch('batch-3', 'Process Orders');
+    }
+
+    private function insertBatch($id, $name)
+    {
+        DB::connection('testing')
+            ->table('job_batches')
+            ->insert([
+                'id' => $id,
+                'name' => $name,
+                'total_jobs' => 10,
+                'pending_jobs' => 0,
+                'failed_jobs' => 0,
+                'failed_job_ids' => '[]',
+                'options' => serialize([]),
+                'created_at' => time(),
+                'cancelled_at' => null,
+                'finished_at' => null,
+            ]);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I recently had a scenario pop up at work where I had to monitor several thousands of jobs over a day to coordinate some work with Stripe. These were all batched, for one reason or another, and it became fairly annoying to have to find failed jobs within a batch on the batch view in Horizon.

Another slight annoyance was that while I was sifting through batches and paging through a lot of job data, I couldn't navigate back to my paginated spot on the batch view when inspecting a batch from the batch detail view.

This PR adds a search to the batch table so we can easily search by batch name or UUID, along with adding some query parameters so we can keep pagination state in browser history. Added benefit is getting to send links to coworkers so they can get right to the batch page in the page table we might be interested in looking at. 

Totally open to thoughts around this or if there was a particular reason this wasn't intentionally included. Love Horizon, and hope to make it even better for everyone!

**Screenshots**

Searching for a batch by UUID with the new search field:

<img width="1464" height="389" alt="batch-search" src="https://github.com/user-attachments/assets/bf4d7c65-d5e1-40a1-bda7-f35a14fde2ac" />

Searching for a batch by name:

<img width="1441" height="1119" alt="batch-search-by-name" src="https://github.com/user-attachments/assets/971dfbd1-7ffb-4f4f-b01d-9e8076f6ec59" />