### PR TITLE
Use atomic SET NX EX in Lock::get() to prevent race condition

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -63,13 +63,7 @@ class Lock
      */
     public function get($key, $seconds = 60)
     {
-        $result = $this->connection()->setnx($key, 1);
-
-        if ($result === 1) {
-            $this->connection()->expire($key, $seconds);
-        }
-
-        return $result === 1;
+        return $this->connection()->set($key, 1, 'EX', $seconds, 'NX') === true;
     }
 
     /**


### PR DESCRIPTION
SETNX + EXPIRE are two separate commands — if the process dies between them, the lock key persists forever with no TTL, causing a permanent deadlock.
Replace with a single atomic SET NX EX call, which Redis has supported since 2.6.12. This is also how Laravel's own RedisLock::acquire() works.                                      

Fixes #1738