### PR TITLE
Allow enabling json logs in workers

### DIFF
--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -39,7 +39,8 @@ class SupervisorCommand extends Command
                             {--balance-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}
                             {--workers-name=default : The name that should be assigned to the workers}
                             {--parent-id=0 : The parent process ID}
-                            {--rest=0 : Number of seconds to rest between jobs}';
+                            {--rest=0 : Number of seconds to rest between jobs}
+                            {--json : Output the queue worker information as JSON}';
 
     /**
      * The console command description.
@@ -140,7 +141,8 @@ class SupervisorCommand extends Command
             $this->option('balance-max-shift'),
             $this->option('parent-id'),
             $this->option('rest'),
-            $autoScalingStrategy
+            $autoScalingStrategy,
+            $this->option('json')
         );
     }
 

--- a/src/QueueCommandString.php
+++ b/src/QueueCommandString.php
@@ -59,6 +59,10 @@ class QueueCommandString
             $string .= ' --force';
         }
 
+        if ($options->json) {
+            $string .= ' --json';
+        }
+
         if ($paused) {
             $string .= ' --paused';
         }

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -173,6 +173,13 @@ class SupervisorOptions
     public $retryAfter;
 
     /**
+     * Indicates if the workers should output their information as JSON.
+     *
+     * @var bool
+     */
+    public $json = false;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -196,6 +203,7 @@ class SupervisorOptions
      * @param  int  $parentId
      * @param  int  $rest
      * @param  string|null  $autoScalingStrategy
+     * @param  bool  $json
      */
     public function __construct(
         $name,
@@ -219,6 +227,7 @@ class SupervisorOptions
         $parentId = 0,
         $rest = 0,
         $autoScalingStrategy = 'time',
+        $json = false,
     ) {
         $this->name = $name;
         $this->connection = $connection;
@@ -241,6 +250,7 @@ class SupervisorOptions
         $this->parentId = $parentId;
         $this->rest = $rest;
         $this->autoScalingStrategy = $autoScalingStrategy;
+        $this->json = $json;
     }
 
     /**
@@ -345,6 +355,7 @@ class SupervisorOptions
             'parentId' => $this->parentId,
             'rest' => $this->rest,
             'autoScalingStrategy' => $this->autoScalingStrategy,
+            'json' => $this->json,
         ];
     }
 

--- a/tests/Feature/SupervisorOptionsTest.php
+++ b/tests/Feature/SupervisorOptionsTest.php
@@ -12,4 +12,14 @@ class SupervisorOptionsTest extends IntegrationTest
         $options = new SupervisorOptions('name', 'redis');
         $this->assertSame('default', $options->queue);
     }
+
+    public function test_json_option_is_passed_to_workers()
+    {
+        $options = new SupervisorOptions('name', 'redis');
+        $this->assertStringNotContainsString('--json', $options->toWorkerCommand());
+
+        $options->json = true;
+        $this->assertStringContainsString('--json', $options->toWorkerCommand());
+        $this->assertStringContainsString('--json', $options->toSupervisorCommand());
+    }
 }


### PR DESCRIPTION
The workers support structured json output, but Horizon supervisor never passes the json option.
This allows the json option to be configured on the supervisor level