### PR TITLE
Fix false orphan detection during graceful supervisor shutdown

### DIFF
--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -209,11 +209,6 @@ class Supervisor implements Pausable, Restartable, Terminable
     {
         $this->working = false;
 
-        // We will mark this supervisor as terminating so that any user interface can
-        // correctly show the supervisor's status. Then, we will scale the process
-        // pools down to zero workers to gracefully terminate them all out here.
-        app(SupervisorRepository::class)->forget($this->name);
-
         $this->processPools->each(function ($pool) {
             $pool->processes()->each(function ($process) {
                 $process->terminate();
@@ -225,6 +220,11 @@ class Supervisor implements Pausable, Restartable, Terminable
                 sleep(1);
             }
         }
+
+        // Remove the supervisor from the repository after all workers have
+        // stopped, so that horizon:purge does not flag them as orphans
+        // and force-kill them during graceful shutdown.
+        app(SupervisorRepository::class)->forget($this->name);
 
         $this->exit($status);
     }


### PR DESCRIPTION
## Summary

Move `SupervisorRepository::forget()` to **after** worker processes have stopped, preventing `horizon:purge` from incorrectly killing workers during graceful shutdown.

Fixes #1740

### The problem

`Supervisor::terminate()` removes its entry from the `SupervisorRepository` **before** terminating worker processes. During the shutdown window:

1. `forget()` removes the supervisor from Redis
2. `ProcessInspector::monitoring()` no longer sees this supervisor's PID
3. Worker processes are still running (terminating gracefully)
4. `horizon:purge` computes orphans as `running PIDs - known PIDs`
5. The still-running workers appear as orphans → force-killed with `SIGTERM`/`SIGKILL`

When `fast_termination` is disabled (the default) and jobs take a long time to process, this window can be **minutes** — plenty of time for a purge cycle to run and kill workers mid-job.

This was found during a codebase review. The code comment says "mark this supervisor as terminating" but `forget()` doesn't mark it — it completely removes it, making its workers invisible.

### The fix

Move the `forget()` call to after the wait loop, so workers remain visible to the orphan detection system throughout graceful shutdown:

```php
public function terminate($status = 0)
{
    $this->working = false;

    // Terminate workers first
    $this->processPools->each(function ($pool) { ... });

    // Wait for graceful completion
    if ($this->shouldWait()) { ... }

    // Only then remove from repository
    app(SupervisorRepository::class)->forget($this->name);

    $this->exit($status);
}
```

### Impact

Prevents jobs from being interrupted during graceful shutdown/deployment. The change is a simple reordering — no new code, no behavioral change to the termination sequence itself.