### PR TITLE
Scope WaitTimeCalculator to current supervisor's queues (fixes laravel/horizon#1704)

### DIFF
--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon\Listeners;
 use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\Events\SupervisorLooped;
 use Laravel\Horizon\WaitTimeCalculator;
 
 class MonitorWaitTimes
@@ -37,18 +38,19 @@ class MonitorWaitTimes
     /**
      * Handle the event.
      *
+     * @param  \Laravel\Horizon\Events\SupervisorLooped  $event
      * @return void
      */
-    public function handle()
+    public function handle(SupervisorLooped $event)
     {
         if (! $this->dueToMonitor()) {
             return;
         }
 
         // Here we will calculate the wait time in seconds for each of the queues that
-        // the application is working. Then, we will filter the results to find the
-        // queues with the longest wait times and raise events for each of these.
-        $results = app(WaitTimeCalculator::class)->calculate();
+        // the supervisor is working. We scope the calculation to only the current
+        // supervisor's queues to avoid creating connections to unrelated drivers.
+        $results = app(WaitTimeCalculator::class)->calculateForSupervisor($event->supervisor);
 
         $long = collect($results)->filter(function ($wait, $queue) {
             return config("horizon.waits.{$queue}") !== 0

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -67,10 +67,43 @@ class WaitTimeCalculator
      */
     public function calculate($queue = null)
     {
-        $queues = $this->queueNames(
-            $supervisors = collect($this->supervisors->all()), $queue
-        );
+        $supervisors = collect($this->supervisors->all());
 
+        $queues = $this->queueNames($supervisors, $queue);
+
+        return $this->calculateTimeToClearPerQueue($queues, $supervisors);
+    }
+
+    /**
+     * Calculate the time to clear per queue in seconds, scoped to a specific supervisor.
+     *
+     * This prevents supervisor processes from creating connections to queue drivers
+     * they don't belong to (e.g. a Redis supervisor connecting to RabbitMQ).
+     *
+     * @param  \Laravel\Horizon\Supervisor  $supervisor
+     * @return array
+     */
+    public function calculateForSupervisor($supervisor)
+    {
+        $supervisors = collect($this->supervisors->all());
+
+        $connection = $supervisor->options->connection;
+
+        $queues = collect(explode(',', $supervisor->options->queue))
+            ->map(fn ($queue) => $connection.':'.$queue);
+
+        return $this->calculateTimeToClearPerQueue($queues, $supervisors);
+    }
+
+    /**
+     * Calculate the time to clear for the given queues using the given supervisors for process counts.
+     *
+     * @param  \Illuminate\Support\Collection  $queues
+     * @param  \Illuminate\Support\Collection  $supervisors
+     * @return array
+     */
+    protected function calculateTimeToClearPerQueue($queues, $supervisors)
+    {
         return $queues->mapWithKeys(function ($queue) use ($supervisors) {
             $totalProcesses = $this->totalProcessesFor($supervisors, $queue);
 

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -6,7 +6,10 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\Events\SupervisorLooped;
 use Laravel\Horizon\Listeners\MonitorWaitTimes;
+use Laravel\Horizon\Supervisor;
+use Laravel\Horizon\SupervisorOptions;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Laravel\Horizon\WaitTimeCalculator;
 use Mockery;
@@ -18,7 +21,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->shouldReceive('calculate')->andReturn([
+        $calc->shouldReceive('calculateForSupervisor')->andReturn([
             'redis:test-queue' => 10,
             'redis:test-queue-2' => 80,
         ]);
@@ -26,7 +29,7 @@ class MonitorWaitTimesTest extends IntegrationTest
 
         $listener = new MonitorWaitTimes(app(MetricsRepository::class));
 
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertDispatched(LongWaitDetected::class, function ($event) {
             return $event->connection == 'redis' && $event->queue == 'test-queue-2';
@@ -40,14 +43,14 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->andReturn([
+        $calc->expects('calculateForSupervisor')->andReturn([
             'redis:ignore-queue' => 10,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $listener = new MonitorWaitTimes(app(MetricsRepository::class));
 
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }
@@ -59,7 +62,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->never();
+        $calc->expects('calculateForSupervisor')->never();
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $metrics = Mockery::mock(MetricsRepository::class);
@@ -68,7 +71,7 @@ class MonitorWaitTimesTest extends IntegrationTest
 
         $listener = new MonitorWaitTimes($metrics);
 
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }
@@ -80,7 +83,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->never();
+        $calc->expects('calculateForSupervisor')->never();
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $metrics = Mockery::mock(MetricsRepository::class);
@@ -90,7 +93,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener = new MonitorWaitTimes($metrics);
         $listener->lastMonitored = CarbonImmutable::now(); // Too soon
 
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }
@@ -102,7 +105,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->once()->andReturn([
+        $calc->expects('calculateForSupervisor')->once()->andReturn([
             'redis:default' => 70,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
@@ -114,13 +117,13 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener = new MonitorWaitTimes($metrics);
         $listener->lastMonitored = CarbonImmutable::now(); // Too soon
 
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertNotDispatched(LongWaitDetected::class);
 
         CarbonImmutable::setTestNow(now()->addMinutes(2)); // Simulate time passing
 
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertDispatched(LongWaitDetected::class);
     }
@@ -132,7 +135,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->once()->andReturn([
+        $calc->expects('calculateForSupervisor')->once()->andReturn([
             'redis:default' => 70,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
@@ -142,10 +145,25 @@ class MonitorWaitTimesTest extends IntegrationTest
         $this->app->instance(MetricsRepository::class, $metrics);
 
         $listener = new MonitorWaitTimes($metrics);
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
         // Call it again to ensure it doesn't execute twice
-        $listener->handle();
+        $listener->handle($this->supervisorLoopedEvent());
 
         Event::assertDispatchedTimes(LongWaitDetected::class, 1);
+    }
+
+    /**
+     * Create a SupervisorLooped event with a mocked supervisor.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @return \Laravel\Horizon\Events\SupervisorLooped
+     */
+    protected function supervisorLoopedEvent($connection = 'redis', $queue = 'default')
+    {
+        $supervisor = Mockery::mock(Supervisor::class);
+        $supervisor->options = new SupervisorOptions('test-supervisor', $connection, $queue);
+
+        return new SupervisorLooped($supervisor);
     }
 }

--- a/tests/Feature/WaitTimeCalculatorTest.php
+++ b/tests/Feature/WaitTimeCalculatorTest.php
@@ -5,6 +5,8 @@ namespace Laravel\Horizon\Tests\Feature;
 use Illuminate\Contracts\Queue\Factory as QueueFactory;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Contracts\SupervisorRepository;
+use Laravel\Horizon\Supervisor;
+use Laravel\Horizon\SupervisorOptions;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Laravel\Horizon\WaitTimeCalculator;
 use Mockery;
@@ -146,6 +148,68 @@ class WaitTimeCalculatorTest extends IntegrationTest
         $this->assertEquals(
             ['redis:test-queue' => 10],
             $calculator->calculate()
+        );
+    }
+
+    public function test_calculate_for_supervisor_only_checks_supervisor_queues()
+    {
+        $calculator = $this->with_scenario([
+            'redis-supervisor' => (object) [
+                'processes' => [
+                    'redis:test-queue' => 2,
+                ],
+            ],
+            'rabbitmq-supervisor' => (object) [
+                'processes' => [
+                    'rabbitmq:other-queue' => 1,
+                ],
+            ],
+        ], [
+            'test-queue' => [
+                'size' => 10,
+                'runtime' => 1000,
+            ],
+            // Note: rabbitmq:other-queue is not set up on the mock queue factory,
+            // so if calculateForSupervisor tries to access it, the test would fail.
+        ]);
+
+        $supervisor = Mockery::mock(Supervisor::class);
+        $supervisor->options = new SupervisorOptions('redis-supervisor', 'redis', 'test-queue');
+
+        $this->assertEquals(
+            ['redis:test-queue' => 5],
+            $calculator->calculateForSupervisor($supervisor)
+        );
+    }
+
+    public function test_calculate_for_supervisor_with_multiple_queues()
+    {
+        $calculator = $this->with_scenario([
+            'redis-supervisor' => (object) [
+                'processes' => [
+                    'redis:queue-a' => 2,
+                    'redis:queue-b' => 1,
+                ],
+            ],
+        ], [
+            'queue-a' => [
+                'size' => 10,
+                'runtime' => 1000,
+            ],
+            'queue-b' => [
+                'size' => 5,
+                'runtime' => 2000,
+            ],
+        ]);
+
+        $supervisor = Mockery::mock(Supervisor::class);
+        $supervisor->options = new SupervisorOptions('redis-supervisor', 'redis', 'queue-a,queue-b');
+
+        $results = $calculator->calculateForSupervisor($supervisor);
+
+        $this->assertEquals(
+            ['redis:queue-b' => 10, 'redis:queue-a' => 5],
+            $results
         );
     }
 


### PR DESCRIPTION
## Summary

`MonitorWaitTimes` calls `WaitTimeCalculator::calculate()` which checks ALL queues across ALL supervisors. This creates connections to every queue driver — so a Redis supervisor connects to RabbitMQ, and vice versa. These connections are orphaned and accumulate over time.

- Add `calculateForSupervisor()` that scopes wait time checks to the supervisor's own queues
- `MonitorWaitTimes` now uses the scoped method via `SupervisorLooped` event
- Original `calculate()` preserved for API/dashboard backward compatibility

Fixes #1704

## Related

- **#1607** — User with 9 supervisors across 7 Redis connections reports 258 connected clients for 52 processes. The monitoring logic checking all queues across all connections likely contributes to the excess, though the exact breakdown hasn't been confirmed.

## The problem

`WaitTimeCalculator::calculate()` fetches ALL supervisors from the repository and checks the wait time on every queue from every supervisor. When supervisors use different connections or drivers, this creates cross-driver connections:

```
supervisor-redis     → checks redis:default, redis:emails     ✓ (its own)
                     → checks rabbitmq:GuestCreated            ✗ (not its concern)

supervisor-rabbitmq  → checks rabbitmq:GuestCreated           ✓ (its own)
                     → checks redis:default, redis:emails      ✗ (not its concern)
```

These cross-driver connections are never closed and accumulate with each monitoring cycle. The issue reporter (#1704) provided RabbitMQ management console screenshots showing orphaned AMQP connections from Redis supervisors with 0 channels and 0 B/s traffic.

## The fix

Add `calculateForSupervisor()` which scopes the queue checks to only the supervisor's own queues based on its `options->queue` and `options->connection` configuration. `MonitorWaitTimes::handle()` now accepts the `SupervisorLooped` event (which carries the supervisor reference) and calls the scoped method.

The original `calculate()` method is unchanged — it's still used by the API/dashboard to show wait times across all queues, which is the correct behavior for the UI.

Note: `calculateForSupervisor()` still uses ALL supervisors for the process count calculation. This is intentional — when calculating "time to clear queue X", we need the total worker count across all supervisors that work on queue X, not just the current one. Only the list of queues to check is scoped.

## Backward compatibility

- `calculate()` is preserved with its existing behavior
- `calculateForSupervisor()` is a new method, not a replacement
- `MonitorWaitTimes` is an internal listener wired via `EventMap` — the `SupervisorLooped` event is always dispatched with the supervisor reference
- This builds on the recently merged #1574 (Fix MonitorWaitTimes to respect one-minute monitoring interval)

## Tests

9 tests (7 updated existing + 2 new) covering: single-queue supervisor scoping, multi-queue supervisor scoping, and all existing wait time calculation behavior preserved.

## Impact

Eliminates orphaned cross-driver/cross-connection connections created by the monitoring logic. Most visible in setups with multiple supervisors using different connections or drivers.