### PR TITLE
Adjust CSP test for Laravel <=10 support

### DIFF
--- a/tests/Feature/CspNonceTest.php
+++ b/tests/Feature/CspNonceTest.php
@@ -14,10 +14,10 @@ class CspNonceTest extends ControllerTest
                     ->get('/horizon');
 
         $response->assertOk()
-            ->assertSeeHtml('<style data-scheme="light">')
-            ->assertSeeHtml('<style data-scheme="dark">')
-            ->assertSeeHtml('<style>')
-            ->assertSeeHtml('<script type="module">');
+            ->assertSee('<style data-scheme="light">', false)
+            ->assertSee('<style data-scheme="dark">', false)
+            ->assertSee('<style>', false)
+            ->assertSee('<script type="module">', false);
     }
 
     public function test_csp_nonce_is_rendered_in_style_and_script_tags_if_set()
@@ -30,9 +30,9 @@ class CspNonceTest extends ControllerTest
                     ->get('/horizon');
 
         $response->assertOk()
-            ->assertSeeHtml("<style data-scheme=\"light\" nonce=\"{$nonce}\">")
-            ->assertSeeHtml("<style data-scheme=\"dark\" nonce=\"{$nonce}\">")
-            ->assertSeeHtml("<style nonce=\"{$nonce}\">")
-            ->assertSeeHtml("<script type=\"module\" nonce=\"{$nonce}\">");
+            ->assertSee("<style data-scheme=\"light\" nonce=\"{$nonce}\">", false)
+            ->assertSee("<style data-scheme=\"dark\" nonce=\"{$nonce}\">", false)
+            ->assertSee("<style nonce=\"{$nonce}\">", false)
+            ->assertSee("<script type=\"module\" nonce=\"{$nonce}\">", false);
     }
 }


### PR DESCRIPTION
Previously failing CI test for Laravel 10 because assertSeeHtml() doesn't exist in that version.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I noticed that the CI run on Laravel 10.x failed after merging this PR https://github.com/laravel/horizon/pull/1792 . This commit adjusts the tests to use the longer-supported `assertSee()` method in place of `assertSeeHtml()`.