### PR TITLE
fix: use atomic SET NX EX for locks to prevent permanent deadlocks

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -63,13 +63,7 @@ class Lock
      */
     public function get($key, $seconds = 60)
     {
-        $result = $this->connection()->setnx($key, 1);
-
-        if ($result === 1) {
-            $this->connection()->expire($key, $seconds);
-        }
-
-        return $result === 1;
+        return $this->connection()->set($key, 1, 'EX', $seconds, 'NX') == true;
     }
 
     /**


### PR DESCRIPTION
### Description

`Lock::get()` currently uses `SETNX` followed by a separate `EXPIRE` command. If the process crashes between these two commands, the lock key persists forever with no TTL, creating a permanent deadlock.

### Fix

Replace the non-atomic `SETNX` + `EXPIRE` with a single atomic `SET key value EX seconds NX` command, matching the pattern used by Laravel\s own `RedisLock::acquire()` in the framework. This also reduces Redis round-trips from 2 to 1.

### Related Issue

Closes #1738