### PR TITLE
Fix dashboard "Max Runtime"/"Max Throughput" picking arbitrary queue

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -159,7 +159,7 @@ class RedisMetricsRepository implements MetricsRepository
     {
         return collect($this->measuredQueues())
             ->sortBy(function ($queue) {
-                if ($snapshots = $this->connection()->zrange('snapshot:queue:'.$queue, -1, 1)) {
+                if ($snapshots = $this->connection()->zrange('snapshot:queue:'.$queue, -1, -1)) {
                     return json_decode($snapshots[0])->runtime;
                 }
             })
@@ -175,7 +175,7 @@ class RedisMetricsRepository implements MetricsRepository
     {
         return collect($this->measuredQueues())
             ->sortBy(function ($queue) {
-                if ($snapshots = $this->connection()->zrange('snapshot:queue:'.$queue, -1, 1)) {
+                if ($snapshots = $this->connection()->zrange('snapshot:queue:'.$queue, -1, -1)) {
                     return json_decode($snapshots[0])->throughput;
                 }
             })

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -193,6 +193,31 @@ class MetricsTest extends IntegrationTest
         );
     }
 
+    public function test_queue_with_maximum_runtime_and_throughput_compares_latest_snapshot()
+    {
+        $repository = resolve(MetricsRepository::class);
+        $connection = $repository->connection();
+
+        // Two measured queues, each with three snapshots (the case where the
+        // ZRANGE range matters — fewer than three would mask the bug). The most
+        // recent snapshot is the highest-scored member. "fast" has the greater
+        // throughput, "slow" the greater runtime, so each card must surface a
+        // different queue rather than an arbitrary one.
+        $connection->sadd('measured_queues', 'queue:fast', 'queue:slow');
+
+        foreach ([
+            'fast' => [['throughput' => 10, 'runtime' => 5], ['throughput' => 50, 'runtime' => 10], ['throughput' => 102, 'runtime' => 21]],
+            'slow' => [['throughput' => 3, 'runtime' => 100], ['throughput' => 7, 'runtime' => 200], ['throughput' => 11, 'runtime' => 338]],
+        ] as $queue => $snapshots) {
+            foreach ($snapshots as $score => $snapshot) {
+                $connection->zadd('snapshot:queue:'.$queue, $score, json_encode($snapshot));
+            }
+        }
+
+        $this->assertSame('fast', $repository->queueWithMaximumThroughput());
+        $this->assertSame('slow', $repository->queueWithMaximumRuntime());
+    }
+
     public function test_snapshot_does_not_fail_when_hmget_returns_null()
     {
         $connection = Mockery::mock();


### PR DESCRIPTION
queueWithMaximumRuntime()/queueWithMaximumThroughput() read the latest snapshot with zrange(key, -1, 1). For any queue with >= 3 snapshots (every real deployment — horizon:snapshot retains up to 24), start > stop so Redis returns an empty array, the sort closure returns null for every queue, and ->last() falls back to the alphabetically-last measured queue regardless of the actual values. Use zrange(key, -1, -1) to read the most recent snapshot and compare real runtime/throughput.