### PR TITLE
[5.x] Fix `horizon:clear-metrics` clearing nothing on phpredis 6.1+

### DIFF
--- a/src/Repositories/RedisMetricsRepository.php
+++ b/src/Repositories/RedisMetricsRepository.php
@@ -4,6 +4,7 @@ namespace Laravel\Horizon\Repositories;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Str;
 use Laravel\Horizon\Contracts\MetricsRepository;
 use Laravel\Horizon\Lock;
@@ -397,12 +398,20 @@ class RedisMetricsRepository implements MetricsRepository
         $this->forget('measured_queues');
         $this->forget('metrics:snapshot');
 
+        $connection = $this->connection();
+
+        // phpredis 6.1+ requires the SCAN cursor to start as null, while predis and older phpredis expect "0"...
+        $defaultCursorValue = match (true) {
+            $connection instanceof PhpRedisConnection && version_compare(phpversion('redis'), '6.1.0', '>=') => null,
+            default => '0',
+        };
+
         foreach (['queue:*', 'job:*', 'snapshot:*'] as $pattern) {
-            $cursor = null;
+            $cursor = $defaultCursorValue;
 
             do {
-                $scanResult = $this->connection()->scan(
-                    $cursor ?? 0, ['match' => $this->snapshotPatternToMatch($pattern)]
+                $scanResult = $connection->scan(
+                    $cursor, ['match' => $this->snapshotPatternToMatch($pattern)]
                 );
 
                 if (! is_array($scanResult)) {
@@ -414,7 +423,7 @@ class RedisMetricsRepository implements MetricsRepository
                 foreach ($keys ?? [] as $key) {
                     $this->forget(Str::after($key, config('horizon.prefix')));
                 }
-            } while ($cursor > 0);
+            } while (((string) $cursor) !== $defaultCursorValue);
         }
     }
 

--- a/tests/Feature/MetricsTest.php
+++ b/tests/Feature/MetricsTest.php
@@ -265,4 +265,33 @@ class MetricsTest extends IntegrationTest
 
         CarbonImmutable::setTestNow();
     }
+
+    public function test_metrics_can_be_cleared()
+    {
+        if (getenv('REDIS_CLUSTER_HOSTS_AND_PORTS')) {
+            $this->markTestSkipped('Test is for standalone Redis connections.');
+        }
+
+        Queue::push(new Jobs\BasicJob);
+        $this->work();
+
+        resolve(MetricsRepository::class)->snapshot();
+
+        // Work another job so live "job:*" and "queue:*" hashes exist alongside the snapshots...
+        Queue::push(new Jobs\BasicJob);
+        $this->work();
+
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->measuredJobs());
+        $this->assertNotEmpty(resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class));
+        $this->assertSame(1, resolve(MetricsRepository::class)->throughputForJob(Jobs\BasicJob::class));
+
+        resolve(MetricsRepository::class)->clear();
+
+        $this->assertEmpty(resolve(MetricsRepository::class)->measuredJobs());
+        $this->assertEmpty(resolve(MetricsRepository::class)->measuredQueues());
+        $this->assertEmpty(resolve(MetricsRepository::class)->snapshotsForJob(Jobs\BasicJob::class));
+        $this->assertEmpty(resolve(MetricsRepository::class)->snapshotsForQueue('default'));
+        $this->assertSame(0, resolve(MetricsRepository::class)->throughputForJob(Jobs\BasicJob::class));
+        $this->assertSame(0, resolve(MetricsRepository::class)->throughputForQueue('default'));
+    }
 }

--- a/tests/Unit/RedisMetricsRepositoryTest.php
+++ b/tests/Unit/RedisMetricsRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Horizon\Tests\Unit;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Laravel\Horizon\Repositories\RedisMetricsRepository;
 use Laravel\Horizon\Tests\UnitTest;
 use Mockery;
@@ -55,6 +56,32 @@ class RedisMetricsRepositoryTest extends UnitTest
             ]),
             true
         );
+
+        $repository->clear();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_clear_starts_scan_with_null_for_phpredis_6_1_and_newer()
+    {
+        if (! extension_loaded('redis') || version_compare((string) phpversion('redis'), '6.1.0', '<')) {
+            $this->markTestSkipped('phpredis 6.1 or newer is required.');
+        }
+
+        $connection = Mockery::mock(PhpRedisConnection::class);
+
+        foreach (['last_snapshot_at', 'measured_jobs', 'measured_queues', 'metrics:snapshot'] as $key) {
+            $connection->shouldReceive('del')->once()->with($key);
+        }
+
+        foreach (['queue:*', 'job:*', 'snapshot:*'] as $pattern) {
+            $connection->shouldReceive('scan')
+                ->once()
+                ->with(null, ['match' => 'horizon:'.$pattern])
+                ->andReturn(false);
+        }
+
+        $repository = $this->redisMetricsRepositoryWithConnection($connection);
 
         $repository->clear();
 


### PR DESCRIPTION
Fixes #1799.

**The problem**

`php artisan horizon:clear-metrics` reports "Metrics cleared successfully." but does not delete any `queue:*`, `job:*`, or `snapshot:*` keys when the application uses phpredis 6.1 or newer, so on busy applications these keys accumulate unbounded.

`RedisMetricsRepository::clear()` passes `$cursor ?? 0` to `scan()`, so the first iteration starts the SCAN with integer `0`. phpredis 6.1+ requires the SCAN iterator to start as `null` and treats `0` as "iteration finished". As a result, `Redis::scan()` returns `false`, `PhpRedisConnection::scan()` propagates it, and the loop breaks on its first iteration without deleting anything.

**The fix**

Choose the initial cursor value based on the client (`null` for phpredis 6.1+, `'0'` otherwise) and loop until the cursor returns to its initial value. This mirrors how the framework handles the same client difference in `Illuminate\Cache\RedisTagSet::entries()`.

**Tests**

Added `test_metrics_can_be_cleared` to `MetricsTest`. Since `phpunit.xml.dist` pins `REDIS_CLIENT=predis`, I also verified the test locally against phpredis 6.3.0 on PHP 8.4: it fails without the fix and passes with it.