### PR TITLE
Add doctor diagnostics

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,6 @@ permissions:
 
 jobs:
   tests:
-    uses: laravel/.github/.github/workflows/static-analysis.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/static-analysis.yml@41cb33d868e3f67ea2c9bb53f1ebd9a379400f63 # main
+    with:
+      php: "8.4"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Remove incompatible dependencies
+        if: matrix.laravel < 12 || matrix.php < 8.3
+        run: composer remove laravel/doctor --dev --no-update --no-interaction
+
       - name: Install dependencies
         run: |
           composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/process": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
+        "laravel/doctor": "^0.1",
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^7.56|^8.37|^9.16|^10.9|^11.0",
         "phpstan/phpstan": "^1.10|^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,9 @@
         <testsuite name="Controller">
             <directory suffix="Test.php">./tests/Controller</directory>
         </testsuite>
+        <testsuite name="Diagnostics">
+            <directory suffix="Test.php">./tests/Diagnostics</directory>
+        </testsuite>
     </testsuites>
     <php>
         <server name="REDIS_CLIENT" value="predis"/>

--- a/src/Diagnostics/HorizonEnvironmentIsDefined.php
+++ b/src/Diagnostics/HorizonEnvironmentIsDefined.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Laravel\Horizon\Diagnostics;
+
+use Illuminate\Support\Str;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\EnvironmentMode;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\ProvisioningPlan;
+use Laravel\Horizon\SupervisorOptions;
+use Throwable;
+
+class HorizonEnvironmentIsDefined extends Diagnostic
+{
+    use ResolvesHorizonEnvironment;
+
+    public string $name = 'Horizon environment is defined';
+
+    public string $group = 'horizon';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'no-environments' => Message::make(
+                summary: 'No environments are defined in Horizon\'s configuration.',
+                remediation: 'Add your environments to `horizon.environments` so Horizon can start supervisors.',
+            )->link(Link::docs('horizon', 'environments')),
+            'invalid-configuration' => Message::make(
+                summary: 'The Horizon environment configuration is invalid.',
+                remediation: 'Correct the supervisor options in `config/horizon.php`.',
+            )->link(Link::docs('horizon', 'configuration')),
+            'not-defined' => Message::make(
+                summary: 'Horizon does not define supervisors for the [{environment}] environment.',
+                remediation: 'Add a [{environment}] entry (or a wildcard) to `horizon.environments` so Horizon starts supervisors in this environment.',
+            )->link(Link::docs('horizon', 'environments')),
+            'no-processes' => Message::make(
+                summary: 'No Horizon supervisors for the [{environment}] environment can start worker processes.',
+                remediation: 'Set `maxProcesses` to at least 1 for a supervisor in the [{environment}] environment.',
+            )->link(Link::docs('horizon', 'environments')),
+            'defined' => 'Horizon defines supervisors for the [{environment}] environment.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $environments = config('horizon.environments');
+
+        if (! is_array($environments) || $environments === []) {
+            return EnvironmentMode::current()->isProduction()
+                ? $this->fail('no-environments')
+                : $this->warn('no-environments');
+        }
+
+        try {
+            $plan = new ProvisioningPlan(
+                MasterSupervisor::name(),
+                $environments,
+                (array) config('horizon.defaults', []),
+            );
+        } catch (Throwable $e) {
+            return $this->fail('invalid-configuration')->withDetails($e->getMessage());
+        }
+
+        $environment = $this->horizonEnvironment();
+
+        $supervisors = collect($plan->parsed)->first(
+            fn ($supervisors, string $name): bool => Str::is($name, $environment),
+        );
+
+        if ($supervisors === null) {
+            return EnvironmentMode::current()->isProduction()
+                ? $this->fail('not-defined', ['environment' => $environment])
+                : $this->warn('not-defined', ['environment' => $environment]);
+        }
+
+        if (collect($supervisors)->every(fn (SupervisorOptions $options): bool => $options->maxProcesses < 1)) {
+            return EnvironmentMode::current()->isProduction()
+                ? $this->fail('no-processes', ['environment' => $environment])
+                : $this->warn('no-processes', ['environment' => $environment]);
+        }
+
+        return $this->pass('defined', ['environment' => $environment]);
+    }
+}

--- a/src/Diagnostics/HorizonIsRunning.php
+++ b/src/Diagnostics/HorizonIsRunning.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Laravel\Horizon\Diagnostics;
+
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\EnvironmentMode;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Throwable;
+
+class HorizonIsRunning extends Diagnostic
+{
+    public string $name = 'Horizon is running';
+
+    public string $group = 'horizon';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'redis-unreachable' => Message::make(
+                summary: 'The Horizon Redis connection could not be reached.',
+                remediation: 'Check `horizon.use` and the corresponding Redis connection configuration.',
+            )->link(Link::docs('horizon', 'configuration')),
+            'not-running' => Message::make(
+                summary: 'Horizon is not running.',
+                remediation: 'Run `php artisan horizon` under a process monitor such as Supervisor to process queued jobs.',
+            )->link(Link::docs('horizon', 'deploying-horizon')),
+            'paused' => Message::make(
+                summary: 'At least one Horizon master supervisor is paused.',
+                remediation: 'Run `php artisan horizon:continue` to resume processing queued jobs.',
+            ),
+            'running' => 'Horizon is running.',
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        try {
+            $masters = app(MasterSupervisorRepository::class)->all();
+        } catch (Throwable $e) {
+            $result = EnvironmentMode::current()->isProduction()
+                ? $this->fail('redis-unreachable')
+                : $this->warn('redis-unreachable');
+
+            return $result->withDetails($e->getMessage());
+        }
+
+        if ($masters === []) {
+            return EnvironmentMode::current()->isProduction()
+                ? $this->fail('not-running')
+                : $this->notice('not-running');
+        }
+
+        if ($this->anyPaused($masters)) {
+            return $this->warn('paused');
+        }
+
+        return $this->pass('running');
+    }
+
+    /**
+     * Determine whether any master supervisor is paused.
+     *
+     * @param  array<int|string, object>  $masters
+     */
+    private function anyPaused(array $masters): bool
+    {
+        return collect($masters)->contains(
+            fn (object $master): bool => ($master->status ?? null) === 'paused',
+        );
+    }
+}

--- a/src/Diagnostics/HorizonProcessesDefaultRedisQueue.php
+++ b/src/Diagnostics/HorizonProcessesDefaultRedisQueue.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Laravel\Horizon\Diagnostics;
+
+use Illuminate\Support\Str;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\EnvironmentMode;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+use Laravel\Doctor\Support\Configured;
+use Laravel\Doctor\Support\Details;
+use Laravel\Horizon\MasterSupervisor;
+use Laravel\Horizon\ProvisioningPlan;
+use Laravel\Horizon\SupervisorOptions;
+use Throwable;
+
+class HorizonProcessesDefaultRedisQueue extends Diagnostic
+{
+    use ResolvesHorizonEnvironment;
+
+    public string $name = 'Horizon processes the default Redis queue';
+
+    public string $group = 'horizon';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'no-default' => 'The application does not have a default queue connection configured.',
+            'not-redis' => 'The default queue connection [{connection}] is not Redis-backed, so Horizon is not expected to process it.',
+            'cannot-inspect' => 'Horizon queue coverage cannot be determined for the [{environment}] environment.',
+            'covered' => 'Horizon processes the default Redis queue [{queue}].',
+            'not-covered' => Message::make(
+                summary: 'Horizon does not process the default Redis queue [{queue}].',
+                remediation: 'Add the default queue to a runnable Horizon supervisor in the [{environment}] environment, or change the application default queue.',
+            )->link(Link::docs('horizon', 'environments')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        $connection = Configured::string('queue.default');
+
+        if ($connection === null) {
+            return $this->skip('no-default');
+        }
+
+        if (Configured::string("queue.connections.{$connection}.driver") !== 'redis') {
+            return $this->skip('not-redis', ['connection' => $connection]);
+        }
+
+        $queue = Configured::string("queue.connections.{$connection}.queue", 'default');
+        $target = "{$connection}:{$queue}";
+        $environment = $this->horizonEnvironment();
+
+        try {
+            $plan = new ProvisioningPlan(
+                MasterSupervisor::name(),
+                (array) config('horizon.environments', []),
+                (array) config('horizon.defaults', []),
+            );
+        } catch (Throwable $e) {
+            return $this->skip('cannot-inspect', ['environment' => $environment])
+                ->withDetails($e->getMessage());
+        }
+
+        $supervisors = collect($plan->parsed)->first(
+            fn ($supervisors, string $name): bool => Str::is($name, $environment),
+        );
+
+        if ($supervisors === null) {
+            return $this->skip('cannot-inspect', ['environment' => $environment]);
+        }
+
+        /** @var array<string, SupervisorOptions> $supervisorOptions */
+        $supervisorOptions = collect($supervisors)->all();
+        $watched = $this->watchedQueues($supervisorOptions);
+
+        if (in_array($target, $watched, true)) {
+            return $this->pass('covered', ['queue' => $target]);
+        }
+
+        $result = EnvironmentMode::current()->isProduction()
+            ? $this->fail('not-covered', ['queue' => $target, 'environment' => $environment])
+            : $this->warn('not-covered', ['queue' => $target, 'environment' => $environment]);
+
+        return $result->withDetails(Details::bullets([
+            "Default: {$target}",
+            'Watched: '.($watched === [] ? 'none' : implode(', ', $watched)),
+        ]));
+    }
+
+    /**
+     * Get the connection and queue pairs watched by runnable supervisors.
+     *
+     * @param  array<string, SupervisorOptions>  $supervisors
+     * @return list<string>
+     */
+    private function watchedQueues(array $supervisors): array
+    {
+        return collect($supervisors)
+            ->filter(fn (SupervisorOptions $options): bool => $options->maxProcesses > 0)
+            ->flatMap(fn (SupervisorOptions $options): array => array_map(
+                fn (string $queue): string => "{$options->connection}:{$queue}",
+                explode(',', (string) $options->queue),
+            ))
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+}

--- a/src/Diagnostics/HorizonSnapshotIsScheduled.php
+++ b/src/Diagnostics/HorizonSnapshotIsScheduled.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Laravel\Horizon\Diagnostics;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Laravel\Doctor\Diagnostic;
+use Laravel\Doctor\EnvironmentMode;
+use Laravel\Doctor\Results\DiagnosticResult;
+use Laravel\Doctor\Results\Link;
+use Laravel\Doctor\Results\Message;
+
+class HorizonSnapshotIsScheduled extends Diagnostic
+{
+    public string $name = 'Horizon snapshot is scheduled';
+
+    public string $group = 'horizon';
+
+    /**
+     * Get the diagnostic's named message definitions.
+     *
+     * @return array<string, string|Message>
+     */
+    protected function messages(): array
+    {
+        return [
+            'scheduled' => 'Horizon metric snapshots are scheduled.',
+            'not-scheduled' => Message::make(
+                summary: 'Horizon metric snapshots are not scheduled.',
+                remediation: 'Schedule `horizon:snapshot` every five minutes so the metrics dashboard has data.',
+            )->link(Link::docs('horizon', 'metrics')),
+        ];
+    }
+
+    /**
+     * Run the diagnostic.
+     */
+    public function check(): DiagnosticResult
+    {
+        if ($this->snapshotIsScheduled()) {
+            return $this->pass('scheduled');
+        }
+
+        return EnvironmentMode::current()->isProduction()
+            ? $this->warn('not-scheduled')
+            : $this->notice('not-scheduled');
+    }
+
+    /**
+     * Determine whether metric snapshots are on the application's schedule.
+     */
+    private function snapshotIsScheduled(): bool
+    {
+        foreach (app(Schedule::class)->events() as $event) {
+            if (str_contains((string) $event->command, 'horizon:snapshot')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Diagnostics/ResolvesHorizonEnvironment.php
+++ b/src/Diagnostics/ResolvesHorizonEnvironment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Horizon\Diagnostics;
+
+use Laravel\Doctor\Support\Configured;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Throwable;
+
+trait ResolvesHorizonEnvironment
+{
+    /**
+     * Get the environment Horizon is currently using or would use when started.
+     */
+    private function horizonEnvironment(): string
+    {
+        try {
+            $environment = collect(app(MasterSupervisorRepository::class)->all())
+                ->pluck('environment')
+                ->first(fn ($environment): bool => is_string($environment) && $environment !== '');
+
+            if (is_string($environment)) {
+                return $environment;
+            }
+        } catch (Throwable) {
+            // Fall back to the environment a new Horizon process would use.
+        }
+
+        return Configured::string('horizon.env')
+            ?? Configured::string('app.env', 'production');
+    }
+}

--- a/src/HorizonServiceProvider.php
+++ b/src/HorizonServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Doctor\Doctor;
 use Laravel\Horizon\Connectors\RedisConnector;
 use Laravel\Sentinel\Http\Middleware\SentinelMiddleware;
 
@@ -32,6 +33,24 @@ class HorizonServiceProvider extends ServiceProvider
         $this->registerResources();
         $this->offerPublishing();
         $this->registerCommands();
+        $this->registerDiagnostics();
+    }
+
+    /**
+     * Register the package's Doctor diagnostics.
+     *
+     * @return void
+     */
+    protected function registerDiagnostics()
+    {
+        if ($this->app->bound(Doctor::class)) {
+            $this->app->make(Doctor::class)->diagnostics([
+                Diagnostics\HorizonIsRunning::class,
+                Diagnostics\HorizonEnvironmentIsDefined::class,
+                Diagnostics\HorizonProcessesDefaultRedisQueue::class,
+                Diagnostics\HorizonSnapshotIsScheduled::class,
+            ]);
+        }
     }
 
     /**

--- a/tests/Diagnostics/DiagnosticTestCase.php
+++ b/tests/Diagnostics/DiagnosticTestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Diagnostics;
+
+use Laravel\Doctor\Doctor;
+use Laravel\Doctor\DoctorServiceProvider;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\HorizonServiceProvider;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use Throwable;
+
+abstract class DiagnosticTestCase extends TestCase
+{
+    /**
+     * Setup the test case.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        if (! class_exists(Doctor::class)) {
+            $this->markTestSkipped('laravel/doctor is not installed.');
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * Get the package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            HorizonServiceProvider::class,
+            DoctorServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Bind a master supervisor repository returning or throwing the given value.
+     *
+     * @param  array<int, object>|Throwable  $masters
+     */
+    protected function fakeMasters(array|Throwable $masters): void
+    {
+        $repository = Mockery::mock(MasterSupervisorRepository::class);
+
+        $masters instanceof Throwable
+            ? $repository->shouldReceive('all')->andThrow($masters)
+            : $repository->shouldReceive('all')->andReturn($masters);
+
+        $this->app->instance(MasterSupervisorRepository::class, $repository);
+    }
+}

--- a/tests/Diagnostics/HorizonEnvironmentIsDefinedTest.php
+++ b/tests/Diagnostics/HorizonEnvironmentIsDefinedTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Diagnostics;
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Horizon\Diagnostics\HorizonEnvironmentIsDefined;
+
+class HorizonEnvironmentIsDefinedTest extends DiagnosticTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.env' => 'testing']);
+
+        $this->fakeMasters([]);
+    }
+
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(HorizonEnvironmentIsDefined::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_passes_when_the_environment_is_defined()
+    {
+        config(['horizon.env' => 'production']);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('pass', $result->status->value);
+        $this->assertSame('Horizon defines supervisors for the [production] environment.', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_the_environment_matches_a_wildcard()
+    {
+        config(['horizon.environments' => ['*' => ['supervisor-1' => ['maxProcesses' => 1]]]]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('pass', $result->status->value);
+        $this->assertSame('Horizon defines supervisors for the [testing] environment.', $result->summary);
+    }
+
+    public function test_diagnostic_uses_the_environment_recorded_by_a_running_master()
+    {
+        config(['horizon.environments' => [
+            'workers' => ['supervisor-1' => ['maxProcesses' => 1]],
+        ]]);
+
+        $this->fakeMasters([
+            (object) ['environment' => 'workers'],
+        ]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('pass', $result->status->value);
+        $this->assertSame('Horizon defines supervisors for the [workers] environment.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_environment_is_not_defined_in_production()
+    {
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('Horizon does not define supervisors for the [testing] environment.', $result->summary);
+        $this->assertStringContainsString('horizon.environments', $result->remediation);
+    }
+
+    public function test_diagnostic_warns_when_the_environment_is_not_defined_outside_production()
+    {
+        config(['doctor.environments' => ['local' => ['testing']]]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('warn', $result->status->value);
+        $this->assertSame('Horizon does not define supervisors for the [testing] environment.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_no_environments_are_defined()
+    {
+        config(['horizon.environments' => []]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('No environments are defined in Horizon\'s configuration.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_the_configuration_is_invalid()
+    {
+        config(['horizon.environments' => [
+            'testing' => ['supervisor-1' => ['minProcesses' => 0]],
+        ]]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('The Horizon environment configuration is invalid.', $result->summary);
+        $this->assertStringContainsString('minProcesses', $result->details);
+    }
+
+    public function test_diagnostic_fails_in_production_when_no_supervisor_can_start_processes()
+    {
+        config(['horizon.environments' => [
+            'testing' => ['supervisor-1' => ['maxProcesses' => 0]],
+        ]]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('No Horizon supervisors for the [testing] environment can start worker processes.', $result->summary);
+        $this->assertStringContainsString('maxProcesses', $result->remediation);
+    }
+
+    public function test_diagnostic_warns_outside_production_when_no_supervisor_can_start_processes()
+    {
+        config([
+            'doctor.environments' => ['local' => ['testing']],
+            'horizon.environments' => [
+                'testing' => ['supervisor-1' => ['maxProcesses' => 0]],
+            ],
+        ]);
+
+        $result = (new HorizonEnvironmentIsDefined)->check();
+
+        $this->assertSame('warn', $result->status->value);
+    }
+}

--- a/tests/Diagnostics/HorizonIsRunningTest.php
+++ b/tests/Diagnostics/HorizonIsRunningTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Diagnostics;
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Horizon\Diagnostics\HorizonIsRunning;
+use RuntimeException;
+
+class HorizonIsRunningTest extends DiagnosticTestCase
+{
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(HorizonIsRunning::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_fails_when_horizon_redis_connection_is_unreachable_in_production()
+    {
+        $this->fakeMasters(new RuntimeException('Connection refused'));
+
+        $result = (new HorizonIsRunning)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('The Horizon Redis connection could not be reached.', $result->summary);
+        $this->assertSame('Connection refused', $result->details);
+        $this->assertStringContainsString('horizon.use', $result->remediation);
+    }
+
+    public function test_diagnostic_warns_when_horizon_redis_connection_is_unreachable_outside_production()
+    {
+        config(['doctor.environments' => ['local' => ['testing']]]);
+
+        $this->fakeMasters(new RuntimeException('Connection refused'));
+
+        $result = (new HorizonIsRunning)->check();
+
+        $this->assertSame('warn', $result->status->value);
+        $this->assertSame('The Horizon Redis connection could not be reached.', $result->summary);
+    }
+
+    public function test_diagnostic_fails_when_horizon_is_not_running_in_production()
+    {
+        $this->fakeMasters([]);
+
+        $result = (new HorizonIsRunning)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('Horizon is not running.', $result->summary);
+        $this->assertStringContainsString('php artisan horizon', $result->remediation);
+    }
+
+    public function test_diagnostic_notices_when_horizon_is_not_running_outside_production()
+    {
+        config(['doctor.environments' => ['local' => ['testing']]]);
+
+        $this->fakeMasters([]);
+
+        $result = (new HorizonIsRunning)->check();
+
+        $this->assertSame('notice', $result->status->value);
+        $this->assertSame('Horizon is not running.', $result->summary);
+    }
+
+    public function test_diagnostic_warns_when_any_master_supervisor_is_paused()
+    {
+        $this->fakeMasters([
+            (object) ['name' => 'host-1', 'status' => 'paused'],
+            (object) ['name' => 'host-2', 'status' => 'running'],
+        ]);
+
+        $result = (new HorizonIsRunning)->check();
+
+        $this->assertSame('warn', $result->status->value);
+        $this->assertSame('At least one Horizon master supervisor is paused.', $result->summary);
+        $this->assertStringContainsString('horizon:continue', $result->remediation);
+    }
+
+    public function test_diagnostic_passes_when_every_master_supervisor_is_running()
+    {
+        $this->fakeMasters([
+            (object) ['name' => 'host-1', 'status' => 'running'],
+            (object) ['name' => 'host-2', 'status' => 'running'],
+        ]);
+
+        $result = (new HorizonIsRunning)->check();
+
+        $this->assertSame('pass', $result->status->value);
+        $this->assertSame('Horizon is running.', $result->summary);
+    }
+}

--- a/tests/Diagnostics/HorizonProcessesDefaultRedisQueueTest.php
+++ b/tests/Diagnostics/HorizonProcessesDefaultRedisQueueTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Diagnostics;
+
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Horizon\Diagnostics\HorizonProcessesDefaultRedisQueue;
+
+class HorizonProcessesDefaultRedisQueueTest extends DiagnosticTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.env' => 'production']);
+
+        $this->fakeMasters([]);
+    }
+
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(HorizonProcessesDefaultRedisQueue::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_skips_without_a_default_queue_connection()
+    {
+        config(['queue.default' => null]);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('skip', $result->status->value);
+    }
+
+    public function test_diagnostic_skips_when_the_default_queue_is_not_redis_backed()
+    {
+        config(['queue.default' => 'sync']);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('skip', $result->status->value);
+        $this->assertStringContainsString('not Redis-backed', $result->summary);
+    }
+
+    public function test_diagnostic_passes_when_a_runnable_supervisor_watches_the_default_queue()
+    {
+        $this->configureDefaultQueue('emails');
+        $this->configureSupervisors([
+            'supervisor-1' => [
+                'connection' => 'redis',
+                'queue' => ['default', 'emails'],
+                'maxProcesses' => 1,
+            ],
+        ]);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('pass', $result->status->value);
+        $this->assertSame('Horizon processes the default Redis queue [redis:emails].', $result->summary);
+    }
+
+    public function test_diagnostic_fails_in_production_when_the_default_queue_is_not_watched()
+    {
+        $this->configureDefaultQueue('emails');
+        $this->configureSupervisors([
+            'supervisor-1' => [
+                'connection' => 'redis',
+                'queue' => ['default', 'notifications'],
+                'maxProcesses' => 1,
+            ],
+        ]);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertSame('Horizon does not process the default Redis queue [redis:emails].', $result->summary);
+        $this->assertSame("- Default: redis:emails\n- Watched: redis:default, redis:notifications", $result->details);
+    }
+
+    public function test_diagnostic_ignores_supervisors_that_cannot_start_workers()
+    {
+        $this->configureDefaultQueue('emails');
+        $this->configureSupervisors([
+            'disabled' => [
+                'connection' => 'redis',
+                'queue' => ['emails'],
+                'maxProcesses' => 0,
+            ],
+        ]);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('fail', $result->status->value);
+        $this->assertStringContainsString('Watched: none', $result->details);
+    }
+
+    public function test_diagnostic_warns_outside_production_when_the_default_queue_is_not_watched()
+    {
+        config(['doctor.environments' => ['local' => ['testing']]]);
+
+        $this->configureDefaultQueue('emails');
+        $this->configureSupervisors([
+            'supervisor-1' => [
+                'connection' => 'redis',
+                'queue' => ['default'],
+                'maxProcesses' => 1,
+            ],
+        ]);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('warn', $result->status->value);
+    }
+
+    public function test_diagnostic_uses_the_environment_recorded_by_a_running_master()
+    {
+        $this->configureDefaultQueue('emails');
+        config(['horizon.environments' => [
+            'production' => ['supervisor-1' => ['queue' => ['default']]],
+            'workers' => ['supervisor-1' => ['queue' => ['emails']]],
+        ]]);
+        $this->fakeMasters([
+            (object) ['environment' => 'workers'],
+        ]);
+
+        $result = (new HorizonProcessesDefaultRedisQueue)->check();
+
+        $this->assertSame('pass', $result->status->value);
+    }
+
+    /**
+     * Configure the application's default Redis queue.
+     */
+    private function configureDefaultQueue(string $queue): void
+    {
+        config([
+            'queue.default' => 'redis',
+            'queue.connections.redis.driver' => 'redis',
+            'queue.connections.redis.queue' => $queue,
+        ]);
+    }
+
+    /**
+     * Configure supervisors for the production environment.
+     *
+     * @param  array<string, array<string, mixed>>  $supervisors
+     */
+    private function configureSupervisors(array $supervisors): void
+    {
+        config([
+            'horizon.defaults' => [],
+            'horizon.environments' => ['production' => $supervisors],
+        ]);
+    }
+}

--- a/tests/Diagnostics/HorizonSnapshotIsScheduledTest.php
+++ b/tests/Diagnostics/HorizonSnapshotIsScheduledTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Diagnostics;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Laravel\Doctor\Facades\Doctor;
+use Laravel\Horizon\Diagnostics\HorizonSnapshotIsScheduled;
+
+class HorizonSnapshotIsScheduledTest extends DiagnosticTestCase
+{
+    public function test_diagnostic_is_registered_with_doctor()
+    {
+        $this->assertContains(HorizonSnapshotIsScheduled::class, Doctor::registered());
+    }
+
+    public function test_diagnostic_passes_when_snapshots_are_scheduled()
+    {
+        $schedule = new Schedule;
+        $schedule->command('horizon:snapshot')->everyFiveMinutes();
+
+        $this->app->instance(Schedule::class, $schedule);
+
+        $result = (new HorizonSnapshotIsScheduled)->check();
+
+        $this->assertSame('pass', $result->status->value);
+        $this->assertSame('Horizon metric snapshots are scheduled.', $result->summary);
+    }
+
+    public function test_diagnostic_warns_when_snapshots_are_not_scheduled_in_production()
+    {
+        $this->app->instance(Schedule::class, new Schedule);
+
+        $result = (new HorizonSnapshotIsScheduled)->check();
+
+        $this->assertSame('warn', $result->status->value);
+        $this->assertSame('Horizon metric snapshots are not scheduled.', $result->summary);
+        $this->assertStringContainsString('horizon:snapshot', $result->remediation);
+    }
+
+    public function test_diagnostic_notices_when_snapshots_are_not_scheduled_outside_production()
+    {
+        config(['doctor.environments' => ['local' => ['testing']]]);
+
+        $this->app->instance(Schedule::class, new Schedule);
+
+        $result = (new HorizonSnapshotIsScheduled)->check();
+
+        $this->assertSame('notice', $result->status->value);
+        $this->assertSame('Horizon metric snapshots are not scheduled.', $result->summary);
+    }
+}


### PR DESCRIPTION
This PR registers four Horizon diagnostics with `laravel/doctor` when it is installed.

- `HorizonIsRunning` fails when the Horizon Redis connection is unreachable or no master supervisor is running, and warns when any master supervisor is paused.
- `HorizonEnvironmentIsDefined` checks that `horizon.environments` contains a supervisor entry matching the current environment, including wildcard entries, failing when no environments are defined, the configuration is invalid, or no supervisor for the environment can start worker processes.
- `HorizonProcessesDefaultRedisQueue` verifies that a runnable supervisor watches the application's default queue, skipping when the default queue connection isn't Redis-backed or the supervisor configuration can't be inspected.
- `HorizonSnapshotIsScheduled` warns when `horizon:snapshot` isn't on the application's schedule, since the metrics dashboard has no data without it.