### PR TITLE
Update configure-horizon skill examples and command references

### DIFF
--- a/resources/boost/skills/configure-horizon/SKILL.blade.php
+++ b/resources/boost/skills/configure-horizon/SKILL.blade.php
@@ -60,7 +60,7 @@ Define supervisors in `config/horizon.php`. The `environments` array merges into
 
 'environments' => [
     'production' => [
-        'supervisor-1' => ['maxProcesses' => 10, 'balanceCooldown' => 3],
+        'supervisor-1' => ['maxProcesses' => 20, 'balanceCooldown' => 3],
     ],
     'local' => [
         'supervisor-1' => ['maxProcesses' => 2],
@@ -94,5 +94,5 @@ protected function gate(): void
 - Always check `config/horizon.php` before making changes to understand the current supervisor and environment configuration.
 - The `environments` array overrides only the keys you specify. It merges into `defaults` and does not replace it.
 - The timeout chain must be ordered: job `timeout` less than supervisor `timeout` less than `retry_after`. The wrong order can cause jobs to be retried before Horizon finishes timing them out.
-- The metrics dashboard stays blank until `horizon:snapshot` is scheduled. Running `php artisan horizon` alone does not populate metrics.
+- The metrics dashboard stays blank until `horizon:snapshot` is scheduled. Running `{{ $assist->artisanCommand('horizon') }}` alone does not populate metrics.
 - Always use `search-docs` for the latest Horizon documentation rather than relying on this skill alone.

--- a/resources/boost/skills/configure-horizon/references/metrics.md
+++ b/resources/boost/skills/configure-horizon/references/metrics.md
@@ -10,7 +10,7 @@ Search with `search-docs`:
 
 ### Metrics dashboard stays blank until `horizon:snapshot` is scheduled
 
-Running `php artisan horizon` does not populate metrics automatically. The metrics graph is built from snapshots, so `php artisan horizon:snapshot` must be scheduled to run every 5 minutes via Laravel's scheduler.
+Running `horizon` does not populate metrics automatically. The metrics graph is built from snapshots, so `horizon:snapshot` must be scheduled to run every 5 minutes via Laravel's scheduler.
 
 ### Register the snapshot in the scheduler rather than running it manually
 

--- a/resources/boost/skills/configure-horizon/references/metrics.md
+++ b/resources/boost/skills/configure-horizon/references/metrics.md
@@ -10,7 +10,7 @@ Search with `search-docs`:
 
 ### Metrics dashboard stays blank until `horizon:snapshot` is scheduled
 
-Running `horizon` does not populate metrics automatically. The metrics graph is built from snapshots, so `horizon:snapshot` must be scheduled to run every 5 minutes via Laravel's scheduler.
+Running `horizon` artisan command does not populate metrics automatically. The metrics graph is built from snapshots, so `horizon:snapshot` must be scheduled to run every 5 minutes via Laravel's scheduler.
 
 ### Register the snapshot in the scheduler rather than running it manually
 


### PR DESCRIPTION
Improve the configure-horizon Boost skill with better examples and dynamic command references.

Fixes https://github.com/laravel/horizon/issues/1726

### Approach

- Use dynamic `artisanCommand()` helper instead of hardcoded `php artisan` references
- Increase maxProcesses example from 10 to 20 to show meaningful environment override (matches the skill's guidance that only differing values should be specified)