### PR TITLE
Drain Horizon commands atomically

### DIFF
--- a/src/LuaScripts.php
+++ b/src/LuaScripts.php
@@ -5,6 +5,26 @@ namespace Laravel\Horizon;
 class LuaScripts
 {
     /**
+     * Get the Lua script for atomically draining pending commands.
+     *
+     * KEYS[1] - The name of the command queue
+     *
+     * @return string
+     */
+    public static function pendingCommands()
+    {
+        return <<<'LUA'
+            local commands = redis.call('lrange', KEYS[1], 0, -1)
+
+            if #commands > 0 then
+                redis.call('del', KEYS[1])
+            end
+
+            return commands
+LUA;
+    }
+
+    /**
      * Update the metrics for a job.
      *
      * KEYS[1] - The name of the key being updated

--- a/src/RedisHorizonCommandQueue.php
+++ b/src/RedisHorizonCommandQueue.php
@@ -4,12 +4,9 @@ namespace Laravel\Horizon;
 
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
 use Laravel\Horizon\Contracts\HorizonCommandQueue;
-use Laravel\Horizon\Repositories\UsesClusterAwarePipeline;
 
 class RedisHorizonCommandQueue implements HorizonCommandQueue
 {
-    use UsesClusterAwarePipeline;
-
     /**
      * The Redis connection instance.
      *
@@ -52,19 +49,9 @@ class RedisHorizonCommandQueue implements HorizonCommandQueue
      */
     public function pending($name)
     {
-        $length = $this->connection()->llen('commands:'.$name);
-
-        if ($length < 1) {
-            return [];
-        }
-
-        $results = $this->pipeline(function ($pipe) use ($name, $length) {
-            $pipe->lrange('commands:'.$name, 0, $length - 1);
-
-            $pipe->ltrim('commands:'.$name, $length, -1);
-        });
-
-        return collect($results[0])
+        return collect($this->connection()->eval(
+            LuaScripts::pendingCommands(), 1, 'commands:'.$name
+        ))
             ->map(fn ($result) => (object) json_decode($result, true))
             ->all();
     }

--- a/tests/Unit/RedisHorizonCommandQueueTest.php
+++ b/tests/Unit/RedisHorizonCommandQueueTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Laravel\Horizon\RedisHorizonCommandQueue;
+use Laravel\Horizon\Tests\UnitTest;
+
+class RedisHorizonCommandQueueTest extends UnitTest
+{
+    public function test_pending_commands_are_drained_atomically()
+    {
+        $connection = new CommandQueueFakeRedisConnection;
+        $queue = new RedisHorizonCommandQueue(new CommandQueueFakeRedisFactory($connection));
+
+        $queue->push('supervisor', FirstCommand::class, ['name' => 'first']);
+
+        $connection->afterDrain(function () use ($queue) {
+            $queue->push('supervisor', SecondCommand::class, ['name' => 'second']);
+        });
+
+        $pending = $queue->pending('supervisor');
+
+        $this->assertCount(1, $pending);
+        $this->assertSame(FirstCommand::class, $pending[0]->command);
+        $this->assertSame(['name' => 'first'], $pending[0]->options);
+
+        $pending = $queue->pending('supervisor');
+
+        $this->assertCount(1, $pending);
+        $this->assertSame(SecondCommand::class, $pending[0]->command);
+        $this->assertSame(['name' => 'second'], $pending[0]->options);
+    }
+}
+
+class CommandQueueFakeRedisFactory implements RedisFactory
+{
+    public function __construct(public CommandQueueFakeRedisConnection $connection)
+    {
+    }
+
+    public function connection($name = null)
+    {
+        return $this->connection;
+    }
+}
+
+class CommandQueueFakeRedisConnection
+{
+    public array $commands = [];
+
+    public $afterDrain;
+
+    public function afterDrain(callable $callback)
+    {
+        $this->afterDrain = $callback;
+    }
+
+    public function rpush($key, $value)
+    {
+        $this->commands[$key][] = $value;
+    }
+
+    public function eval($script, $numberOfKeys, $key)
+    {
+        $commands = $this->commands[$key] ?? [];
+
+        if (count($commands) > 0) {
+            unset($this->commands[$key]);
+        }
+
+        if ($this->afterDrain) {
+            $callback = $this->afterDrain;
+            $this->afterDrain = null;
+
+            $callback();
+        }
+
+        return $commands;
+    }
+
+    public function lrange($key, $start, $stop)
+    {
+        $commands = $this->commands[$key] ?? [];
+
+        if ($this->afterDrain) {
+            $callback = $this->afterDrain;
+            $this->afterDrain = null;
+
+            $callback();
+        }
+
+        return $commands;
+    }
+
+    public function del($key)
+    {
+        unset($this->commands[$key]);
+    }
+}
+
+class FirstCommand
+{
+}
+
+class SecondCommand
+{
+}


### PR DESCRIPTION
Fixes #1739.

`RedisHorizonCommandQueue::pending()` previously used `LLEN` followed by a pipelined `LRANGE` and `LTRIM`. A command pushed after the range was read but before the trim could be removed without ever being returned.

This drains the command list with a single Lua script so Redis reads and clears the current commands atomically. Commands pushed after the script runs remain in the list for the next loop.

Tests run:

- `php -l src/LuaScripts.php`
- `php -l src/RedisHorizonCommandQueue.php`
- `php -l tests/Unit/RedisHorizonCommandQueueTest.php`
- `php vendor/bin/phpunit tests/Unit/RedisHorizonCommandQueueTest.php`
- `php vendor/bin/phpstan analyse src/LuaScripts.php src/RedisHorizonCommandQueue.php tests/Unit/RedisHorizonCommandQueueTest.php --memory-limit=1G`

Not run: the existing supervisor feature command-loop tests require a Redis server on `127.0.0.1:6379`; my local environment does not have Redis running there.