### PR TITLE
Fix AutoScaler not respecting minProcesses on startup (fixes laravel/horizon#1647)

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -121,7 +121,10 @@ class AutoScaler
                     ? ($timeToClear['size'] / $totalJobs)
                     : ($timeToClear['time'] / $timeToClearAll);
 
-                return [$queue => $numberOfProcesses *= $supervisor->options->maxProcesses];
+                return [$queue => max(
+                    $numberOfProcesses *= $supervisor->options->maxProcesses,
+                    $supervisor->options->minProcesses,
+                )];
             } elseif ($timeToClearAll == 0 &&
                       $supervisor->options->autoScaling()) {
                 return [

--- a/tests/Unit/AutoScalerMinProcessesTest.php
+++ b/tests/Unit/AutoScalerMinProcessesTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Laravel\Horizon\AutoScaler;
+use Laravel\Horizon\Contracts\HorizonCommandQueue;
+use Laravel\Horizon\Contracts\MetricsRepository;
+use Laravel\Horizon\Supervisor;
+use Laravel\Horizon\SupervisorOptions;
+use Laravel\Horizon\Tests\Feature\Fakes\FakePool;
+use Laravel\Horizon\Tests\UnitTest;
+use Mockery;
+
+class AutoScalerMinProcessesTest extends UnitTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a minimal Laravel application container for Supervisor.
+        $app = new \Illuminate\Foundation\Application;
+        $commandQueue = Mockery::mock(HorizonCommandQueue::class);
+        $commandQueue->shouldReceive('flush')->andReturnNull();
+        $app->instance(HorizonCommandQueue::class, $commandQueue);
+        \Illuminate\Foundation\Application::setInstance($app);
+    }
+
+    public function test_autoscaler_respects_min_processes_for_empty_queues_when_other_queues_have_work()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'busy' => ['current' => 1, 'size' => 10000, 'runtime' => 10],
+            'empty' => ['current' => 0, 'size' => 0, 'runtime' => 0],
+        ], ['minProcesses' => 2]);
+
+        // Run multiple scaling iterations to converge.
+        for ($i = 0; $i < 20; $i++) {
+            $scaler->scale($supervisor);
+        }
+
+        // The empty queue should never go below minProcesses.
+        $this->assertGreaterThanOrEqual(
+            2,
+            $supervisor->processPools['empty']->totalProcessCount(),
+            'Empty queue should have at least minProcesses workers'
+        );
+    }
+
+    public function test_autoscaler_respects_min_processes_with_multiple_active_queues()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(12, [
+            'queue_a' => ['current' => 0, 'size' => 10000, 'runtime' => 10],
+            'queue_b' => ['current' => 0, 'size' => 10000, 'runtime' => 10],
+            'queue_c' => ['current' => 0, 'size' => 0, 'runtime' => 0],
+        ], ['minProcesses' => 1]);
+
+        for ($i = 0; $i < 30; $i++) {
+            $scaler->scale($supervisor);
+        }
+
+        // The empty queue should have at least minProcesses.
+        $this->assertGreaterThanOrEqual(
+            1,
+            $supervisor->processPools['queue_c']->totalProcessCount(),
+            'Empty queue should have at least minProcesses workers'
+        );
+    }
+
+    public function test_autoscaler_respects_min_processes_with_size_strategy()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'busy' => ['current' => 1, 'size' => 10000, 'runtime' => 10],
+            'empty' => ['current' => 0, 'size' => 0, 'runtime' => 0],
+        ], ['minProcesses' => 2, 'autoScalingStrategy' => 'size']);
+
+        for ($i = 0; $i < 20; $i++) {
+            $scaler->scale($supervisor);
+        }
+
+        $this->assertGreaterThanOrEqual(
+            2,
+            $supervisor->processPools['empty']->totalProcessCount(),
+            'Empty queue should have at least minProcesses workers with size strategy'
+        );
+    }
+
+    /**
+     * @return array{0: AutoScaler, 1: Supervisor}
+     */
+    protected function with_scaling_scenario($maxProcesses, array $pools, array $extraOptions = [])
+    {
+        $queue = Mockery::mock(QueueFactory::class);
+        $metrics = Mockery::mock(MetricsRepository::class);
+
+        $scaler = new AutoScaler($queue, $metrics);
+
+        $options = new SupervisorOptions('name', 'redis', 'default');
+        $options->maxProcesses = $maxProcesses;
+        $options->balance = 'auto';
+        foreach ($extraOptions as $key => $value) {
+            $options->{$key} = $value;
+        }
+        $supervisor = new Supervisor($options);
+
+        $supervisor->processPools = collect($pools)->mapWithKeys(function ($pool, $name) {
+            return [$name => new FakePool($name, $pool['current'])];
+        });
+
+        $queue->shouldReceive('connection')->with('redis')->andReturnSelf();
+
+        collect($pools)->each(function ($pool, $name) use ($queue, $metrics) {
+            $queue->shouldReceive('readyNow')->with($name)->andReturn($pool['size']);
+            $metrics->shouldReceive('runtimeForQueue')->with($name)->andReturn($pool['runtime']);
+        });
+
+        return [$scaler, $supervisor];
+    }
+}


### PR DESCRIPTION
## Summary

Horizon's AutoScaler does not respect `minProcesses` when distributing workers proportionally. When a queue has low traffic relative to others, proportional allocation can assign fewer workers than `minProcesses`, starving that queue.

- Wrap per-queue calculation in `max($calculated, $supervisor->options->minProcesses)`

Fixes #1647

## Steps to reproduce

### Setup

```bash
git clone https://github.com/laravel/horizon.git
cd horizon
git checkout 5.x
composer install
```

### Before (on `5.x`)

```php
// Scenario: 2 queues with work, minProcesses=2, maxProcesses=10
// "default" has 900 jobs (90%), "emails" has 100 jobs (10%)

// Proportional allocation:
//   default: 0.9 * 10 = 9 workers
//   emails:  0.1 * 10 = 1 worker  ← below minProcesses=2!

// The "emails" queue gets 1 worker despite minProcesses=2
// Jobs pile up on "emails" waiting for the next scaling interval
```

### Apply the fix

```bash
git remote add joshsalway https://github.com/JoshSalway/horizon.git
git fetch joshsalway
git checkout joshsalway/fix/autoscaler-respect-min-processes
```

### After (with this fix)

```php
// Same scenario: 2 queues, minProcesses=2, maxProcesses=10
// "default" has 900 jobs (90%), "emails" has 100 jobs (10%)

// Proportional allocation with floor:
//   default: max(0.9 * 10, 2) = 9 workers
//   emails:  max(0.1 * 10, 2) = 2 workers  ← respects minProcesses
```

## Scope

One line changed in `src/AutoScaler.php`: wraps the existing proportional calculation in `max(..., minProcesses)`. Only affects the `$timeToClearAll > 0` branch — the `$timeToClearAll == 0` branch already respects `minProcesses`. No behavior change when proportional allocation already exceeds `minProcesses`.

When `numQueues * minProcesses > maxProcesses`, the per-queue targets exceed the total budget. This is safe because `scalePool()` independently caps the total at `maxProcesses` via `max(0, maxProcesses - totalProcessCount)` — later queues simply get fewer workers once the cap is hit.

## Test plan
- [x] 3 unit tests: empty queues with active siblings, multiple active queues, size-based strategy
- [x] Verified `scalePool()` prevents total workers from exceeding `maxProcesses` even when per-queue targets overflow
- [x] Fix matches the exact patch suggested by the issue reporter (#1647)
- [x] Tested with Redis running locally