### PR TITLE
Auto register dev commands

### DIFF
--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -170,6 +170,8 @@ class HorizonServiceProvider extends ServiceProvider
         $this->configure();
         $this->registerServices();
         $this->registerQueueConnectors();
+
+        Horizon::registerDevCommands();
     }
 
     /**


### PR DESCRIPTION
Auto registers the `php artisan horizon` into `DevCommands` if the class exists.