### PR TITLE
Add logarithmic auto-scaling strategy

### DIFF
--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -104,8 +104,11 @@ class AutoScaler
     {
         $timeToClearAll = $queues->sum('time');
         $totalJobs = $queues->sum('size');
+        $totalLogJobs = $supervisor->options->autoScaleLogarithmically()
+            ? $queues->sum(fn ($queue) => log1p($queue['size']))
+            : 0;
 
-        return $queues->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll, $totalJobs) {
+        return $queues->mapWithKeys(function ($timeToClear, $queue) use ($supervisor, $timeToClearAll, $totalJobs, $totalLogJobs) {
             if (! $supervisor->options->balancing()) {
                 $targetProcesses = min(
                     $supervisor->options->maxProcesses,
@@ -117,9 +120,13 @@ class AutoScaler
 
             if ($timeToClearAll > 0 &&
                 $supervisor->options->autoScaling()) {
-                $numberOfProcesses = $supervisor->options->autoScaleByNumberOfJobs()
-                    ? ($timeToClear['size'] / $totalJobs)
-                    : ($timeToClear['time'] / $timeToClearAll);
+                if ($supervisor->options->autoScaleByNumberOfJobs()) {
+                    $numberOfProcesses = $timeToClear['size'] / $totalJobs;
+                } elseif ($supervisor->options->autoScaleLogarithmically()) {
+                    $numberOfProcesses = log1p($timeToClear['size']) / $totalLogJobs;
+                } else {
+                    $numberOfProcesses = $timeToClear['time'] / $timeToClearAll;
+                }
 
                 return [$queue => $numberOfProcesses *= $supervisor->options->maxProcesses];
             } elseif ($timeToClearAll == 0 &&

--- a/src/AutoScaler.php
+++ b/src/AutoScaler.php
@@ -156,7 +156,7 @@ class AutoScaler
 
         $totalProcessCount = $pool->totalProcessCount();
 
-        $desiredProcessCount = ceil($workers);
+        $desiredProcessCount = (int) ceil($workers);
 
         if ($desiredProcessCount > $totalProcessCount) {
             $maxUpShift = min(

--- a/src/Console/SupervisorCommand.php
+++ b/src/Console/SupervisorCommand.php
@@ -34,7 +34,7 @@ class SupervisorCommand extends Command
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}
-                            {--auto-scaling-strategy=time : If supervisor should scale by jobs or time to complete}
+                            {--auto-scaling-strategy=time : The auto-scaling strategy to use (time, size, or log)}
                             {--balance-cooldown=3 : The number of seconds to wait in between auto-scaling attempts}
                             {--balance-max-shift=1 : The maximum number of processes to increase or decrease per one scaling}
                             {--workers-name=default : The name that should be assigned to the workers}

--- a/src/SupervisorOptions.php
+++ b/src/SupervisorOptions.php
@@ -40,7 +40,7 @@ class SupervisorOptions
     public $balance = 'off';
 
     /**
-     * Indicates whether auto-scaling strategy should use "time" (time-to-complete) or "size" (total count of jobs) strategies.
+     * Indicates whether auto-scaling strategy should use "time" (time-to-complete), "size" (total count of jobs), or "log" (logarithmic job count) strategies.
      *
      * @var string|null
      */
@@ -294,6 +294,16 @@ class SupervisorOptions
     public function autoScaleByNumberOfJobs()
     {
         return $this->autoScalingStrategy === 'size';
+    }
+
+    /**
+     * Determine if auto-scaling should use logarithmic queue sizes.
+     *
+     * @return bool
+     */
+    public function autoScaleLogarithmically()
+    {
+        return $this->autoScalingStrategy === 'log';
     }
 
     /**

--- a/tests/Feature/AutoScalerTest.php
+++ b/tests/Feature/AutoScalerTest.php
@@ -262,6 +262,71 @@ class AutoScalerTest extends IntegrationTest
         $this->assertSame(48, $supervisor->processPools['second']->totalProcessCount());
     }
 
+    public function test_scaler_assigns_processes_using_logarithmic_queue_sizes()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(10, [
+            'first' => ['current' => 1, 'size' => 999, 'runtime' => 10],
+            'second' => ['current' => 1, 'size' => 99, 'runtime' => 10],
+            'third' => ['current' => 1, 'size' => 99, 'runtime' => 10],
+            'fourth' => ['current' => 1, 'size' => 99, 'runtime' => 10],
+            'fifth' => ['current' => 1, 'size' => 9, 'runtime' => 10],
+        ], ['autoScalingStrategy' => 'log', 'balanceMaxShift' => 10]);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(3, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['second']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['third']->totalProcessCount());
+        $this->assertSame(2, $supervisor->processPools['fourth']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['fifth']->totalProcessCount());
+    }
+
+    public function test_logarithmic_scaling_allocates_more_workers_to_smaller_busy_queue_than_size_scaling()
+    {
+        $queues = [
+            'A' => ['current' => 1, 'size' => 946, 'runtime' => 1],
+            'B' => ['current' => 1, 'size' => 13702, 'runtime' => 1],
+            'C' => ['current' => 1, 'size' => 0, 'runtime' => 0],
+        ];
+
+        [$sizeScaler, $sizeSupervisor] = $this->with_scaling_scenario(25, $queues, [
+            'autoScalingStrategy' => 'size',
+            'balanceMaxShift' => 25,
+        ]);
+
+        $sizeScaler->scale($sizeSupervisor);
+
+        $this->assertSame(2, $sizeSupervisor->processPools['A']->totalProcessCount());
+        $this->assertSame(22, $sizeSupervisor->processPools['B']->totalProcessCount());
+        $this->assertSame(1, $sizeSupervisor->processPools['C']->totalProcessCount());
+        $this->assertSame(25, $sizeSupervisor->totalProcessCount());
+
+        [$logScaler, $logSupervisor] = $this->with_scaling_scenario(25, $queues, [
+            'autoScalingStrategy' => 'log',
+            'balanceMaxShift' => 25,
+        ]);
+
+        $logScaler->scale($logSupervisor);
+
+        $this->assertSame(11, $logSupervisor->processPools['A']->totalProcessCount());
+        $this->assertSame(13, $logSupervisor->processPools['B']->totalProcessCount());
+        $this->assertSame(1, $logSupervisor->processPools['C']->totalProcessCount());
+        $this->assertSame(25, $logSupervisor->totalProcessCount());
+    }
+
+    public function test_logarithmic_scaling_is_based_on_queue_size_instead_of_runtime()
+    {
+        [$scaler, $supervisor] = $this->with_scaling_scenario(3, [
+            'first' => ['current' => 1, 'size' => 99, 'runtime' => 1],
+            'second' => ['current' => 1, 'size' => 9, 'runtime' => 1000],
+        ], ['autoScalingStrategy' => 'log']);
+
+        $scaler->scale($supervisor);
+
+        $this->assertSame(2, $supervisor->processPools['first']->totalProcessCount());
+        $this->assertSame(1, $supervisor->processPools['second']->totalProcessCount());
+    }
+
     public function test_scaler_works_with_a_single_process_pool()
     {
         [$scaler, $supervisor] = $this->with_scaling_scenario(10, [

--- a/tests/Feature/Fakes/FakePool.php
+++ b/tests/Feature/Fakes/FakePool.php
@@ -15,7 +15,7 @@ class FakePool
 
     public function scale($processCount)
     {
-        $this->processCount = $processCount;
+        $this->processCount = max(0, (int) $processCount);
     }
 
     public function queue()


### PR DESCRIPTION
**tl;dr:** With the new `log` algorithm a queue with 100k jobs doesn't get 10times the worker assignment weight of a queue with 10k jobs.

------

This will add a new supervisor auto-scale behavior - logarithmic size scaling.

The currently existing options `time` & `size` are pretty basic and allow one big queue to monopolize all workers in the supervisor. While the `log` algorithm normalizes the weight first meaning that one 10k queue won't steal all workers from a 1k queue.

To demonstrate the real impact, result and also properly showing why it's not a best for all - here's a real world example (numbers smoothed for demonstration).

We have 4 jobs, each on it's own queue and each with different execution times per job and the three follow up jobs depending on the first and we will produce 1000 imports per minute on 10 workers for the whole supervisor.

| Queue       | Runtime | Jobs/min | Worker-seconds/min | Workers needed |
|-------------|---------|----------|--------------------|----------------|
| Import      | 0.1 s   | 1,000    | 100 s              | 1.67           |
| WebP        | 0.3 s   | 1,000    | 300 s              | 5.00           |
| Thumbnail   | 0.2 s   | 1,000    | 200 s              | 3.33           |
| Fingerprint | 0.5 s   | 1,000    | 500 s              | 8.33           |
| Total       |         |          | 1,100 s/min        | 18.33          |

This example is intentionally constructed to show how an underprovisioned supervisor will handle the load and where the backlog, that has to happen, will land.

The absolute theoretical ceiling, even with perfect fractional scheduling and zero overhead, is:
```
10 × 60 / 1.1 ≈ 545 images/min
```
So even in a perfect world the setup is 455 images short per minute for full processing.

## End-to-end result

After two hours, 120,000 images have entered the system:

| Strategy | Fully finished | Avg. completed/min | Images still unfinished | Imports completed |
|----------|----------------|--------------------|-------------------------|-------------------|
| time     | **59,892**         | 499.1/min          | 60,108                  | 88,950            |
| size     | 56,976         | 474.8/min          | 63,024                  | 98,850            |
| log      | 43,170         | 359.8/min          | 76,830                  | **110,160**           |

This shows the strength of the `log` algorithm compared to `time` and `size`. While `time` processes the most images completely and `size` shortly after, the `log` algorithm imports the most images.

Depending on the requirements of the project both "winning" algorithms have their benefits. While `time` balances complete processing and leaves not a bunch of images unprocessed, the `log` algorithm pulls the most images into our own systems which means that we at least own them.

**Queued jobs after two hours**

| Queue       | Size  | Time  | Log   |
|-------------|-------|-------|-------|
| Import      | 21150 | 31050 | 9840  |
| WebP        | 37420 | 22900 | 38190 |
| Thumbnail   | 22995 | 22425 | 21240 |
| Fingerprint | 41874 | 29058 | 66990 |

**The worker assignment over time**

| Minute | Size I/W/T/F | Time I/W/T/F | Log I/W/T/F |
|--------|--------------|--------------|-------------|
| 20     | 2/2/2/4      | 1/3/2/4      | 1/3/3/3     |
| 40     | 1/3/2/4      | 1/2/2/5      | 2/3/2/3     |
| 60     | 1/3/2/4      | 1/3/2/4      | 1/3/3/3     |
| 80     | 2/2/2/4      | 1/3/2/4      | 1/3/3/3     |
| 100    | 1/2/3/4      | 2/3/1/4      | 2/3/2/3     |
| 120    | 1/3/2/4      | 1/3/2/4      | 2/3/2/3     |

------

The above tables and numbers should showcase why a third balancing algorithm is useful. As requirements of projects are different and it's not always about processing the most jobs/entities entirely but sometimes it's important to not starve a single queue when they all are close - even so one is 4times as big as another one.

The full write up about my usecase: https://gummibeer.dev/blog/2026/logarithmic-auto-scaling-laravel-horizon