### PR TITLE
[5.x] Fix RedisMetricsRepository::clear() scan prefix for PhpRedis

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -4,11 +4,13 @@ namespace Laravel\Horizon\Repositories;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Lock;
 use Laravel\Horizon\LuaScripts;
 use Laravel\Horizon\WaitTimeCalculator;
+use Redis;
 
 class RedisMetricsRepository implements MetricsRepository
 {
@@ -392,12 +394,21 @@ class RedisMetricsRepository implements MetricsRepository
         $this->forget('measured_queues');
         $this->forget('metrics:snapshot');
 
+        $connection = $this->connection();
+
+        $scanPrefixEnabled = $connection instanceof PhpRedisConnection
+            && defined('Redis::OPT_SCAN')
+            && defined('Redis::SCAN_PREFIX')
+            && ((int) $connection->client()->getOption(Redis::OPT_SCAN) & Redis::SCAN_PREFIX);
+
+        $prefix = $scanPrefixEnabled ? '' : config('horizon.prefix');
+
         foreach (['queue:*', 'job:*', 'snapshot:*'] as $pattern) {
             $cursor = null;
 
             do {
                 $scanResult = $this->connection()->scan(
-                    $cursor ?? 0, ['match' => config('horizon.prefix').$pattern]
+                    $cursor ?? 0, ['match' => $prefix.$pattern]
                 );
 
                 if (! is_array($scanResult)) {

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -221,4 +221,32 @@ class MetricsTest extends IntegrationTest
 
         CarbonImmutable::setTestNow();
     }
+
+    public function test_clear_removes_all_metrics()
+    {
+        $stopwatch = Mockery::mock(Stopwatch::class);
+        $stopwatch->shouldReceive('start');
+        $stopwatch->shouldReceive('check')->andReturn(1);
+        $this->app->instance(Stopwatch::class, $stopwatch);
+
+        Queue::push(new Jobs\BasicJob);
+        $this->work();
+
+        CarbonImmutable::setTestNow(CarbonImmutable::now());
+        resolve(MetricsRepository::class)->snapshot();
+
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->measuredJobs());
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->measuredQueues());
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class));
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->snapshotsForQueue('default'));
+
+        resolve(MetricsRepository::class)->clear();
+
+        $this->assertEmpty(resolve(MetricsRepository::class)->measuredJobs());
+        $this->assertEmpty(resolve(MetricsRepository::class)->measuredQueues());
+        $this->assertEmpty(resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class));
+        $this->assertEmpty(resolve(MetricsRepository::class)->snapshotsForQueue('default'));
+
+        CarbonImmutable::setTestNow();
+    }
 }


### PR DESCRIPTION
`RedisMetricsRepository::clear()` prepends `config('horizon.prefix')` to the SCAN match pattern manually. When PhpRedis has `SCAN_PREFIX` enabled the driver adds the prefix again, so the pattern matches nothing and no keys are deleted.

Check `OPT_SCAN` at runtime and skip the manual prefix when `SCAN_PREFIX` is active.

Fixes #1746