### PR TITLE
[5.x] Fix `horizon:clear-metrics` deleting nothing on phpredis 6.x

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -402,7 +402,7 @@ class RedisMetricsRepository implements MetricsRepository
 
             do {
                 $scanResult = $this->connection()->scan(
-                    $cursor ?? 0, ['match' => $this->snapshotPatternToMatch($pattern)]
+                    $cursor, ['match' => $this->snapshotPatternToMatch($pattern)]
                 );
 
                 if (! is_array($scanResult)) {

--- a/tests/Unit/RedisMetricsRepositoryTest.php
+++ b/tests/Unit/RedisMetricsRepositoryTest.php
@@ -96,7 +96,9 @@ class RedisMetricsRepositoryTest extends UnitTest
         }
 
         foreach ($patterns as $pattern) {
-            $connection->shouldReceive('scan')->once()->with(0, ['match' => $pattern])->andReturn([0, []]);
+            $connection->shouldReceive('scan')->once()->with(
+                Mockery::on(fn ($cursor) => $cursor === null), ['match' => $pattern]
+            )->andReturn([0, []]);
         }
 
         return $connection;


### PR DESCRIPTION
On phpredis 6.x, `clear()` seeds the SCAN cursor with integer `0` (`$cursor ?? 0`), which phpredis treats as a finished iteration and returns `false`. The `do/while` then breaks on the first pass, so `horizon:clear-metrics` reports success but never deletes the per-job/queue or snapshot keys, letting them grow unbounded. Passing the cursor as `null` on the first call scans and clears the keys correctly.

Fixes #1799