### PR TITLE
[5.x] Replace sleep() with Carbon time travel in ProcessRepositoryTest

### DIFF
--- a/tests/Feature/ProcessRepositoryTest.php
+++ b/tests/Feature/ProcessRepositoryTest.php
@@ -2,17 +2,25 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
+use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\ProcessRepository;
 use Laravel\Horizon\Tests\IntegrationTest;
 
 class ProcessRepositoryTest extends IntegrationTest
 {
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow();
+
+        parent::tearDown();
+    }
+
     public function test_expired_orphans_can_be_found()
     {
         $repo = resolve(ProcessRepository::class);
 
         $repo->orphaned('foo', [1, 2, 3, 4, 5, 6]);
-        sleep(2);
+        CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(2));
         $repo->orphaned('foo', [1, 2, 3]);
 
         $orphans = $repo->orphanedFor('foo', 1);


### PR DESCRIPTION
## Summary

- Replaces `sleep(2)` with `CarbonImmutable::setTestNow()` in `ProcessRepositoryTest::test_expired_orphans_can_be_found`
- The underlying `RedisProcessRepository::orphaned()` and `orphanedFor()` methods use `CarbonImmutable::now()->getTimestamp()`, so Carbon time travel works correctly here

## Problem

The test uses a real `sleep(2)` to wait for orphan expiry time to pass. On slow CI runners, this is both:
1. **Flaky** — if the CI machine is under load, the 2-second margin may not be sufficient for the 1-second expiry window check
2. **Slow** — adds 2 seconds of wall-clock time to every test run unnecessarily

## Solution

Replace `sleep(2)` with `CarbonImmutable::setTestNow(CarbonImmutable::now()->addSeconds(2))` to simulate time passing without actually waiting. Added `tearDown()` to reset Carbon state.

## Test plan

- [x] Both ProcessRepositoryTest tests pass locally
- [x] Confirmed `orphaned()` and `orphanedFor()` both use `CarbonImmutable::now()` (not Redis TTL)
- [x] Carbon state properly cleaned up in tearDown

🤖 Generated with [Claude Code](https://claude.com/claude-code)