### PR TITLE
Release unique job locks when clearing queues (fixes laravel/horizon#1678)

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -2,8 +2,11 @@
 
 namespace Laravel\Horizon\Console;
 
+use Illuminate\Bus\UniqueLock;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Arr;
 use Laravel\Horizon\Contracts\JobRepository;
@@ -52,8 +55,12 @@ class ClearCommand extends Command
         $connection = $this->argument('connection')
             ?: Arr::first($this->laravel['config']->get('horizon.defaults'))['connection'] ?? 'redis';
 
+        $queue = $this->getQueue($connection);
+
+        $this->releaseUniqueJobLocks($manager, $connection, $queue);
+
         if (method_exists($jobRepository, 'purge')) {
-            $jobRepository->purge($queue = $this->getQueue($connection));
+            $jobRepository->purge($queue);
         }
 
         $count = $manager->connection($connection)->clear($queue);
@@ -61,6 +68,59 @@ class ClearCommand extends Command
         $this->components->info('Cleared '.$count.' jobs from the ['.$queue.'] queue.');
 
         return 0;
+    }
+
+    /**
+     * Release any unique job locks for jobs on the given queue.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @param  string  $connection
+     * @param  string  $queue
+     * @return void
+     */
+    protected function releaseUniqueJobLocks(QueueManager $manager, $connection, $queue)
+    {
+        $redisQueue = $manager->connection($connection);
+
+        $redisConnection = $redisQueue->getConnection();
+        $queueKey = $redisQueue->getQueue($queue);
+
+        $payloads = collect()
+            ->merge($redisConnection->lrange($queueKey, 0, -1))
+            ->merge($redisConnection->zrangebyscore($queueKey.':delayed', '-inf', '+inf'))
+            ->merge($redisConnection->zrangebyscore($queueKey.':reserved', '-inf', '+inf'));
+
+        $cache = $this->laravel->make(Cache::class);
+
+        $payloads->each(function ($payload) use ($cache) {
+            $this->releaseUniqueJobLock($cache, $payload);
+        });
+    }
+
+    /**
+     * Release the unique job lock for the given payload if applicable.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @param  string  $payload
+     * @return void
+     */
+    protected function releaseUniqueJobLock(Cache $cache, $payload)
+    {
+        try {
+            $decoded = json_decode($payload, true);
+
+            if (! isset($decoded['data']['command'])) {
+                return;
+            }
+
+            $command = unserialize($decoded['data']['command']);
+
+            if ($command instanceof ShouldBeUnique) {
+                (new UniqueLock($cache))->release($command);
+            }
+        } catch (\Throwable) {
+            // If the job payload can't be decoded or unserialized, skip it.
+        }
     }
 
     /**

--- a/tests/Unit/ClearCommandUniqueLocksTest.php
+++ b/tests/Unit/ClearCommandUniqueLocksTest.php
@@ -30,6 +30,7 @@ class ClearCommandUniqueLocksTest extends UnitTest
         $command = new ClearCommand;
 
         $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
+        $method->setAccessible(true);
         $method->invoke($command, $cache, $payload);
     }
 
@@ -51,6 +52,7 @@ class ClearCommandUniqueLocksTest extends UnitTest
         $command = new ClearCommand;
 
         $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
+        $method->setAccessible(true);
         $method->invoke($command, $cache, $payload);
     }
 
@@ -62,6 +64,7 @@ class ClearCommandUniqueLocksTest extends UnitTest
         $command = new ClearCommand;
 
         $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
+        $method->setAccessible(true);
 
         // Invalid JSON should not throw.
         $method->invoke($command, $cache, 'not-json');

--- a/tests/Unit/ClearCommandUniqueLocksTest.php
+++ b/tests/Unit/ClearCommandUniqueLocksTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Laravel\Horizon\Console\ClearCommand;
+use Laravel\Horizon\Tests\UnitTest;
+use Mockery;
+use ReflectionMethod;
+
+class ClearCommandUniqueLocksTest extends UnitTest
+{
+    public function test_unique_job_lock_is_released_for_unique_jobs()
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('forceRelease')->once();
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldReceive('lock')->once()->andReturn($lock);
+
+        $job = new FakeUniqueJob;
+        $payload = json_encode([
+            'data' => [
+                'command' => serialize($job),
+            ],
+        ]);
+
+        $command = new ClearCommand;
+
+        $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
+        $method->invoke($command, $cache, $payload);
+    }
+
+    public function test_non_unique_job_does_not_release_lock()
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldNotReceive('forceRelease');
+
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldNotReceive('lock');
+
+        $job = new FakeNonUniqueJob;
+        $payload = json_encode([
+            'data' => [
+                'command' => serialize($job),
+            ],
+        ]);
+
+        $command = new ClearCommand;
+
+        $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
+        $method->invoke($command, $cache, $payload);
+    }
+
+    public function test_invalid_payload_does_not_throw()
+    {
+        $cache = Mockery::mock(Cache::class);
+        $cache->shouldNotReceive('lock');
+
+        $command = new ClearCommand;
+
+        $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
+
+        // Invalid JSON should not throw.
+        $method->invoke($command, $cache, 'not-json');
+
+        // Missing command key should not throw.
+        $method->invoke($command, $cache, json_encode(['data' => []]));
+
+        // This assertion is implicit - no exception means success.
+        $this->assertTrue(true);
+    }
+}
+
+class FakeUniqueJob implements ShouldBeUnique
+{
+    public $uniqueId = 'test-unique-id';
+}
+
+class FakeNonUniqueJob
+{
+    //
+}

--- a/tests/Unit/ClearCommandUniqueLocksTest.php
+++ b/tests/Unit/ClearCommandUniqueLocksTest.php
@@ -10,6 +10,22 @@ use Laravel\Horizon\Tests\UnitTest;
 use Mockery;
 use ReflectionMethod;
 
+/**
+ * Helper to invoke protected methods across PHP versions.
+ *
+ * PHP 8.0 requires setAccessible(true), PHP 8.5 deprecates it.
+ */
+function invokeProtected(object $object, string $method, array $args = []): mixed
+{
+    $ref = new ReflectionMethod($object, $method);
+
+    if (PHP_VERSION_ID < 80100) {
+        $ref->setAccessible(true);
+    }
+
+    return $ref->invoke($object, ...$args);
+}
+
 class ClearCommandUniqueLocksTest extends UnitTest
 {
     public function test_unique_job_lock_is_released_for_unique_jobs()
@@ -29,9 +45,7 @@ class ClearCommandUniqueLocksTest extends UnitTest
 
         $command = new ClearCommand;
 
-        $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
-        $method->setAccessible(true);
-        $method->invoke($command, $cache, $payload);
+        invokeProtected($command, 'releaseUniqueJobLock', [$cache, $payload]);
     }
 
     public function test_non_unique_job_does_not_release_lock()
@@ -51,9 +65,7 @@ class ClearCommandUniqueLocksTest extends UnitTest
 
         $command = new ClearCommand;
 
-        $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
-        $method->setAccessible(true);
-        $method->invoke($command, $cache, $payload);
+        invokeProtected($command, 'releaseUniqueJobLock', [$cache, $payload]);
     }
 
     public function test_invalid_payload_does_not_throw()
@@ -63,14 +75,11 @@ class ClearCommandUniqueLocksTest extends UnitTest
 
         $command = new ClearCommand;
 
-        $method = new ReflectionMethod($command, 'releaseUniqueJobLock');
-        $method->setAccessible(true);
-
         // Invalid JSON should not throw.
-        $method->invoke($command, $cache, 'not-json');
+        invokeProtected($command, 'releaseUniqueJobLock', [$cache, 'not-json']);
 
         // Missing command key should not throw.
-        $method->invoke($command, $cache, json_encode(['data' => []]));
+        invokeProtected($command, 'releaseUniqueJobLock', [$cache, json_encode(['data' => []])]);
 
         // This assertion is implicit - no exception means success.
         $this->assertTrue(true);


### PR DESCRIPTION
## Summary

Fixes laravel/horizon#1678 — When `horizon:clear` runs, unique job locks (`ShouldBeUnique`) are left behind indefinitely in Redis, permanently blocking new jobs with the same unique key from ever running.

## Steps to Reproduce

1. Define a unique queueable job (`ShouldQueue` + `ShouldBeUnique`)
2. Dispatch the job (but don't start `queue:work`)
3. Run `php artisan horizon:clear`
4. Check Redis — the `laravel_unique_job:*` lock keys still exist
5. Dispatch the same job again — it silently refuses to run because the lock is still held
6. Only `Cache::lockConnection()->command('flushdb')` can fix it

## Before (Bug)

`horizon:clear` removes jobs from the queue but does not release their unique locks in Redis. The locks persist until their TTL expires (which may be indefinite if no TTL was set), permanently blocking any new dispatch of the same unique job.

## After (Fix)

Before clearing the queue, `horizon:clear` reads all job payloads from the queue (pending, delayed, and reserved), deserializes each one, and releases the `ShouldBeUnique` lock via `UniqueLock::release()`.

## Root Cause

The `ClearCommand` delegates to `QueueManager::clear()` which removes jobs from Redis lists/sorted sets without examining payloads. The `ShouldBeUnique` lock is stored separately in the cache store and is not coupled to queue job lifecycle.

## The Fix

Added two methods to `ClearCommand`:
- `releaseUniqueJobLocks()` — reads all job payloads from the queue's pending, delayed, and reserved lists
- `releaseUniqueJobLock()` — deserializes each payload and releases the lock if the job implements `ShouldBeUnique`

This runs before the queue is cleared, ensuring locks are released before jobs are removed.

## Breaking Changes

None.

## Files Changed

- `src/Console/ClearCommand.php` — Added unique lock release logic before queue clearing (+56 lines)

## Test Results

Existing Horizon test suite passes. Unique job locks are properly released on `horizon:clear`.