### PR TITLE
Use atomic Lua script for orphaned process cleanup

### DIFF
--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -36,6 +36,40 @@ LUA;
     }
 
     /**
+     * Atomically update the orphaned process hash.
+     *
+     * KEYS[1] - The name of the orphans hash key
+     * ARGV[1] - The current timestamp
+     * ARGV[2...] - The process IDs to record as orphaned
+     *
+     * @return string
+     */
+    public static function orphaned()
+    {
+        return <<<'LUA'
+            local key = KEYS[1]
+            local time = ARGV[1]
+
+            local existing = redis.call('hkeys', key)
+
+            local active = {}
+            for i = 2, #ARGV do
+                active[ARGV[i]] = true
+            end
+
+            for _, field in ipairs(existing) do
+                if not active[field] then
+                    redis.call('hdel', key, field)
+                end
+            end
+
+            for i = 2, #ARGV do
+                redis.call('hsetnx', key, ARGV[i], time)
+            end
+LUA;
+    }
+
+    /**
      * Get the Lua script for purging recent and pending jobs off of the queue.
      *
      * KEYS[1] - The name of the recent jobs sorted set

--- a/src/Repositories/RedisProcessRepository.php
+++ b/src/Repositories/RedisProcessRepository.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon\Repositories;
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Laravel\Horizon\Contracts\ProcessRepository;
+use Laravel\Horizon\LuaScripts;
 
 class RedisProcessRepository implements ProcessRepository
 {
@@ -50,19 +51,13 @@ class RedisProcessRepository implements ProcessRepository
     {
         $time = CarbonImmutable::now()->getTimestamp();
 
-        $shouldRemove = array_diff($this->connection()->hkeys(
-            $key = "{$master}:orphans"
-        ), $processIds);
-
-        if (! empty($shouldRemove)) {
-            $this->connection()->hdel($key, ...$shouldRemove);
-        }
-
-        $this->connection()->pipeline(function ($pipe) use ($key, $time, $processIds) {
-            foreach ($processIds as $processId) {
-                $pipe->hsetnx($key, $processId, $time);
-            }
-        });
+        $this->connection()->eval(
+            LuaScripts::orphaned(),
+            1,
+            "{$master}:orphans",
+            $time,
+            ...$processIds
+        );
     }
 
     /**

--- a/tests/Feature/ProcessRepositoryTest.php
+++ b/tests/Feature/ProcessRepositoryTest.php
@@ -2,17 +2,25 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\ProcessRepository;
 use Laravel\Horizon\Tests\IntegrationTest;
 
 class ProcessRepositoryTest extends IntegrationTest
 {
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+
+        parent::tearDown();
+    }
+
     public function test_expired_orphans_can_be_found()
     {
         $repo = resolve(ProcessRepository::class);
 
         $repo->orphaned('foo', [1, 2, 3, 4, 5, 6]);
-        sleep(2);
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(2));
         $repo->orphaned('foo', [1, 2, 3]);
 
         $orphans = $repo->orphanedFor('foo', 1);
@@ -71,7 +79,7 @@ class ProcessRepositoryTest extends IntegrationTest
         $firstOrphans = $repo->allOrphans('master');
         $originalTimestamp = $firstOrphans['pid:1'];
 
-        sleep(2);
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(2));
 
         // Second call with the same processes should NOT update existing timestamps (hsetnx)
         $repo->orphaned('master', ['pid:1', 'pid:2']);
@@ -101,7 +109,7 @@ class ProcessRepositoryTest extends IntegrationTest
         // Initial set of processes
         $repo->orphaned('master', ['pid:1', 'pid:2', 'pid:3']);
 
-        sleep(1);
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(1));
 
         // New call: pid:2 still orphaned, pid:1 and pid:3 recovered, pid:4 newly orphaned
         $repo->orphaned('master', ['pid:2', 'pid:4']);

--- a/tests/Feature/ProcessRepositoryTest.php
+++ b/tests/Feature/ProcessRepositoryTest.php
@@ -27,4 +27,97 @@ class ProcessRepositoryTest extends IntegrationTest
         $repo->forgetOrphans('foo', [1, 2, 3]);
         $this->assertEquals([], $repo->allOrphans('foo'));
     }
+
+    public function test_orphaned_lua_script_adds_new_processes()
+    {
+        $repo = resolve(ProcessRepository::class);
+
+        $repo->orphaned('master', ['pid:1', 'pid:2', 'pid:3']);
+
+        $orphans = $repo->allOrphans('master');
+
+        $this->assertCount(3, $orphans);
+        $this->assertArrayHasKey('pid:1', $orphans);
+        $this->assertArrayHasKey('pid:2', $orphans);
+        $this->assertArrayHasKey('pid:3', $orphans);
+    }
+
+    public function test_orphaned_lua_script_removes_stale_processes()
+    {
+        $repo = resolve(ProcessRepository::class);
+
+        // First call records 5 processes
+        $repo->orphaned('master', ['pid:1', 'pid:2', 'pid:3', 'pid:4', 'pid:5']);
+        $this->assertCount(5, $repo->allOrphans('master'));
+
+        // Second call with only 2 processes should remove the other 3
+        $repo->orphaned('master', ['pid:2', 'pid:4']);
+
+        $orphans = $repo->allOrphans('master');
+        $this->assertCount(2, $orphans);
+        $this->assertArrayHasKey('pid:2', $orphans);
+        $this->assertArrayHasKey('pid:4', $orphans);
+        $this->assertArrayNotHasKey('pid:1', $orphans);
+        $this->assertArrayNotHasKey('pid:3', $orphans);
+        $this->assertArrayNotHasKey('pid:5', $orphans);
+    }
+
+    public function test_orphaned_lua_script_preserves_original_timestamps()
+    {
+        $repo = resolve(ProcessRepository::class);
+
+        // First call records processes with an initial timestamp
+        $repo->orphaned('master', ['pid:1', 'pid:2']);
+        $firstOrphans = $repo->allOrphans('master');
+        $originalTimestamp = $firstOrphans['pid:1'];
+
+        sleep(2);
+
+        // Second call with the same processes should NOT update existing timestamps (hsetnx)
+        $repo->orphaned('master', ['pid:1', 'pid:2']);
+        $secondOrphans = $repo->allOrphans('master');
+
+        $this->assertSame($originalTimestamp, $secondOrphans['pid:1']);
+        $this->assertSame($firstOrphans['pid:2'], $secondOrphans['pid:2']);
+    }
+
+    public function test_orphaned_lua_script_handles_empty_process_list()
+    {
+        $repo = resolve(ProcessRepository::class);
+
+        // First populate some orphans
+        $repo->orphaned('master', ['pid:1', 'pid:2']);
+        $this->assertCount(2, $repo->allOrphans('master'));
+
+        // Calling with empty list should remove all existing entries
+        $repo->orphaned('master', []);
+        $this->assertCount(0, $repo->allOrphans('master'));
+    }
+
+    public function test_orphaned_lua_script_adds_new_and_removes_stale_atomically()
+    {
+        $repo = resolve(ProcessRepository::class);
+
+        // Initial set of processes
+        $repo->orphaned('master', ['pid:1', 'pid:2', 'pid:3']);
+
+        sleep(1);
+
+        // New call: pid:2 still orphaned, pid:1 and pid:3 recovered, pid:4 newly orphaned
+        $repo->orphaned('master', ['pid:2', 'pid:4']);
+
+        $orphans = $repo->allOrphans('master');
+
+        // pid:1 and pid:3 should be removed
+        $this->assertArrayNotHasKey('pid:1', $orphans);
+        $this->assertArrayNotHasKey('pid:3', $orphans);
+
+        // pid:2 should still exist with its original timestamp
+        $this->assertArrayHasKey('pid:2', $orphans);
+
+        // pid:4 should be newly added
+        $this->assertArrayHasKey('pid:4', $orphans);
+
+        $this->assertCount(2, $orphans);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1750.

Replaces the non-atomic `HKEYS` → `array_diff` → `HDEL` pattern in `RedisProcessRepository::orphaned()` with a single atomic Lua script, preventing orphaned processes from being missed during cleanup when concurrent `horizon:purge` commands overlap.

### The problem

The existing implementation uses three separate Redis commands:

1. `HKEYS` — read all current orphan keys
2. `array_diff` (PHP) — compute which to remove
3. `HDEL` — delete stale entries

Between steps 1 and 3, another process can modify the hash, causing entries to be incorrectly deleted or timestamps to be reset via `HSETNX`. This occurs when:

- `horizon:purge` is scheduled via cron without `withoutOverlapping()` protection
- Multiple servers run `horizon:purge` against the same Redis in multi-server deployments

### The fix

A Lua script (`LuaScripts::orphaned()`) that atomically reads the current hash, deletes entries not in the incoming process list, and adds new entries via `HSETNX` — all in a single `EVAL`. This follows the existing pattern used by `LuaScripts::updateMetrics()`.

### Changes

- **`src/LuaScripts.php`** — Added `orphaned()` Lua script
- **`src/Repositories/RedisProcessRepository.php`** — Replaced the three-step pattern with a single `eval()` call

## Test plan

- Deploy with multiple servers running `horizon:purge` against the same Redis and verify no orphaned processes are missed during concurrent cleanup
- Verify the Lua script correctly deletes entries not in the incoming process list
- Verify `HSETNX` behavior is preserved: new entries get timestamps, existing entries keep their original timestamps
- Run `horizon:purge` with a known set of orphaned processes and confirm they are correctly identified and cleaned up
- Confirm no regressions in the existing test suite with `php artisan test`