### PR TITLE
Reduce risks of `localStorage` collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.phpunit.cache
 /phpunit.xml
 /.vscode
+/node_modules
 /vendor
 composer.phar
 composer.lock

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -9,6 +9,8 @@ import Alert from './components/Alert.vue';
 import SchemeToggler from './components/SchemeToggler.vue';
 import Poll from './components/Poll.vue';
 
+const LOCALSTORAGE_AUTOLOAD_KEY = 'horizonAutoLoadsNewEntries';
+
 let token = document.head.querySelector("meta[name='csrf-token']");
 
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
@@ -27,7 +29,7 @@ const app = createApp({
                 confirmationProceed: null,
                 confirmationCancel: null,
             },
-            autoLoadsNewEntries: localStorage.autoLoadsNewEntries === '1',
+            autoLoadsNewEntries: localStorage[LOCALSTORAGE_AUTOLOAD_KEY] === '1',
         };
     },
 });

--- a/resources/js/base.js
+++ b/resources/js/base.js
@@ -1,5 +1,7 @@
 import moment from 'moment-timezone';
 
+const LOCALSTORAGE_AUTOLOAD_KEY = 'horizonAutoLoadsNewEntries';
+
 export default {
     computed: {
         Horizon() {
@@ -37,13 +39,8 @@ export default {
          * Autoload new entries in listing screens.
          */
         autoLoadNewEntries() {
-            if (!this.autoLoadsNewEntries) {
-                this.autoLoadsNewEntries = true;
-                localStorage.autoLoadsNewEntries = 1;
-            } else {
-                this.autoLoadsNewEntries = false;
-                localStorage.autoLoadsNewEntries = 0;
-            }
+            this.autoLoadsNewEntries = !this.autoLoadsNewEntries;
+            localStorage[LOCALSTORAGE_AUTOLOAD_KEY] = Number(this.autoLoadsNewEntries);
         },
 
         /**

--- a/resources/js/components/SchemeToggler.vue
+++ b/resources/js/components/SchemeToggler.vue
@@ -1,4 +1,6 @@
 <script type="text/ecmascript-6">
+    const LOCALSTORAGE_COLOR_SCHEME_KEY = 'horizonColorScheme';
+
     export default {
         data () {
             return {
@@ -8,12 +10,12 @@
 
         watch: {
             scheme (value) {
-                localStorage.setItem('scheme', value);
+                localStorage.setItem(LOCALSTORAGE_COLOR_SCHEME_KEY, value);
             }
         },
 
         mounted () {
-            this.scheme = localStorage.getItem('scheme') ?? 'system';
+            this.scheme = localStorage.getItem(LOCALSTORAGE_COLOR_SCHEME_KEY) ?? 'system';
 
             window
                 .matchMedia('(prefers-color-scheme: dark)')


### PR DESCRIPTION
This is the PR matching [the one in Telescope](https://github.com/laravel/telescope/pull/1687) for the same topic.

In this one, it’s also applied to the theme switcher, also saved in `localStorage`.

Edit: also adds `/node_modules` to `.gitignore`!