### PR TITLE
Fix 'delayed until' showing wrong time (fixes laravel/horizon#1668)

### DIFF
--- a/resources/js/screens/recentJobs/job.vue
+++ b/resources/js/screens/recentJobs/job.vue
@@ -130,6 +130,10 @@
                     return this.formatDate(this.job.payload.pushedAt).add(unserialized.delay, 'seconds')
                         .local()
                         .format('YYYY-MM-DD HH:mm:ss');
+                } else if (this.job.delay > 0) {
+                    return this.formatDate(this.job.payload.pushedAt).add(this.job.delay, 'seconds')
+                        .local()
+                        .format('YYYY-MM-DD HH:mm:ss');
                 }
 
                 return null;

--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -108,7 +108,13 @@ class RedisQueue extends BaseQueue
     #[\Override]
     public function later($delay, $job, $data = '', $queue = null)
     {
-        $payload = (new JobPayload($this->createPayload($job, $queue, $data)))->prepare($job)->value;
+        $preparedPayload = (new JobPayload($this->createPayload($job, $queue, $data)))->prepare($job);
+
+        $delayInSeconds = $this->secondsUntil($delay);
+
+        $preparedPayload->set(['delay' => $delayInSeconds]);
+
+        $payload = $preparedPayload->value;
 
         if (method_exists($this, 'enqueueUsing')) {
             return $this->enqueueUsing(

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -350,6 +350,7 @@ class RedisJobRepository implements JobRepository
                 'payload' => $payload->value,
                 'created_at' => $time,
                 'updated_at' => $time,
+                'delay' => $payload->decoded['delay'] ?? 0,
             ]);
 
             $pipe->expireat(

--- a/tests/Feature/QueueProcessingTest.php
+++ b/tests/Feature/QueueProcessingTest.php
@@ -93,4 +93,32 @@ class QueueProcessingTest extends IntegrationTest
 
         $this->assertSame('pending', $status);
     }
+
+    public function test_delayed_job_payload_contains_delay_field()
+    {
+        $id = Queue::later(30, new Jobs\BasicJob);
+
+        $payload = json_decode(Redis::connection('horizon')->hget($id, 'payload'), true);
+
+        $this->assertArrayHasKey('delay', $payload);
+        $this->assertSame(30, $payload['delay']);
+    }
+
+    public function test_delayed_job_record_stores_delay_value()
+    {
+        $id = Queue::later(60, new Jobs\BasicJob);
+
+        $delay = Redis::connection('horizon')->hget($id, 'delay');
+
+        $this->assertSame('60', $delay);
+    }
+
+    public function test_non_delayed_job_has_zero_delay()
+    {
+        $id = Queue::push(new Jobs\BasicJob);
+
+        $delay = Redis::connection('horizon')->hget($id, 'delay');
+
+        $this->assertSame('0', $delay);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes laravel/horizon#1668 -- The "delayed until" timestamp in Horizon's job detail view shows the wrong time because the delay value is not stored in the job payload when dispatching via `later()`. The frontend tries to compute the delayed-until time from `pushedAt + delay`, but `delay` is missing from the payload.

## Root Cause

**The bug exists because** `RedisQueue::later()` calculates the delay for Redis sorted set scheduling but never persists the delay value into the job payload itself. When Horizon's frontend displays a delayed job, it attempts to deserialize the job class to read its `delay` property. If the job was dispatched with `->delay(60)` via the queue method (not as a class property), the deserialized object has no delay information. The frontend falls back to showing nothing or an incorrect timestamp.

## Why This Fix Works

**This fix works because** it stores the delay (in seconds) directly in the job payload via `$preparedPayload->set(['delay' => $delayInSeconds])` inside `RedisQueue::later()`. The `RedisJobRepository::pushed()` method then persists this value alongside the job record. The Vue frontend already had partial support for reading delay from the payload -- this PR adds a fallback that reads `this.job.delay` when the deserialized class property is unavailable, computing the correct "delayed until" timestamp as `pushedAt + delay`.

## Alternatives Considered

**We chose this approach over** always deserializing the job class to read its delay because: (1) deserialization is expensive and fragile (class may not exist on the Horizon dashboard server); (2) storing the delay in the payload is the source of truth -- it captures the actual delay used at dispatch time, not a property that may differ from the runtime value; (3) the payload-based approach works for all job types, including closures and jobs dispatched with dynamic delays via `->delay()`.

## Files Changed

- `src/RedisQueue.php` -- Stores delay in job payload during `later()` dispatch
- `src/Repositories/RedisJobRepository.php` -- Persists delay from payload into job record
- `resources/js/screens/recentJobs/job.vue` -- Frontend fallback to read delay from job record when unserialized property unavailable