### PR TITLE
[5.x] Allow minProcesses to be set to zero

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -96,7 +96,13 @@ class SupervisorCommand extends Command
 
         $supervisor->working = ! $this->option('paused');
 
-        $balancedWorkerCount = floor(($this->option('min-processes') + $this->option('max-processes')) / 2);
+        // When the supervisor is allowed to scale down to zero processes, we will not
+        // start any workers up front. The auto-scaler will start them as soon as it
+        // sees jobs waiting on the queue, so idle queues consume no resources...
+        $balancedWorkerCount = (int) $this->option('min-processes') === 0
+            ? 0
+            : floor(($this->option('min-processes') + $this->option('max-processes')) / 2);
+
         $supervisor->scale(max(
             0, $balancedWorkerCount - $supervisor->totalSystemProcessCount()
         ));

--- a/src/ProvisioningPlan.php
+++ b/src/ProvisioningPlan.php
@@ -182,8 +182,8 @@ class ProvisioningPlan
             return [Str::camel($key) => $value];
         })->all();
 
-        if (isset($options['minProcesses']) && $options['minProcesses'] < 1) {
-            throw new Exception("The value of [{$supervisor}.minProcesses] must be greater than 0.");
+        if (isset($options['minProcesses']) && $options['minProcesses'] < 0) {
+            throw new Exception("The value of [{$supervisor}.minProcesses] must be greater than or equal to 0.");
         }
 
         $options['parentId'] = getmypid();

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -244,6 +244,48 @@ class AutoScalerTest extends IntegrationTest
         $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
     }
 
+    public function test_scaler_may_scale_down_to_zero_processes_when_min_processes_is_zero()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'first' => ['current' => 2, 'size' => 0, 'runtime' => 0],
+            'second' => ['current' => 1, 'size' => 0, 'runtime' => 0],
+        ], ['minProcesses' => 0]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(1, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(0, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(0, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(0, $supervisor->processPools['second']->totalProcessCount());
+
+        // Assert scaler stays at zero while the queues are empty...
+        $scaler->scale($supervisor);
+
+        $this->assertSame(0, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(0, $supervisor->processPools['second']->totalProcessCount());
+    }
+
+    public function test_scaler_scales_up_from_zero_processes_when_jobs_are_pushed()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'first' => ['current' => 0, 'size' => 50, 'runtime' => 10],
+            'second' => ['current' => 0, 'size' => 0, 'runtime' => 0],
+        ], ['minProcesses' => 0, 'balanceMaxShift' => 5]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(5, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(0, $supervisor->processPools['second']->totalProcessCount());
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(10, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(0, $supervisor->processPools['second']->totalProcessCount());
+    }
+
     public function test_scaler_assigns_more_processes_to_queue_with_more_jobs_when_using_size_strategy()
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(100, [

--- a/tests/Feature/Fakes/SupervisorWithFakeScaling.php
+++ b/tests/Feature/Fakes/SupervisorWithFakeScaling.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Horizon\Tests\Feature\Fakes;
+
+class SupervisorWithFakeScaling extends SupervisorWithFakeMonitor
+{
+    public $scaledTo;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function scale($processes)
+    {
+        $this->scaledTo = $processes;
+    }
+}

--- a/tests/Feature/Fixtures/FakeSupervisorFactory.php
+++ b/tests/Feature/Fixtures/FakeSupervisorFactory.php
@@ -10,8 +10,15 @@ class FakeSupervisorFactory extends SupervisorFactory
 {
     public $supervisor;
 
+    public $supervisorClass;
+
+    public function __construct($supervisorClass = SupervisorWithFakeMonitor::class)
+    {
+        $this->supervisorClass = $supervisorClass;
+    }
+
     public function make(SupervisorOptions $options)
     {
-        return $this->supervisor = new SupervisorWithFakeMonitor($options);
+        return $this->supervisor = new $this->supervisorClass($options);
     }
 }

--- a/tests/Feature/ProvisioningPlanTest.php
+++ b/tests/Feature/ProvisioningPlanTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Horizon\Tests\Feature;
 
+use Exception;
 use Illuminate\Support\Facades\Redis;
 use Laravel\Horizon\MasterSupervisor;
 use Laravel\Horizon\MasterSupervisorCommands\AddSupervisor;
@@ -140,5 +141,42 @@ class ProvisioningPlanTest extends IntegrationTest
         $results = (new ProvisioningPlan(MasterSupervisor::name(), $plan))->toSupervisorOptions();
 
         $this->assertSame('30,60', $results['local']['supervisor-2']->backoff);
+    }
+
+    public function test_min_processes_may_be_zero()
+    {
+        $plan = [
+            'local' => [
+                'supervisor-1' => [
+                    'connection' => 'redis',
+                    'queue' => 'default',
+                    'balance' => 'auto',
+                    'minProcesses' => 0,
+                    'maxProcesses' => 10,
+                ],
+            ],
+        ];
+
+        $results = (new ProvisioningPlan(MasterSupervisor::name(), $plan))->toSupervisorOptions();
+
+        $this->assertSame(0, $results['local']['supervisor-1']->minProcesses);
+    }
+
+    public function test_negative_min_processes_are_rejected()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The value of [supervisor-1.minProcesses] must be greater than or equal to 0.');
+
+        $plan = [
+            'local' => [
+                'supervisor-1' => [
+                    'connection' => 'redis',
+                    'queue' => 'default',
+                    'minProcesses' => -1,
+                ],
+            ],
+        ];
+
+        (new ProvisioningPlan(MasterSupervisor::name(), $plan))->toSupervisorOptions();
     }
 }

--- a/tests/Feature/SupervisorCommandTest.php
+++ b/tests/Feature/SupervisorCommandTest.php
@@ -3,8 +3,11 @@
 namespace Laravel\Horizon\Tests\Feature;
 
 use Laravel\Horizon\SupervisorFactory;
+use Laravel\Horizon\SystemProcessCounter;
+use Laravel\Horizon\Tests\Feature\Fakes\SupervisorWithFakeScaling;
 use Laravel\Horizon\Tests\Feature\Fixtures\FakeSupervisorFactory;
 use Laravel\Horizon\Tests\IntegrationTest;
+use Mockery;
 
 class SupervisorCommandTest extends IntegrationTest
 {
@@ -31,6 +34,52 @@ class SupervisorCommandTest extends IntegrationTest
         $this->artisan('horizon:supervisor', ['name' => 'foo', 'connection' => 'redis', '--nice' => 10]);
 
         $this->assertSame(10, $this->myNiceness());
+    }
+
+    public function test_supervisor_command_starts_balanced_number_of_workers()
+    {
+        $this->withoutRunningWorkers();
+
+        $this->app->instance(SupervisorFactory::class, $factory = new FakeSupervisorFactory(
+            SupervisorWithFakeScaling::class
+        ));
+
+        $this->artisan('horizon:supervisor', [
+            'name' => 'foo',
+            'connection' => 'redis',
+            '--balance' => 'auto',
+            '--min-processes' => 1,
+            '--max-processes' => 9,
+        ]);
+
+        $this->assertEquals(5, $factory->supervisor->scaledTo);
+    }
+
+    public function test_supervisor_command_does_not_start_any_workers_when_min_processes_is_zero()
+    {
+        $this->withoutRunningWorkers();
+
+        $this->app->instance(SupervisorFactory::class, $factory = new FakeSupervisorFactory(
+            SupervisorWithFakeScaling::class
+        ));
+
+        $this->artisan('horizon:supervisor', [
+            'name' => 'foo',
+            'connection' => 'redis',
+            '--balance' => 'auto',
+            '--min-processes' => 0,
+            '--max-processes' => 9,
+        ]);
+
+        $this->assertEquals(0, $factory->supervisor->scaledTo);
+    }
+
+    private function withoutRunningWorkers()
+    {
+        $counter = Mockery::mock(SystemProcessCounter::class);
+        $counter->shouldReceive('get')->andReturn(0);
+
+        $this->app->instance(SystemProcessCounter::class, $counter);
     }
 
     private function myNiceness()


### PR DESCRIPTION
A supervisor that works many queues currently pays a floor of one worker per queue, even when every one of those queues is idle. On a supervisor with a dozen queues that is a dozen resident PHP processes doing nothing.

Allowing `minProcesses` to be `0` lets the auto-scaler drain a pool all the way down, and start workers again as soon as jobs are pushed:

- `ProvisioningPlan` now rejects only negative values.
- `horizon:supervisor` no longer boots `floor((min + max) / 2)` workers when `minProcesses` is `0`, so idle queues start with no processes at all instead of being scaled down again a few seconds later.

Behaviour is unchanged for any supervisor with `minProcesses >= 1`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
