### PR TITLE
Allow disabling automatic model tagging

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -141,6 +141,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Automatic Job Tagging
+    |--------------------------------------------------------------------------
+    |
+    | Jobs that do not define a "tags" method are tagged automatically: Horizon
+    | reflects over the job's properties and records a tag for every Eloquent
+    | model it holds, such as "App\Models\User:1". Those tags power the tag
+    | search on the failed jobs screen and the monitoring feature, but they
+    | cost reflection on every push, bytes in every stored payload, and a
+    | Redis key per model instance for each failed job. Set this option to
+    | false to keep only the tags your jobs declare themselves.
+    |
+    */
+
+    'auto_tags' => env('HORIZON_AUTO_TAGS', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Metrics
     |--------------------------------------------------------------------------
     |

--- a/src/Tags.php
+++ b/src/Tags.php
@@ -33,9 +33,27 @@ class Tags
             return $tags;
         }
 
+        if (! static::autoTaggingEnabled()) {
+            return [];
+        }
+
         return static::modelsFor(static::targetsFor($job))
             ->map(fn ($model) => get_class($model).':'.$model->getKey())
             ->all();
+    }
+
+    /**
+     * Determine if jobs without explicit tags should be tagged with their models.
+     *
+     * Reflecting over every queued job to find its Eloquent models costs time on
+     * each push and stores a tag per model instance in the payload, so it may be
+     * turned off by applications that never look a job up by model.
+     *
+     * @return bool
+     */
+    public static function autoTaggingEnabled()
+    {
+        return (bool) config('horizon.auto_tags', true);
     }
 
     /**

--- a/tests/Feature/RedisPayloadTest.php
+++ b/tests/Feature/RedisPayloadTest.php
@@ -60,6 +60,48 @@ class RedisPayloadTest extends IntegrationTest
         $this->assertEquals([FakeModel::class.':1', FakeModel::class.':2'], $JobPayload->decoded['tags']);
     }
 
+    public function test_automatic_model_tags_can_be_disabled()
+    {
+        config(['horizon.auto_tags' => false]);
+
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $first = new FakeModel;
+        $first->id = 1;
+
+        $JobPayload->prepare(new FakeJobWithEloquentModel($first, new FakeModel));
+        $this->assertEquals([], $JobPayload->decoded['tags']);
+    }
+
+    public function test_explicit_tags_are_kept_when_automatic_tagging_is_disabled()
+    {
+        config(['horizon.auto_tags' => false]);
+
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $JobPayload->prepare(new FakeJobWithTagsMethod);
+        $this->assertEquals(['first', 'second'], $JobPayload->decoded['tags']);
+    }
+
+    public function test_listener_model_tags_are_dropped_when_automatic_tagging_is_disabled()
+    {
+        config(['horizon.auto_tags' => false]);
+
+        $JobPayload = new JobPayload(json_encode(['id' => 1]));
+
+        $job = new CallQueuedListener(FakeListenerWithProperties::class, 'handle', [new FakeEventWithModel(42)]);
+
+        $JobPayload->prepare($job);
+        $this->assertEquals([], $JobPayload->decoded['tags']);
+
+        $job = new CallQueuedListener(FakeListener::class, 'handle', [new FakeEvent()]);
+
+        $JobPayload->prepare($job);
+        $this->assertEquals([
+            'listenerTag1', 'listenerTag2', 'eventTag1', 'eventTag2',
+        ], $JobPayload->decoded['tags']);
+    }
+
     public function test_tags_are_correctly_gathered_from_collections()
     {
         $JobPayload = new JobPayload(json_encode(['id' => 1]));


### PR DESCRIPTION
Jobs that do not define a tags() method are tagged automatically with every Eloquent model they carry. Those tags feed the monitoring tab and the tag filter on the failed jobs screen, but applications that use neither still pay for them: the tags are stored in every copy of the payload, and each failure writes a failed:{tag} sorted set per tag, which for model tags means a Redis key per model instance held for trim.failed minutes.

The new auto_tags option gates only the model-derived fallback, so a tags() method declared on a job, mailable, notification, event or listener keeps working, as do silenced_tags and monitoring for the tags an application declares itself. The option defaults to true, leaving current behavior unchanged.
