### PR TITLE
Escape CSP nonce attribute value

### DIFF
--- a/src/Horizon.php
+++ b/src/Horizon.php
@@ -304,7 +304,7 @@ class Horizon
      */
     public static function cspNonce($nonce)
     {
-        static::$nonceAttribute = " nonce=\"{$nonce}\"";
+        static::$nonceAttribute = ' nonce="'.htmlspecialchars($nonce, ENT_QUOTES, 'UTF-8').'"';
 
         return new static;
     }

--- a/tests/Feature/CspNonceTest.php
+++ b/tests/Feature/CspNonceTest.php
@@ -35,4 +35,16 @@ class CspNonceTest extends ControllerTest
             ->assertSee("<style nonce=\"{$nonce}\">", false)
             ->assertSee("<script type=\"module\" nonce=\"{$nonce}\">", false);
     }
+
+    public function test_csp_nonce_value_is_escaped_when_rendered()
+    {
+        Horizon::cspNonce('"><script>alert(1)</script>');
+
+        $response = $this->actingAs(new Fakes\User)
+                    ->get('/horizon');
+
+        $response->assertOk()
+            ->assertDontSee('<script>alert(1)</script>', false)
+            ->assertSee('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', false);
+    }
 }


### PR DESCRIPTION
The nonce passed to `Horizon::cspNonce()` is interpolated verbatim into a double-quoted HTML attribute in both `Horizon::css()` and `Horizon::js()`. A value containing `"` or `>` breaks out of the attribute context on the dashboard origin.

This escapes the value with `htmlspecialchars(..., ENT_QUOTES)` when the attribute is built, so any caller-supplied string renders inert while normal nonce values (`Str::random()`, base64) are unchanged.

Added a test covering a nonce containing markup.