### PR TITLE
Fix horizon:clear-metrics not clearing metric keys

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -4,7 +4,6 @@ namespace Laravel\Horizon\Repositories;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
-use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Lock;
 use Laravel\Horizon\LuaScripts;
@@ -387,29 +386,22 @@ class RedisMetricsRepository implements MetricsRepository
      */
     public function clear()
     {
+        $jobs = $this->measuredJobs();
+        $queues = $this->measuredQueues();
+
         $this->forget('last_snapshot_at');
         $this->forget('measured_jobs');
         $this->forget('measured_queues');
         $this->forget('metrics:snapshot');
 
-        foreach (['queue:*', 'job:*', 'snapshot:*'] as $pattern) {
-            $cursor = null;
+        foreach ($jobs as $job) {
+            $this->forget('job:'.$job);
+            $this->forget('snapshot:job:'.$job);
+        }
 
-            do {
-                $scanResult = $this->connection()->scan(
-                    $cursor ?? 0, ['match' => config('horizon.prefix').$pattern]
-                );
-
-                if (! is_array($scanResult)) {
-                    break;
-                }
-
-                [$cursor, $keys] = $scanResult;
-
-                foreach ($keys ?? [] as $key) {
-                    $this->forget(Str::after($key, config('horizon.prefix')));
-                }
-            } while ($cursor > 0);
+        foreach ($queues as $queue) {
+            $this->forget('queue:'.$queue);
+            $this->forget('snapshot:queue:'.$queue);
         }
     }
 

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -221,4 +221,32 @@ class MetricsTest extends IntegrationTest
 
         CarbonImmutable::setTestNow();
     }
+
+    public function test_clear_removes_all_metric_keys()
+    {
+        $stopwatch = Mockery::mock(Stopwatch::class);
+        $stopwatch->shouldReceive('start');
+        $stopwatch->shouldReceive('check')->andReturn(1);
+        $this->app->instance(Stopwatch::class, $stopwatch);
+
+        Queue::push(new Jobs\BasicJob);
+        $this->work();
+
+        // Sanity check: live metric hashes are recorded before snapshot.
+        $this->assertSame(1, resolve(MetricsRepository::class)->throughput());
+
+        resolve(MetricsRepository::class)->snapshot();
+
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->measuredJobs());
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->measuredQueues());
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class));
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->snapshotsForQueue('default'));
+
+        resolve(MetricsRepository::class)->clear();
+
+        $this->assertEmpty(resolve(MetricsRepository::class)->measuredJobs());
+        $this->assertEmpty(resolve(MetricsRepository::class)->measuredQueues());
+        $this->assertEmpty(resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class));
+        $this->assertEmpty(resolve(MetricsRepository::class)->snapshotsForQueue('default'));
+    }
 }


### PR DESCRIPTION
The previous implementation used SCAN with a manually prefixed match pattern. When PhpRedis is configured with Redis::OPT_SCAN = SCAN_PREFIX, the connection auto-prepends the prefix to scan patterns, so manually adding it produced a double-prefix (horizon:horizon:queue:*) that matched nothing and silently left every metric key in place.

Avoid SCAN entirely: Horizon already tracks every metric key in the measured_jobs and measured_queues Redis sets. Enumerate them directly and delete each metric hash and its snapshot zset by name. The result is deterministic, prefix-agnostic, and also clears the per-job snapshot charts (/horizon/metrics/jobs/<JobName>) that previously lingered after clear-metrics.

Fixes #1746

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
