### PR TITLE
Refine Horizon skill description

### DIFF
--- a/resources/boost/skills/configure-horizon/SKILL.blade.php
+++ b/resources/boost/skills/configure-horizon/SKILL.blade.php
@@ -1,6 +1,6 @@
 ---
 name: configuring-horizon
-description: "Configures Laravel Horizon for Redis queue management. Activate when the user explicitly mentions Horizon by name. Covers Horizon installation, supervisor configuration, worker processes, dashboard authorization, auto-scaling, balancing strategies, job monitoring, metrics, tags, and notifications. Also applies when troubleshooting Horizon-specific issues such as blank metrics, LongWaitDetected alerts, or misconfigured Horizon workers. Do NOT activate for generic queue, Redis, or job monitoring questions that do not mention Horizon."
+description: "Use this skill whenever the user mentions Horizon by name in a Laravel context. Covers the full Horizon lifecycle: installing Horizon (horizon:install, Sail setup), configuring config/horizon.php (supervisor blocks, queue assignments, balancing strategies, minProcesses/maxProcesses), fixing the dashboard (authorization via Gate::define viewHorizon, blank metrics, horizon:snapshot scheduling), and troubleshooting production issues (worker crashes, timeout chain ordering, LongWaitDetected notifications, waits config). Also covers job tagging and silencing. Do not use for generic Laravel queues without Horizon, SQS or database drivers, standalone Redis setup, Linux supervisord, Telescope, or job batching."
 license: MIT
 metadata:
   author: laravel


### PR DESCRIPTION
The current Horizon skill description is generic and doesn't enumerate specific scenarios that should trigger it. This makes it harder for the skill system to reliably match user queries to the skill.

### Approach

- Rewrite the skill description to be more specific about what Horizon topics are covered (installation, config/horizon.php, dashboard fixes, production troubleshooting, job tagging)
- Add explicit negative boundaries so the skill doesn't trigger for unrelated topics (generic queues, SQS, database drivers, standalone Redis, supervisord, Telescope, job batching)

### Eval Results

| | **Original** | **Final (Winner)** |
|---|---|---|
| **Train Accuracy** | 50% | 86% |
| **Test Accuracy** | 50% | 96% |
| **Precision** | 100% | 100% |
| **Recall (Test)** | 0% | 92% |
| **Description** | "Configures Laravel Horizon for Redis queue management. Activate when the user explicitly mentions Horizon by name..." | "Use this skill whenever the user mentions Horizon by name in a Laravel context. Covers the full Horizon lifecycle..." |
