### PR TITLE
[5.x] Add job lookup by ID

### DIFF
--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -95,7 +95,7 @@
                                 jobId: response.data.id,
                                 type: ['pending', 'reserved'].includes(response.data.status)
                                     ? 'pending'
-                                    : (this.$route.params.type === 'silenced' ? 'silenced' : 'completed'),
+                                    : (response.data.payload?.silenced ? 'silenced' : 'completed'),
                             },
                         });
                     })
@@ -215,9 +215,9 @@
                 <h2 class="h6 m-0" v-if="$route.params.type == 'completed'">Completed Jobs</h2>
                 <h2 class="h6 m-0" v-if="$route.params.type == 'silenced'">Silenced Jobs</h2>
 
-                <form class="form-control-with-icon" @submit.prevent="findJob">
-                    <button type="submit" class="icon-wrapper border-0 bg-transparent p-0" title="Find Job" :disabled="findingJob">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon">
+                <form class="form-control-with-icon" role="search" @submit.prevent="findJob">
+                    <button type="submit" class="icon-wrapper border-0 bg-transparent p-0" title="Find Job" aria-label="Find Job" :disabled="findingJob">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon" aria-hidden="true" focusable="false">
                             <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd" />
                         </svg>
                     </button>

--- a/resources/js/screens/recentJobs/index.vue
+++ b/resources/js/screens/recentJobs/index.vue
@@ -13,7 +13,9 @@
                 page: 1,
                 perPage: 50,
                 totalPages: 1,
-                jobs: []
+                jobs: [],
+                jobId: '',
+                findingJob: false,
             };
         },
 
@@ -44,6 +46,7 @@
                 this.updatePageTitle();
 
                 this.page = 1;
+                this.jobId = '';
 
                 this.loadJobs();
             },
@@ -57,6 +60,63 @@
 
 
         methods: {
+            /**
+             * Find a retained job by its ID.
+             */
+            findJob() {
+                var jobId = this.jobId.trim();
+
+                if (!jobId || this.findingJob) {
+                    return;
+                }
+
+                this.findingJob = true;
+
+                this.$http.get(Horizon.basePath + '/api/jobs/' + encodeURIComponent(jobId))
+                    .then(response => {
+                        if (!response.data.id) {
+                            this.showJobSearchError('The job could not be found. It may have expired according to your trim configuration.');
+
+                            return;
+                        }
+
+                        if (response.data.status === 'failed') {
+                            this.$router.push({
+                                name: 'failed-jobs-preview',
+                                params: { jobId: response.data.id },
+                            });
+
+                            return;
+                        }
+
+                        this.$router.push({
+                            name: 'job-preview',
+                            params: {
+                                jobId: response.data.id,
+                                type: ['pending', 'reserved'].includes(response.data.status)
+                                    ? 'pending'
+                                    : (this.$route.params.type === 'silenced' ? 'silenced' : 'completed'),
+                            },
+                        });
+                    })
+                    .catch(() => {
+                        this.showJobSearchError('The job could not be loaded. Please try again.');
+                    })
+                    .finally(() => {
+                        this.findingJob = false;
+                    });
+            },
+
+
+            /**
+             * Show an error from the job search.
+             */
+            showJobSearchError(message) {
+                this.$root.alert.message = message;
+                this.$root.alert.type = 'error';
+            },
+
+
             /**
              * Load the jobs of the given tag.
              */
@@ -154,6 +214,16 @@
                 <h2 class="h6 m-0" v-if="$route.params.type == 'pending'">Pending Jobs</h2>
                 <h2 class="h6 m-0" v-if="$route.params.type == 'completed'">Completed Jobs</h2>
                 <h2 class="h6 m-0" v-if="$route.params.type == 'silenced'">Silenced Jobs</h2>
+
+                <form class="form-control-with-icon" @submit.prevent="findJob">
+                    <button type="submit" class="icon-wrapper border-0 bg-transparent p-0" title="Find Job" :disabled="findingJob">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="icon">
+                            <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd" />
+                        </svg>
+                    </button>
+
+                    <input type="search" class="form-control w-100" v-model="jobId" placeholder="Find Job by ID" aria-label="Find Job by ID" :disabled="findingJob">
+                </form>
             </div>
 
             <div v-if="!ready"


### PR DESCRIPTION
## Summary

This adds a `Find Job by ID` field to the pending, completed, and silenced job screens.

Submitting an ID uses Horizon's existing `/api/jobs/{id}` endpoint and opens the matching job preview. Failed jobs are directed to the failed job preview, pending or reserved jobs use the pending route, and completed jobs use their stored silenced state to select the completed or silenced route.

If the job is no longer retained, Horizon explains that it may have expired according to the configured trim period.

## Why

Finding a specific retained job currently requires paging through the job tables or manually constructing its detail URL. This becomes impractical when an application processes a large number of jobs.

The lookup is deliberately limited to an exact job ID. Horizon already stores job hashes by ID, so this exposes the existing constant-time lookup without adding Redis indexes, background maintenance, storage overhead, configuration, or dependencies.

## Trimmed jobs

#1669 reverted direct links to completed job details because a job may be trimmed before the link is followed. This lookup checks the existing job endpoint before navigating. If the record has already been trimmed, the user stays on the list and sees a trim-aware message instead of opening an empty preview.

## Manual browser validation

- Pending ID opens the pending job preview.
- Completed ID opens the completed job preview.
- Silenced ID searched from the completed screen opens the silenced job preview.
- Completed ID searched from the silenced screen opens the completed job preview.
- Failed ID opens the failed job preview.
- Missing or trimmed ID stays on the current list and shows the trim-aware message.
- A fresh valid lookup completed without console errors or uncaught page errors.
- The search form, icon button, and decorative SVG expose the expected accessibility semantics.

## Screenshots

### Job ID lookup

<img width="1280" height="577" alt="Find Job by ID field on the pending jobs screen" src="https://github.com/user-attachments/assets/1bce6fa8-ea7d-44ec-a55c-594277e398b5" />

### Missing or trimmed job

<img width="1280" height="577" alt="Trim-aware message for a missing job" src="https://github.com/user-attachments/assets/20e0348b-8a13-442f-b58b-5e56ce0181e7" />

## Validation

- `npm run build -- --outDir /tmp/laravel-horizon-job-search-dist-20260716-routing-fix`
- `composer test` — 186 tests, 418 assertions
- `composer lint`
- `git diff --check`
