### PR TITLE
Fix null access in JobPayload::id() for corrupt jobs (fixes laravel/horizon#1698)

### DIFF
--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -42,11 +42,11 @@ class JobPayload implements ArrayAccess
     /**
      * Get the job ID from the payload.
      *
-     * @return string
+     * @return string|null
      */
     public function id()
     {
-        return $this->decoded['uuid'] ?? $this->decoded['id'];
+        return $this->decoded['uuid'] ?? $this->decoded['id'] ?? null;
     }
 
     /**

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -444,6 +444,10 @@ class RedisJobRepository implements JobRepository
     {
         $this->connection()->pipeline(function ($pipe) use ($payloads) {
             foreach ($payloads as $payload) {
+                if ($payload->id() === null) {
+                    continue;
+                }
+
                 $pipe->hmset(
                     $payload->id(), [
                         'status' => 'pending',

--- a/tests/Unit/JobPayloadTest.php
+++ b/tests/Unit/JobPayloadTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Laravel\Horizon\JobPayload;
+use Laravel\Horizon\Tests\UnitTest;
+
+class JobPayloadTest extends UnitTest
+{
+    public function test_id_returns_uuid_when_present()
+    {
+        $payload = new JobPayload(json_encode(['uuid' => 'abc-123', 'id' => 'fallback']));
+
+        $this->assertSame('abc-123', $payload->id());
+    }
+
+    public function test_id_falls_back_to_id_when_uuid_missing()
+    {
+        $payload = new JobPayload(json_encode(['id' => 'fallback-id']));
+
+        $this->assertSame('fallback-id', $payload->id());
+    }
+
+    public function test_id_returns_null_for_invalid_json()
+    {
+        $payload = new JobPayload('not-valid-json');
+
+        $this->assertNull($payload->id());
+    }
+
+    public function test_id_returns_null_for_empty_object()
+    {
+        $payload = new JobPayload(json_encode([]));
+
+        $this->assertNull($payload->id());
+    }
+
+    public function test_id_returns_null_for_null_decoded()
+    {
+        $payload = new JobPayload('null');
+
+        $this->assertNull($payload->id());
+    }
+}


### PR DESCRIPTION
## Summary

`JobPayload::id()` crashes with "Undefined array key" when processing corrupt job payloads that lack both `uuid` and `id` keys. This causes the migration pipeline to fail entirely, blocking all pending job processing.

- Add `?? null` fallback to `id()` (`@return string` → `@return string|null`)
- Skip null-ID payloads in `migrated()` instead of crashing the worker

Fixes #1698

## Steps to reproduce

### Setup

```bash
git clone https://github.com/laravel/horizon.git
cd horizon
git checkout 5.x
composer install
```

### Before (on `5.x`)

```php
$payload = new \Laravel\Horizon\JobPayload('{}');
$payload->id();
// Warning: Undefined array key "id" in src/JobPayload.php:49

$payload = new \Laravel\Horizon\JobPayload('not-valid-json');
$payload->id();
// Warning: Trying to access array offset on null in src/JobPayload.php:49

$payload = new \Laravel\Horizon\JobPayload(json_encode(['job' => 'App\Jobs\SomeJob']));
$payload->id();
// Warning: Undefined array key "id" in src/JobPayload.php:49

// Normal payloads work fine:
$payload = new \Laravel\Horizon\JobPayload(json_encode(['uuid' => 'abc-123', 'id' => 'job-456']));
$payload->id();
// "abc-123"
```

With strict error handling (Laravel's default), these warnings become fatal errors that crash the worker and block all job processing.

### Apply the fix

```bash
git remote add joshsalway https://github.com/JoshSalway/horizon.git
git fetch joshsalway
git checkout joshsalway/fix/job-payload-null-safety
```

### After (with this fix)

```php
$payload = new \Laravel\Horizon\JobPayload('{}');
$payload->id();
// null — no error

$payload = new \Laravel\Horizon\JobPayload('not-valid-json');
$payload->id();
// null — no error

$payload = new \Laravel\Horizon\JobPayload(json_encode(['job' => 'App\Jobs\SomeJob']));
$payload->id();
// null — no error

// Normal payloads still work exactly as before:
$payload = new \Laravel\Horizon\JobPayload(json_encode(['uuid' => 'abc-123', 'id' => 'job-456']));
$payload->id();
// "abc-123"
```

In production, this occurs when `migrated()` processes delayed/reserved jobs from Redis that have corrupt payloads — typically after version upgrades, failed serialization, or manual queue manipulation. The crash blocks the entire migration pipeline, preventing all pending jobs from processing.

## Scope

Only `migrated()` needs the null guard — it's the only code path that processes raw Redis payloads (which can be corrupt). All other `id()` callers receive payloads through Laravel's queue serialization which always sets `uuid`. No behavior change for normal jobs.

## Test plan

- [x] 5 unit tests: uuid present, id fallback, invalid JSON, empty object, null decoded
- [x] Traced all 20+ callers of `id()` — confirmed only `migrated()` can encounter corrupt data
- [x] Reproduced on macOS (PHP 8.4.19) — before: warnings/fatal errors on corrupt payloads, after: returns null gracefully
- [x] Reproduced on Windows (PHP 8.4.16) — same results
- [x] Full test suite passes: 174 tests, 396 assertions
