### PR TITLE
Scope wait time monitoring by connection

### DIFF
--- a/src/Contracts/MetricsRepository.php
+++ b/src/Contracts/MetricsRepository.php
@@ -122,9 +122,10 @@ interface MetricsRepository
     /**
      * Attempt to acquire a lock to monitor the queue wait times.
      *
+     * @param  string|null  $connection
      * @return bool
      */
-    public function acquireWaitTimeMonitorLock();
+    public function acquireWaitTimeMonitorLock($connection = null);
 
     /**
      * Clear the metrics for a key.

--- a/src/Listeners/MonitorWaitTimes.php
+++ b/src/Listeners/MonitorWaitTimes.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon\Listeners;
 use Carbon\CarbonImmutable;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\Events\SupervisorLooped;
 use Laravel\Horizon\WaitTimeCalculator;
 
 class MonitorWaitTimes
@@ -37,18 +38,21 @@ class MonitorWaitTimes
     /**
      * Handle the event.
      *
+     * @param  \Laravel\Horizon\Events\SupervisorLooped  $event
      * @return void
      */
-    public function handle()
+    public function handle(SupervisorLooped $event)
     {
-        if (! $this->dueToMonitor()) {
+        $connection = $event->supervisor->options->connection;
+
+        if (! $this->dueToMonitor($connection)) {
             return;
         }
 
         // Here we will calculate the wait time in seconds for each of the queues that
         // the application is working. Then, we will filter the results to find the
         // queues with the longest wait times and raise events for each of these.
-        $results = app(WaitTimeCalculator::class)->calculate();
+        $results = app(WaitTimeCalculator::class)->calculateForConnection($connection);
 
         $long = collect($results)->filter(function ($wait, $queue) {
             return config("horizon.waits.{$queue}") !== 0
@@ -68,18 +72,19 @@ class MonitorWaitTimes
     /**
      * Determine if monitoring is due.
      *
+     * @param  string  $connection
      * @return bool
      */
-    protected function dueToMonitor()
+    protected function dueToMonitor($connection)
     {
         // We will keep track of the amount of time between attempting to acquire the
-        // lock to monitor the wait times. We only want a single supervisor to run
-        // the checks on a given interval so that we don't fire too many events.
+        // lock to monitor the wait times. We only want a single supervisor for each
+        // connection to run the checks on a given interval.
         if (! $this->timeToMonitor()) {
             return false;
         }
 
-        $lock = $this->metrics->acquireWaitTimeMonitorLock();
+        $lock = $this->metrics->acquireWaitTimeMonitorLock($connection);
 
         if (! $lock) {
             return false;

--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -367,11 +367,12 @@ class RedisMetricsRepository implements MetricsRepository
     /**
      * Attempt to acquire a lock to monitor the queue wait times.
      *
+     * @param  string|null  $connection
      * @return bool
      */
-    public function acquireWaitTimeMonitorLock()
+    public function acquireWaitTimeMonitorLock($connection = null)
     {
-        return app(Lock::class)->get('monitor:time-to-clear');
+        return app(Lock::class)->get('monitor:time-to-clear'.($connection ? ':'.$connection : ''));
     }
 
     /**

--- a/src/WaitTimeCalculator.php
+++ b/src/WaitTimeCalculator.php
@@ -60,6 +60,26 @@ class WaitTimeCalculator
     }
 
     /**
+     * Calculate the time to clear per queue for a given connection in seconds.
+     *
+     * @param  string  $connection
+     * @param  string|null  $queue
+     * @return array
+     */
+    public function calculateForConnection($connection, $queue = null)
+    {
+        $supervisors = collect($this->supervisors->all());
+
+        return $this->calculateQueues(
+            $this->queueNames(
+                $supervisors->filter(fn ($supervisor) => $this->connectionFor($supervisor) === $connection),
+                $queue
+            ),
+            $supervisors
+        );
+    }
+
+    /**
      * Calculate the time to clear per queue in seconds.
      *
      * @param  string|null  $queue
@@ -67,10 +87,23 @@ class WaitTimeCalculator
      */
     public function calculate($queue = null)
     {
-        $queues = $this->queueNames(
-            $supervisors = collect($this->supervisors->all()), $queue
-        );
+        $supervisors = collect($this->supervisors->all());
 
+        return $this->calculateQueues(
+            $this->queueNames($supervisors, $queue),
+            $supervisors
+        );
+    }
+
+    /**
+     * Calculate the time to clear for the given queues.
+     *
+     * @param  \Illuminate\Support\Collection  $queues
+     * @param  \Illuminate\Support\Collection  $supervisors
+     * @return array
+     */
+    protected function calculateQueues($queues, $supervisors)
+    {
         return $queues->mapWithKeys(function ($queue) use ($supervisors) {
             $totalProcesses = $this->totalProcessesFor($supervisors, $queue);
 
@@ -92,7 +125,7 @@ class WaitTimeCalculator
      */
     protected function queueNames($supervisors, $queue = null)
     {
-        $queues = $supervisors->map(fn ($supervisor) => array_keys($supervisor->processes))
+        $queues = $supervisors->map(fn ($supervisor) => array_keys($this->processesFor($supervisor)))
             ->collapse()
             ->unique()
             ->values();
@@ -110,8 +143,44 @@ class WaitTimeCalculator
     protected function totalProcessesFor($allSupervisors, $queue)
     {
         return $allSupervisors->sum(function ($supervisor) use ($queue) {
-            return $supervisor->processes[$queue] ?? 0;
+            $processes = $this->processesFor($supervisor);
+
+            return $processes[$queue] ?? 0;
         });
+    }
+
+    /**
+     * Get the queue connection for the given supervisor record.
+     *
+     * @param  object  $supervisor
+     * @return string|null
+     */
+    protected function connectionFor($supervisor)
+    {
+        $options = $supervisor->options ?? null;
+
+        return is_array($options) ? ($options['connection'] ?? null) : ($options->connection ?? null);
+    }
+
+    /**
+     * Get the queue process counts for the given supervisor.
+     *
+     * @param  object  $supervisor
+     * @return array
+     */
+    protected function processesFor($supervisor)
+    {
+        if (isset($supervisor->processes)) {
+            return (array) $supervisor->processes;
+        }
+
+        if (isset($supervisor->processPools, $supervisor->options)) {
+            return collect($supervisor->processPools)
+                ->mapWithKeys(fn ($pool) => [$supervisor->options->connection.':'.$pool->queue() => count($pool->processes())])
+                ->all();
+        }
+
+        return [];
     }
 
     /**

--- a/tests/Feature/MonitorWaitTimesTest.php
+++ b/tests/Feature/MonitorWaitTimesTest.php
@@ -6,7 +6,10 @@ use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Events\LongWaitDetected;
+use Laravel\Horizon\Events\SupervisorLooped;
 use Laravel\Horizon\Listeners\MonitorWaitTimes;
+use Laravel\Horizon\Supervisor;
+use Laravel\Horizon\SupervisorOptions;
 use Laravel\Horizon\Tests\IntegrationTest;
 use Laravel\Horizon\WaitTimeCalculator;
 use Mockery;
@@ -18,15 +21,15 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->shouldReceive('calculate')->andReturn([
+        $calc->shouldReceive('calculateForConnection')->with('redis')->andReturn([
             'redis:test-queue' => 10,
             'redis:test-queue-2' => 80,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
-        $listener = new MonitorWaitTimes(app(MetricsRepository::class));
+        $listener = new MonitorWaitTimes($this->metricsRepositoryAcquiringLock());
 
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertDispatched(LongWaitDetected::class, function ($event) {
             return $event->connection == 'redis' && $event->queue == 'test-queue-2';
@@ -40,14 +43,14 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->andReturn([
+        $calc->expects('calculateForConnection')->with('redis')->andReturn([
             'redis:ignore-queue' => 10,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
-        $listener = new MonitorWaitTimes(app(MetricsRepository::class));
+        $listener = new MonitorWaitTimes($this->metricsRepositoryAcquiringLock());
 
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }
@@ -59,16 +62,16 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->never();
+        $calc->expects('calculateForConnection')->never();
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $metrics = Mockery::mock(MetricsRepository::class);
-        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->andReturnFalse();
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->with('redis')->andReturnFalse();
         $this->app->instance(MetricsRepository::class, $metrics);
 
         $listener = new MonitorWaitTimes($metrics);
 
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }
@@ -80,7 +83,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->never();
+        $calc->expects('calculateForConnection')->never();
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $metrics = Mockery::mock(MetricsRepository::class);
@@ -90,7 +93,7 @@ class MonitorWaitTimesTest extends IntegrationTest
         $listener = new MonitorWaitTimes($metrics);
         $listener->lastMonitored = CarbonImmutable::now(); // Too soon
 
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertNotDispatched(LongWaitDetected::class);
     }
@@ -102,25 +105,25 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->once()->andReturn([
+        $calc->expects('calculateForConnection')->once()->with('redis')->andReturn([
             'redis:default' => 70,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $metrics = Mockery::mock(MetricsRepository::class);
-        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->andReturnTrue();
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->with('redis')->andReturnTrue();
         $this->app->instance(MetricsRepository::class, $metrics);
 
         $listener = new MonitorWaitTimes($metrics);
         $listener->lastMonitored = CarbonImmutable::now(); // Too soon
 
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertNotDispatched(LongWaitDetected::class);
 
         CarbonImmutable::setTestNow(now()->addMinutes(2)); // Simulate time passing
 
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertDispatched(LongWaitDetected::class);
     }
@@ -132,20 +135,36 @@ class MonitorWaitTimesTest extends IntegrationTest
         Event::fake();
 
         $calc = Mockery::mock(WaitTimeCalculator::class);
-        $calc->expects('calculate')->once()->andReturn([
+        $calc->expects('calculateForConnection')->once()->with('redis')->andReturn([
             'redis:default' => 70,
         ]);
         $this->app->instance(WaitTimeCalculator::class, $calc);
 
         $metrics = Mockery::mock(MetricsRepository::class);
-        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->andReturnTrue();
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->with('redis')->andReturnTrue();
         $this->app->instance(MetricsRepository::class, $metrics);
 
         $listener = new MonitorWaitTimes($metrics);
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
         // Call it again to ensure it doesn't execute twice
-        $listener->handle();
+        $listener->handle($this->supervisorLooped());
 
         Event::assertDispatchedTimes(LongWaitDetected::class, 1);
+    }
+
+    protected function metricsRepositoryAcquiringLock()
+    {
+        $metrics = Mockery::mock(MetricsRepository::class);
+        $metrics->shouldReceive('acquireWaitTimeMonitorLock')->once()->with('redis')->andReturnTrue();
+
+        return $metrics;
+    }
+
+    protected function supervisorLooped()
+    {
+        $supervisor = Mockery::mock(Supervisor::class);
+        $supervisor->options = new SupervisorOptions('supervisor', 'redis');
+
+        return new SupervisorLooped($supervisor);
     }
 }

--- a/tests/Unit/RedisMetricsRepositoryTest.php
+++ b/tests/Unit/RedisMetricsRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon\Tests\Unit;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Laravel\Horizon\Lock;
 use Laravel\Horizon\Repositories\RedisMetricsRepository;
 use Laravel\Horizon\Tests\UnitTest;
 use Mockery;
@@ -85,6 +86,17 @@ class RedisMetricsRepositoryTest extends UnitTest
         );
 
         $this->assertFalse($repository->detectsPhpRedisScanPrefix());
+    }
+
+    public function test_wait_time_monitor_lock_is_scoped_by_connection()
+    {
+        $lock = Mockery::mock(Lock::class);
+        $lock->shouldReceive('get')->once()->with('monitor:time-to-clear:redis')->andReturnTrue();
+        Container::getInstance()->instance(Lock::class, $lock);
+
+        $repository = new RedisMetricsRepository(Mockery::mock(RedisFactory::class));
+
+        $this->assertTrue($repository->acquireWaitTimeMonitorLock('redis'));
     }
 
     protected function connectionForClearingMetrics(array $patterns)

--- a/tests/Unit/WaitTimeCalculatorTest.php
+++ b/tests/Unit/WaitTimeCalculatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Unit;
+
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Laravel\Horizon\Contracts\MetricsRepository;
+use Laravel\Horizon\Contracts\SupervisorRepository;
+use Laravel\Horizon\Tests\UnitTest;
+use Laravel\Horizon\WaitTimeCalculator;
+use Mockery;
+
+class WaitTimeCalculatorTest extends UnitTest
+{
+    public function test_wait_times_can_be_calculated_for_a_single_connection()
+    {
+        $queue = Mockery::mock(QueueFactory::class);
+        $supervisors = Mockery::mock(SupervisorRepository::class);
+        $metrics = Mockery::mock(MetricsRepository::class);
+
+        $supervisors->shouldReceive('all')->once()->andReturn([
+            (object) [
+                'options' => ['connection' => 'redis'],
+                'processes' => ['redis:default' => 1],
+            ],
+            (object) [
+                'options' => ['connection' => 'redis'],
+                'processes' => ['redis:default' => 2],
+            ],
+            (object) [
+                'options' => ['connection' => 'rabbitmq'],
+                'processes' => ['rabbitmq:emails' => 1],
+            ],
+        ]);
+
+        $queue->shouldReceive('connection')->once()->with('redis')->andReturnSelf();
+        $queue->shouldReceive('connection')->with('rabbitmq')->never();
+        $queue->shouldReceive('readyNow')->once()->with('default')->andReturn(10);
+        $queue->shouldReceive('readyNow')->with('emails')->never();
+
+        $metrics->shouldReceive('runtimeForQueue')->once()->with('default')->andReturn(1500);
+        $metrics->shouldReceive('runtimeForQueue')->with('emails')->never();
+
+        $calculator = new WaitTimeCalculator($queue, $supervisors, $metrics);
+
+        $this->assertEquals(
+            ['redis:default' => 5],
+            $calculator->calculateForConnection('redis')
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1704.

This scopes supervisor loop wait-time monitoring to the queue connection that emitted the event, so a supervisor does not open queue driver connections that belong to unrelated supervisors. The global wait-time calculation path remains unchanged for dashboard/workload callers.

The wait-time monitor lock is also scoped per connection so each connection can be monitored without duplicate checks from supervisors sharing that connection.

Tests:
- php -l on touched source and test files
- php vendor/bin/phpunit tests/Unit/WaitTimeCalculatorTest.php --debug
- php vendor/bin/phpunit tests/Unit/RedisMetricsRepositoryTest.php --debug
- php vendor/bin/phpstan analyse touched source and test files