### PR TITLE
return exit code from terminate command

### DIFF
--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -36,9 +36,9 @@ class TerminateCommand extends Command
      *
      * @param  \Illuminate\Contracts\Cache\Factory  $cache
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
-     * @return void
+     * @return int|null
      */
-    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters): ?int
+    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters)
     {
         if (config('horizon.fast_termination')) {
             $cache->forever(
@@ -56,6 +56,7 @@ class TerminateCommand extends Command
             ->whenNotEmpty(fn () => $this->components->info('Sending TERM signal to processes.'))
             ->whenEmpty(function () use (&$exitCode) {
                 $this->components->info('No processes to terminate.');
+
                 $exitCode = Command::FAILURE;
             })
             ->each(function ($processId) use (&$exitCode) {
@@ -78,6 +79,6 @@ class TerminateCommand extends Command
 
         $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
 
-        return $exitCode;
+        return $exitCode ?? Command::SUCCESS;
     }
 }

--- a/src/Console/TerminateCommand.php
+++ b/src/Console/TerminateCommand.php
@@ -38,7 +38,7 @@ class TerminateCommand extends Command
      * @param  \Laravel\Horizon\Contracts\MasterSupervisorRepository  $masters
      * @return void
      */
-    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters)
+    public function handle(CacheFactory $cache, MasterSupervisorRepository $masters): ?int
     {
         if (config('horizon.fast_termination')) {
             $cache->forever(
@@ -50,10 +50,15 @@ class TerminateCommand extends Command
             ->filter(fn ($master) => Str::startsWith($master->name, MasterSupervisor::basename()))
             ->all();
 
-        collect(Arr::pluck($masters, 'pid'))
+        $exitCode = null;
+
+        $result = collect(Arr::pluck($masters, 'pid'))
             ->whenNotEmpty(fn () => $this->components->info('Sending TERM signal to processes.'))
-            ->whenEmpty(fn () => $this->components->info('No processes to terminate.'))
-            ->each(function ($processId) {
+            ->whenEmpty(function () use (&$exitCode) {
+                $this->components->info('No processes to terminate.');
+                $exitCode = Command::FAILURE;
+            })
+            ->each(function ($processId) use (&$exitCode) {
                 $result = true;
 
                 $this->components->task("Process: $processId", function () use ($processId, &$result) {
@@ -62,9 +67,17 @@ class TerminateCommand extends Command
 
                 if (! $result) {
                     $this->components->error("Failed to kill process: {$processId} (".posix_strerror(posix_get_last_error()).')');
+
+                    $exitCode = Command::FAILURE;
+                } else if ($exitCode === null) {
+                    $exitCode = Command::SUCCESS;
                 }
             })->whenNotEmpty(fn () => $this->output->writeln(''));
 
+
+
         $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
+
+        return $exitCode;
     }
 }


### PR DESCRIPTION
Currently, when `horizon:terminate` returns an error, the command still exits with the default `statusCode = 0`, which indicates success.

As a result, automation scripts such as Deployer do not report a failure and instead mark the step as successful.

The problem occurs, for example, when the queue is running under a different user than the one attempting to restart it. In that case, we receive the message:

```
ERROR  Failed to kill process: 109462 (Operation not permitted).
```

However, Deployer still treats this as a success and continues the deployment process, even though the code has not actually been updated because the queue was not restarted.
