### PR TITLE
Fix race condition in RedisHorizonCommandQueue::pending()

### DIFF
--- a/src/RedisHorizonCommandQueue.php
+++ b/src/RedisHorizonCommandQueue.php
@@ -49,19 +49,12 @@ class RedisHorizonCommandQueue implements HorizonCommandQueue
      */
     public function pending($name)
     {
-        $length = $this->connection()->llen('commands:'.$name);
-
-        if ($length < 1) {
-            return [];
-        }
-
-        $results = $this->connection()->pipeline(function ($pipe) use ($name, $length) {
-            $pipe->lrange('commands:'.$name, 0, $length - 1);
-
-            $pipe->ltrim('commands:'.$name, $length, -1);
+        $results = $this->connection()->transaction(function ($pipe) use ($name) {
+            $pipe->lrange('commands:'.$name, 0, -1);
+            $pipe->del('commands:'.$name);
         });
 
-        return collect($results[0])
+        return collect($results[0] ?? [])
             ->map(fn ($result) => (object) json_decode($result, true))
             ->all();
     }

--- a/tests/Feature/RedisHorizonCommandQueueTest.php
+++ b/tests/Feature/RedisHorizonCommandQueueTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature;
+
+use Laravel\Horizon\RedisHorizonCommandQueue;
+use Laravel\Horizon\Tests\IntegrationTest;
+
+class RedisHorizonCommandQueueTest extends IntegrationTest
+{
+    public function test_pending_returns_all_pushed_commands()
+    {
+        $queue = $this->app->make(RedisHorizonCommandQueue::class);
+
+        $queue->push('test-supervisor', 'Scale', ['processes' => 5]);
+        $queue->push('test-supervisor', 'Balance', []);
+        $queue->push('test-supervisor', 'Pause', []);
+
+        $commands = $queue->pending('test-supervisor');
+
+        $this->assertCount(3, $commands);
+        $this->assertEquals('Scale', $commands[0]->command);
+        $this->assertEquals('Balance', $commands[1]->command);
+        $this->assertEquals('Pause', $commands[2]->command);
+    }
+
+    public function test_pending_consumes_commands_atomically()
+    {
+        $queue = $this->app->make(RedisHorizonCommandQueue::class);
+
+        $queue->push('test-supervisor', 'Scale', ['processes' => 5]);
+        $queue->push('test-supervisor', 'Terminate', []);
+
+        $first = $queue->pending('test-supervisor');
+        $second = $queue->pending('test-supervisor');
+
+        $this->assertCount(2, $first);
+        $this->assertEmpty($second);
+    }
+
+    public function test_pending_returns_empty_when_no_commands()
+    {
+        $queue = $this->app->make(RedisHorizonCommandQueue::class);
+
+        $this->assertEmpty($queue->pending('nonexistent-supervisor'));
+    }
+
+    public function test_pending_preserves_command_options()
+    {
+        $queue = $this->app->make(RedisHorizonCommandQueue::class);
+
+        $queue->push('test-supervisor', 'Scale', ['processes' => 10, 'queue' => 'default']);
+
+        $commands = $queue->pending('test-supervisor');
+
+        $this->assertCount(1, $commands);
+        $this->assertEquals(10, $commands[0]->options['processes']);
+        $this->assertEquals('default', $commands[0]->options['queue']);
+    }
+
+    public function test_flush_removes_all_commands()
+    {
+        $queue = $this->app->make(RedisHorizonCommandQueue::class);
+
+        $queue->push('test-supervisor', 'Scale', []);
+        $queue->push('test-supervisor', 'Balance', []);
+        $queue->flush('test-supervisor');
+
+        $this->assertEmpty($queue->pending('test-supervisor'));
+    }
+
+    public function test_commands_are_isolated_between_supervisors()
+    {
+        $queue = $this->app->make(RedisHorizonCommandQueue::class);
+
+        $queue->push('supervisor-a', 'Scale', []);
+        $queue->push('supervisor-b', 'Terminate', []);
+
+        $a = $queue->pending('supervisor-a');
+        $b = $queue->pending('supervisor-b');
+
+        $this->assertCount(1, $a);
+        $this->assertEquals('Scale', $a[0]->command);
+        $this->assertCount(1, $b);
+        $this->assertEquals('Terminate', $b[0]->command);
+    }
+}


### PR DESCRIPTION
## Summary

Simplify `RedisHorizonCommandQueue::pending()` by replacing `LLEN` + `pipeline(LRANGE/LTRIM)` with `transaction(LRANGE/DEL)`, matching the existing pattern in `RedisMetricsRepository::baseSnapshotData()`.

Fixes #1739

## The change

The current code makes a separate `LLEN` call, then uses that count as the offset for `LRANGE` and `LTRIM` inside a `pipeline()`. This works in practice because each supervisor has its own command queue and reads it synchronously, but the offset from `LLEN` is inherently stale — commands pushed between `LLEN` and the pipeline are picked up on the next loop iteration rather than the current one.

Using `transaction()` with `LRANGE 0 -1` + `DEL` simplifies this to a single operation. No offset calculation needed, no stale count.

### Before

```php
$length = $this->connection()->llen('commands:'.$name);

if ($length < 1) {
    return [];
}

$results = $this->connection()->pipeline(function ($pipe) use ($name, $length) {
    $pipe->lrange('commands:'.$name, 0, $length - 1);
    $pipe->ltrim('commands:'.$name, $length, -1);
});
```

### After

```php
$results = $this->connection()->transaction(function ($pipe) use ($name) {
    $pipe->lrange('commands:'.$name, 0, -1);
    $pipe->del('commands:'.$name);
});
```

## Why transaction() over pipeline()

`pipeline()` batches commands to reduce network round-trips. `transaction()` wraps commands in Redis `MULTI/EXEC`, which the [Redis docs](https://redis.io/docs/latest/develop/using-commands/transactions/) describe as:

> "All the commands in a transaction are serialized and executed sequentially. A request sent by another client will never be served in the middle of the execution of a Redis Transaction."

For a read-then-delete pattern, `transaction()` ensures the `LRANGE` and `DEL` execute as a single isolated unit. This is the same approach already used in `RedisMetricsRepository::baseSnapshotData()` in the same codebase for the same reason.

## Sentinel compatibility note

Issue #193 previously raised a concern about `transaction()` (MULTI/EXEC) not working with Redis Sentinel via Predis. PRs #198 and #199 attempted to remove the existing `transaction()` from `baseSnapshotData()` but were both closed — the team chose to keep `transaction()`. This PR uses the same approach and does not change the Sentinel compatibility status of Horizon.

## Tests

6 new integration tests against real Redis: command retrieval, atomic consumption (second `pending()` returns empty), empty queue, option preservation, flush, and supervisor isolation.

## Impact

The source change is 4 lines added and 11 removed (+86 lines for the new test file). Eliminates the stale `LLEN` offset and uses `MULTI/EXEC` consistent with the existing codebase pattern.