### PR TITLE
Fix null hmget response in baseSnapshotData

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -324,6 +324,10 @@ class RedisMetricsRepository implements MetricsRepository
             $trans->del($key);
         });
 
+        if (! is_array($responses[0])) {
+            return ['throughput' => null, 'runtime' => null];
+        }
+
         $snapshot = array_values($responses[0]);
 
         return [

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon\Tests\Feature;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Queue;
 use Laravel\Horizon\Contracts\MetricsRepository;
+use Laravel\Horizon\Repositories\RedisMetricsRepository;
 use Laravel\Horizon\Stopwatch;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Mockery;
@@ -190,6 +191,24 @@ class MetricsTest extends IntegrationTest
         $this->assertSame(
             0.0, resolve(MetricsRepository::class)->jobsProcessedPerMinute()
         );
+    }
+
+    public function test_snapshot_does_not_fail_when_hmget_returns_null()
+    {
+        $connection = Mockery::mock();
+        $connection->shouldReceive('smembers')->with('measured_jobs')->andReturn(['job:Foo']);
+        $connection->shouldReceive('smembers')->with('measured_queues')->andReturn([]);
+        $connection->shouldReceive('transaction')->andReturn([null, 0]);
+        $connection->shouldReceive('zadd');
+        $connection->shouldReceive('zremrangebyrank');
+        $connection->shouldReceive('set');
+
+        $repository = Mockery::mock(RedisMetricsRepository::class.'[connection]', [app('redis')]);
+        $repository->shouldReceive('connection')->andReturn($connection);
+
+        $repository->snapshot();
+
+        $this->assertTrue(true);
     }
 
     public function test_only_past_24_snapshots_are_retained()


### PR DESCRIPTION
## Problem

Running `php artisan horizon:snapshot` throws a TypeError when a measured job/queue exists in the `measured_jobs` / `measured_queues` set but its hash is missing from Redis on (fresh install, evicted keys, expired data, etc). Inside the transaction, `hmget` returns null instead of an array, so `array_values()` blows up.

```
TypeError artisan horizon:snapshot
array_values(): Argument #1 ($array) must be of type array, null given

    vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php:327 array_values
    vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php:327 Laravel\Horizon\Repositories\RedisMetricsRepository::baseSnapshotData
    vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php:274 Laravel\Horizon\Repositories\RedisMetricsRepository::storeSnapshotForJob
    vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php:256 Laravel\Horizon\Repositories\RedisMetricsRepository::{closure:Laravel\Horizon\Repositories\RedisMetricsRepository::snapshot():255}
    vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php:235 Illuminate\Support\Collection::each
    vendor/laravel/horizon/src/Repositories/RedisMetricsRepository.php:255 Laravel\Horizon\Repositories\RedisMetricsRepository::snapshot
    vendor/laravel/horizon/src/Console/SnapshotCommand.php:37 Laravel\Horizon\Console\SnapshotCommand::handle
    vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36 Illuminate\Container\BoundMethod::{closure:Illuminate\Container\BoundMethod::call():35}
    vendor/laravel/framework/src/Illuminate/Container/Util.php:41 Illuminate\Container\Util::unwrapIfClosure
    vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:93 Illuminate\Container\BoundMethod::callBoundMethod
    vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:35 Illuminate\Container\BoundMethod::call
    vendor/laravel/framework/src/Illuminate/Container/Container.php:661 Illuminate\Container\Container::call
    vendor/laravel/framework/src/Illuminate/Console/Command.php:183 Illuminate\Console\Command::execute
    vendor/symfony/console/Command/Command.php:326 Symfony\Component\Console\Command\Command::run
    vendor/laravel/framework/src/Illuminate/Console/Command.php:152 Illuminate\Console\Command::run
    vendor/symfony/console/Application.php:1083 Symfony\Component\Console\Application::doRunCommand
    vendor/symfony/console/Application.php:324 Symfony\Component\Console\Application::doRun
    vendor/symfony/console/Application.php:175 Symfony\Component\Console\Application::run
    vendor/laravel/framework/src/Illuminate/Console/Application.php:102 Illuminate\Console\Application::run
    vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:155 Illuminate\Foundation\Console\Kernel::handle
    artisan:35 [main]
```

## Fix

Check if `$responses[0]` is an array before passing it to `array_values()`. If not, return nulls early, downstream already handles that fine.

## Test

Added a test in `MetricsTest` that mocks the connection so `hmget` returns null, then calls `snapshot()`. Without the fix it throws the same TypeError, with the fix it passes.