### PR TITLE
Fix metric clearing with PhpRedis scan prefix

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -402,7 +402,7 @@ class RedisMetricsRepository implements MetricsRepository
 
             do {
                 $scanResult = $this->connection()->scan(
-                    $cursor ?? 0, ['match' => $this->scanMatchPattern($pattern)]
+                    $cursor ?? 0, ['match' => $this->snapshotPatternToMatch($pattern)]
                 );
 
                 if (! is_array($scanResult)) {
@@ -424,7 +424,7 @@ class RedisMetricsRepository implements MetricsRepository
      * @param  string  $pattern
      * @return string
      */
-    protected function scanMatchPattern($pattern)
+    protected function snapshotPatternToMatch($pattern)
     {
         return $this->usesPhpRedisScanPrefix()
             ? $pattern

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -9,6 +9,7 @@ use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Lock;
 use Laravel\Horizon\LuaScripts;
 use Laravel\Horizon\WaitTimeCalculator;
+use Throwable;
 
 class RedisMetricsRepository implements MetricsRepository
 {
@@ -401,7 +402,7 @@ class RedisMetricsRepository implements MetricsRepository
 
             do {
                 $scanResult = $this->connection()->scan(
-                    $cursor ?? 0, ['match' => config('horizon.prefix').$pattern]
+                    $cursor ?? 0, ['match' => $this->scanMatchPattern($pattern)]
                 );
 
                 if (! is_array($scanResult)) {
@@ -414,6 +415,49 @@ class RedisMetricsRepository implements MetricsRepository
                     $this->forget(Str::after($key, config('horizon.prefix')));
                 }
             } while ($cursor > 0);
+        }
+    }
+
+    /**
+     * Get the Redis SCAN match pattern for the given metric pattern.
+     *
+     * @param  string  $pattern
+     * @return string
+     */
+    protected function scanMatchPattern($pattern)
+    {
+        return $this->usesPhpRedisScanPrefix()
+            ? $pattern
+            : config('horizon.prefix').$pattern;
+    }
+
+    /**
+     * Determine if PhpRedis prefixes SCAN patterns itself.
+     *
+     * @return bool
+     */
+    protected function usesPhpRedisScanPrefix()
+    {
+        if (! defined('Redis::OPT_SCAN') || ! defined('Redis::SCAN_PREFIX')) {
+            return false;
+        }
+
+        $connection = $this->connection();
+
+        if (! method_exists($connection, 'client')) {
+            return false;
+        }
+
+        $client = $connection->client();
+
+        if (! is_object($client) || ! method_exists($client, 'getOption')) {
+            return false;
+        }
+
+        try {
+            return (int) $client->getOption(\Redis::OPT_SCAN) === \Redis::SCAN_PREFIX;
+        } catch (Throwable) {
+            return false;
         }
     }
 

--- a/tests/Unit/RedisMetricsRepositoryTest.php
+++ b/tests/Unit/RedisMetricsRepositoryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Laravel\Horizon\Repositories\RedisMetricsRepository;
+use Laravel\Horizon\Tests\UnitTest;
+use Mockery;
+
+class RedisMetricsRepositoryTest extends UnitTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = new Container;
+        $container->instance('config', new ConfigRepository([
+            'horizon.prefix' => 'horizon:',
+        ]));
+
+        Container::setInstance($container);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        parent::tearDown();
+    }
+
+    public function test_clear_scans_prefixed_metric_patterns_by_default()
+    {
+        $repository = $this->redisMetricsRepositoryWithConnection(
+            $this->connectionForClearingMetrics([
+                'horizon:queue:*',
+                'horizon:job:*',
+                'horizon:snapshot:*',
+            ])
+        );
+
+        $repository->clear();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_clear_uses_raw_metric_patterns_when_phpredis_scan_prefix_is_enabled()
+    {
+        $repository = $this->redisMetricsRepositoryWithConnection(
+            $this->connectionForClearingMetrics([
+                'queue:*',
+                'job:*',
+                'snapshot:*',
+            ]),
+            true
+        );
+
+        $repository->clear();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_phpredis_scan_prefix_option_is_detected()
+    {
+        if (! defined('Redis::SCAN_PREFIX')) {
+            $this->markTestSkipped('The redis extension is required.');
+        }
+
+        $repository = $this->redisMetricsRepositoryDetectingScanPrefix(
+            $this->connectionWithPhpRedisScanOption(\Redis::SCAN_PREFIX)
+        );
+
+        $this->assertTrue($repository->detectsPhpRedisScanPrefix());
+    }
+
+    public function test_other_phpredis_scan_options_are_not_detected_as_scan_prefix()
+    {
+        if (! defined('Redis::SCAN_PREFIX') || ! defined('Redis::SCAN_NOPREFIX')) {
+            $this->markTestSkipped('The redis extension is required.');
+        }
+
+        $repository = $this->redisMetricsRepositoryDetectingScanPrefix(
+            $this->connectionWithPhpRedisScanOption(\Redis::SCAN_NOPREFIX)
+        );
+
+        $this->assertFalse($repository->detectsPhpRedisScanPrefix());
+    }
+
+    protected function connectionForClearingMetrics(array $patterns)
+    {
+        $connection = Mockery::mock();
+
+        foreach (['last_snapshot_at', 'measured_jobs', 'measured_queues', 'metrics:snapshot'] as $key) {
+            $connection->shouldReceive('del')->once()->with($key);
+        }
+
+        foreach ($patterns as $pattern) {
+            $connection->shouldReceive('scan')->once()->with(0, ['match' => $pattern])->andReturn([0, []]);
+        }
+
+        return $connection;
+    }
+
+    protected function connectionWithPhpRedisScanOption($option)
+    {
+        return new class($option)
+        {
+            public $option;
+
+            public function __construct($option)
+            {
+                $this->option = $option;
+            }
+
+            public function client()
+            {
+                return new class($this->option)
+                {
+                    public $option;
+
+                    public function __construct($option)
+                    {
+                        $this->option = $option;
+                    }
+
+                    public function getOption($option)
+                    {
+                        return $this->option;
+                    }
+                };
+            }
+        };
+    }
+
+    protected function redisMetricsRepositoryWithConnection($connection, $usesPhpRedisScanPrefix = false)
+    {
+        return new class(Mockery::mock(RedisFactory::class), $connection, $usesPhpRedisScanPrefix) extends RedisMetricsRepository
+        {
+            public $connection;
+
+            public $usesPhpRedisScanPrefix;
+
+            public function __construct($redis, $connection, $usesPhpRedisScanPrefix)
+            {
+                parent::__construct($redis);
+
+                $this->connection = $connection;
+                $this->usesPhpRedisScanPrefix = $usesPhpRedisScanPrefix;
+            }
+
+            public function connection()
+            {
+                return $this->connection;
+            }
+
+            protected function usesPhpRedisScanPrefix()
+            {
+                return $this->usesPhpRedisScanPrefix;
+            }
+        };
+    }
+
+    protected function redisMetricsRepositoryDetectingScanPrefix($connection)
+    {
+        return new class(Mockery::mock(RedisFactory::class), $connection) extends RedisMetricsRepository
+        {
+            public $connection;
+
+            public function __construct($redis, $connection)
+            {
+                parent::__construct($redis);
+
+                $this->connection = $connection;
+            }
+
+            public function connection()
+            {
+                return $this->connection;
+            }
+
+            public function detectsPhpRedisScanPrefix()
+            {
+                return $this->usesPhpRedisScanPrefix();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #1746 when PhpRedis `SCAN_PREFIX` is enabled.

When PhpRedis has `Redis::OPT_SCAN` set to `Redis::SCAN_PREFIX`, it automatically prepends the configured Redis prefix to `SCAN MATCH` patterns. Horizon was also prepending `config('horizon.prefix')`, so `horizon:clear-metrics` could scan for double-prefixed metric keys and leave the stored snapshots behind.

This keeps the existing prefixed scan behavior by default, but uses raw metric patterns when PhpRedis is configured to prefix scan patterns itself.

Tests:
- `php -l src\Repositories\RedisMetricsRepository.php`
- `php -l tests\Unit\RedisMetricsRepositoryTest.php`
- `vendor\bin\phpunit.bat tests\Unit`
- `vendor\bin\phpstan.bat analyse --memory-limit=1G`

Note: two ext-redis-specific unit assertions skip locally because this Windows PHP build does not have ext-redis loaded.