### PR TITLE
[5.x] Fix `Laravel\Horizon\RedisQueue::later()` usage on Laravel 12.10 and lower.

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Application;
 use Illuminate\Queue\RedisQueue as BaseQueue;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Events\JobDeleted;
@@ -112,7 +113,11 @@ class RedisQueue extends BaseQueue
     #[\Override]
     public function later($delay, $job, $data = '', $queue = null)
     {
-        $payload = (new JobPayload($this->createPayload($job, $queue, $data, $delay)))->prepare($job)->value;
+        $args = version_compare(Application::class, '12.11.0', '>=')
+            ? [$job, $queue, $data, $delay]
+            : [$job, $queue, $data];
+
+        $payload = (new JobPayload($this->createPayload(...$args)))->prepare($job)->value;
 
         if (method_exists($this, 'enqueueUsing')) {
             return $this->enqueueUsing(


### PR DESCRIPTION


fixes #1797

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
