### PR TITLE
[5.x] Pass `$later` in `RedisQueue@later()`

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -108,7 +108,7 @@ class RedisQueue extends BaseQueue
     #[\Override]
     public function later($delay, $job, $data = '', $queue = null)
     {
-        $payload = (new JobPayload($this->createPayload($job, $queue, $data)))->prepare($job)->value;
+        $payload = (new JobPayload($this->createPayload($job, $queue, $data, $delay)))->prepare($job)->value;
 
         if (method_exists($this, 'enqueueUsing')) {
             return $this->enqueueUsing(


### PR DESCRIPTION
This stores stores job delay in the payload when dispatching a job with a delay. Storing the job delay was added in https://github.com/laravel/framework/pull/55529 but Horizon was never updated to account for this.

I'm building some job middleware to monitor queue latency and time to complete. Using framework provided queue workers, I can determine how long the job was delayed for. With Horizon, delay is always null. This is important because I need to subtract intentional delay from the queue latency. As it exists right now, measures report queue latency as delay time + actual queue latency.