### PR TITLE
[5.x] Fix `RedisQueue::later()` never passing the delay to the payload

### DIFF
--- a/src/RedisQueue.php
+++ b/src/RedisQueue.php
@@ -113,7 +113,7 @@ class RedisQueue extends BaseQueue
     #[\Override]
     public function later($delay, $job, $data = '', $queue = null)
     {
-        $args = version_compare(Application::class, '12.11.0', '>=')
+        $args = version_compare(Application::VERSION, '12.11.0', '>=')
             ? [$job, $queue, $data, $delay]
             : [$job, $queue, $data];
 

--- a/tests/Feature/QueueProcessingTest.php
+++ b/tests/Feature/QueueProcessingTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Horizon\Tests\Feature;
 
 use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
@@ -39,6 +40,17 @@ class QueueProcessingTest extends IntegrationTest
         $id = Queue::later(1, new Jobs\BasicJob);
         $this->assertSame(1, $this->recentJobs());
         $this->assertSame('pending', Redis::connection('horizon')->hget($id, 'status'));
+    }
+
+    public function test_pending_delayed_jobs_are_stored_with_their_delay()
+    {
+        if (version_compare(Application::VERSION, '12.11.0', '<')) {
+            $this->markTestSkipped('Requires Laravel 12.11 or newer.');
+        }
+
+        $id = Queue::later(60, new Jobs\BasicJob);
+        $payload = json_decode(Redis::connection('horizon')->hget($id, 'payload'), true);
+        $this->assertSame(60, $payload['delay']);
     }
 
     public function test_pending_jobs_are_stored_with_their_tags()


### PR DESCRIPTION
The version guard added in #1798 compares `Application::class`, which is the class-name string, instead of `Application::VERSION`. `version_compare()` never reads that as a version above 12.11.0, so the condition is false on every Laravel version and `$delay` is never forwarded to `createPayload()`.

Scheduling still works, since the delay is applied through `enqueueUsing()`/`laterRaw()`, but `payload['delay']` stays null, so a failed delayed job loses its own delay as the retry fallback and drops back to the supervisor's `backoff`.

Added a test in `QueueProcessingTest` asserting the delay reaches the stored payload. It fails on the current 5.x branch and is skipped below Laravel 12.11, where `createPayload()` has no delay argument.

Fixes #1809