### PR TITLE
[5.x] Fix runaway memory usage with `horizon:listen`

### DIFF
--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -114,13 +114,13 @@ class ListenCommand extends Command
      */
     protected function startHorizon()
     {
-        $command = 'php artisan horizon';
+        $command = ['php', 'artisan', 'horizon'];
 
         if ($environment = $this->option('environment')) {
-            $command .= ' --environment='.$environment;
+            $command[] = '--environment='.$environment;
         }
 
-        $this->horizonProcess = Process::fromShellCommandline($command)
+        $this->horizonProcess = (new Process($command))
             ->setTimeout(null);
 
         $this->trap([SIGINT, SIGTERM, SIGQUIT], function ($signal) {


### PR DESCRIPTION
To resolve https://github.com/laravel/horizon/issues/1715

So it turns out that calling Symfony's Process with an array vs a string produces different behavior. Who knew? It seems that by passing a string, it calls `sh <command>` rather than `exec <command>` and the PID belongs to the sh process, not the actual command. Killing that process doesn't kill the underlying supervisor + workers.

Note that the identified problem doesn't appear to be an issue on bare metal on my MBP. However, inside of a docker container, big sadness.